### PR TITLE
fix: switch manylinux to 2_28 to fix pq-src build failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,8 +101,8 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           args: --release --out dist --features postgres
-          manylinux: auto
-          before-script-linux: yum install -y openssl-devel perl-IPC-Cmd
+          manylinux: 2_28
+          before-script-linux: dnf install -y openssl-devel perl-IPC-Cmd
 
       - name: Build wheels
         if: runner.os != 'Linux'


### PR DESCRIPTION
## Summary
- Switch `manylinux: auto` → `manylinux: 2_28` to fix `pq-src` compilation failure caused by CentOS 7's glibc `strsep` macro conflicting with modern libpq headers
- Switch `yum` → `dnf` as the proper package manager for AlmaLinux 8 (manylinux_2_28 base)

## Context
The `build-wheels` CI job fails on Linux because `manylinux: auto` selects a CentOS 7-based container (EOL June 2024) where `string.h` defines `strsep` as a macro using `__extension__`, conflicting with libpq's `extern char *strsep(...)` declaration.

`manylinux_2_28` uses AlmaLinux 8 with glibc 2.28, which is the current industry baseline covering Ubuntu 18.04+, Debian 10+, RHEL 8+, and Fedora 28+.