### PR TITLE
fix: Install OpenSSL dev libs in manylinux container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,7 @@ jobs:
         with:
           args: --release --out dist --features postgres
           manylinux: auto
+          before-script-linux: yum install -y openssl-devel perl-IPC-Cmd
 
       - name: Build wheels
         if: runner.os != 'Linux'


### PR DESCRIPTION
## Summary
- The `build-wheels` CI job fails on Linux because the manylinux container lacks OpenSSL development libraries required by `openssl-sys` (transitive dependency of `pq-sys` when building with `--features postgres`)
- Adds `before-script-linux` to the maturin-action step to install `openssl-devel` and `perl-IPC-Cmd` via `yum` before the build runs
- macOS and Windows jobs are unaffected since `before-script-linux` only executes on Linux