### PR TITLE
docs: add Postgres backend documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@
 [![Python versions](https://img.shields.io/pypi/pyversions/taskito.svg)](https://pypi.org/project/taskito/)
 [![License](https://img.shields.io/pypi/l/taskito.svg)](https://github.com/pratyush618/taskito/blob/master/LICENSE)
 
-A Rust-powered task queue for Python. No broker required — just SQLite.
+A Rust-powered task queue for Python. No broker required — just SQLite or Postgres.
 
 ```
-pip install taskito
+pip install taskito                # SQLite (default)
+pip install taskito[postgres]      # with Postgres backend
 ```
 
 ## Quickstart
@@ -41,7 +42,7 @@ print(job.result(timeout=10))  # 5
 
 ## Why taskito?
 
-Most Python task queues require a separate broker (Redis, RabbitMQ) even for single-machine workloads. taskito embeds everything — storage, scheduling, and worker management — into a single `pip install` with no external dependencies beyond Python itself.
+Most Python task queues require a separate broker (Redis, RabbitMQ) even for single-machine workloads. taskito embeds everything — storage, scheduling, and worker management — into a single `pip install` with no external dependencies beyond Python itself. For distributed setups, an optional Postgres backend enables multi-machine workers with the same API.
 
 The heavy lifting runs in Rust: a Tokio async scheduler, OS thread worker pool with crossbeam channels, and Diesel ORM over SQLite in WAL mode. Python's GIL is only held during task execution.
 
@@ -71,6 +72,7 @@ The heavy lifting runs in Rust: a Tokio async scheduler, OS thread worker pool w
 - **Async support** — `await job.aresult()`, `await queue.astats()`
 - **Web dashboard** — `taskito dashboard --app myapp:queue` serves a built-in monitoring UI
 - **FastAPI integration** — `TaskitoRouter` for instant REST API over the queue
+- **Postgres backend** — optional multi-machine storage via PostgreSQL
 - **CLI** — `taskito worker`, `taskito info --watch`, `taskito dashboard`
 
 ## Examples
@@ -256,6 +258,7 @@ Coming from Celery? See the **[Migration Guide](https://taskito-sepia.vercel.app
 | Per-task middleware | **Yes** | No | No | Yes | No |
 | Cancel running tasks | **Yes** | Yes | No | No | No |
 | Custom serializers | **Yes** | Yes | No | No | No |
+| Postgres backend | **Yes** | Yes | No | No | No |
 | Setup | **`pip install`** | Broker + backend | Redis | Broker | Redis |
 
 ## License

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,12 +21,14 @@ graph TB
         I["Rate Limiter<br/>Token bucket"]
     end
 
-    subgraph Storage ["Embedded Storage"]
+    subgraph Storage ["Storage Backend"]
         J[("SQLite · WAL mode<br/>Diesel ORM · r2d2 pool")]
+        K[("PostgreSQL<br/>Diesel ORM · r2d2 pool")]
     end
 
     A -->|"enqueue()"| F
     F -->|INSERT| J
+    F -->|INSERT| K
     G -->|"dequeue (poll every 50ms)"| J
     G -->|"dispatch via crossbeam"| H
     H -->|"acquire GIL → run task"| B
@@ -55,7 +57,7 @@ stateDiagram-v2
     Dead --> [*]: purge_dead()
 ```
 
-**Status codes in SQLite:**
+**Status codes:**
 
 | Status | Integer | Description |
 |---|---|---|
@@ -151,7 +153,18 @@ workers (worker_id, last_heartbeat, queues, status)
 
 ### Connection Pooling
 
-Diesel's `r2d2` connection pool with up to 8 connections. In-memory databases use a single connection (SQLite `:memory:` is per-connection).
+Diesel's `r2d2` connection pool with up to 8 connections (SQLite) or 10 connections (Postgres). In-memory databases use a single connection (SQLite `:memory:` is per-connection).
+
+### Postgres Configuration
+
+taskito also supports PostgreSQL as an alternative storage backend. See the [Postgres Backend guide](guide/postgres.md) for full details.
+
+Key differences from the SQLite storage layer:
+
+- **Connection pooling**: `r2d2` pool with a default of 10 connections (vs. 8 for SQLite)
+- **Schema isolation**: All tables are created inside a configurable PostgreSQL schema (default: `taskito`), with `search_path` set on each connection
+- **Additional tables**: The Postgres backend creates 11 tables (vs. 6 for SQLite), adding `job_dependencies`, `task_metrics`, `replay_history`, `task_logs`, and `circuit_breakers`
+- **Concurrent writes**: No single-writer constraint — multiple workers can write simultaneously
 
 ## Scheduler Loop
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -11,6 +11,19 @@ taskito has a single runtime dependency: [`cloudpickle`](https://github.com/clou
 !!! note "SQLite is bundled"
     taskito ships with SQLite compiled in via Rust's `libsqlite3-sys` crate. You do **not** need a system SQLite installation.
 
+## Postgres Backend
+
+To use PostgreSQL as the storage backend instead of SQLite:
+
+```bash
+pip install taskito[postgres]
+```
+
+!!! warning "Linux only"
+    The `postgres` extra currently requires Linux. macOS and Windows are not yet supported.
+
+See the [Postgres Backend guide](../guide/postgres.md) for configuration details.
+
 ## From Source
 
 Building from source requires a Rust toolchain (1.70+).
@@ -46,4 +59,5 @@ print(taskito.__version__)  # 0.1.0
 
 - Python 3.9+
 - Any OS with SQLite support (Linux, macOS, Windows)
+- PostgreSQL 12+ (optional, for `taskito[postgres]` — Linux only)
 - Rust toolchain only needed for building from source

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -143,6 +143,53 @@ sqlite3 /var/lib/myapp/taskito.db "VACUUM INTO '/backups/taskito-$(date +%Y%m%d)
 
 Both methods are safe while the worker is running.
 
+## Postgres Deployment
+
+If you're using the [Postgres backend](postgres.md), deployment is simpler in several ways:
+
+- **No shared-file constraints** — workers connect over the network, no need for shared volumes or local storage
+- **Multi-machine workers** — run workers on separate hosts against the same database
+- **Standard backups** — use `pg_dump` instead of `sqlite3 .backup`
+
+### Docker Compose with Postgres
+
+```yaml
+services:
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: myapp
+      POSTGRES_USER: taskito
+      POSTGRES_PASSWORD: secret
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+  worker:
+    build: .
+    environment:
+      TASKITO_BACKEND: postgres
+      TASKITO_DB_URL: postgresql://taskito:secret@postgres:5432/myapp
+    depends_on:
+      - postgres
+    stop_signal: SIGINT
+    stop_grace_period: 35s
+
+volumes:
+  pgdata:
+```
+
+### Postgres Backups
+
+```bash
+# Dump the taskito schema
+pg_dump -h localhost -U taskito -d myapp -n taskito > backup.sql
+
+# Restore
+psql -h localhost -U taskito -d myapp < backup.sql
+```
+
+See the [Postgres Backend guide](postgres.md) for full configuration details.
+
 ## Database Maintenance
 
 ### Auto-Cleanup
@@ -237,7 +284,7 @@ app.include_router(TaskitoRouter(queue), prefix="/tasks")
 
 ## Multiple Workers
 
-taskito is designed as a **single-process** task queue. Running multiple worker processes against the same SQLite file is possible (WAL mode allows concurrent access), but:
+taskito is designed as a **single-process** task queue when using SQLite. Running multiple worker processes against the same SQLite file is possible (WAL mode allows concurrent access), but:
 
 - Only one process can write at a time — this limits throughput
 - SQLite lock contention increases with more writers
@@ -252,7 +299,7 @@ queue = Queue(
 )
 ```
 
-If you need distributed workers across multiple machines, consider [Celery or Dramatiq](../comparison.md) instead.
+If you need distributed workers across multiple machines, use the [Postgres backend](postgres.md) which removes the single-writer constraint and supports multi-machine deployments. Alternatively, consider [Celery or Dramatiq](../comparison.md).
 
 ## SQLite Scaling Limits
 
@@ -266,12 +313,14 @@ taskito uses SQLite as its storage backend. Understanding its limitations helps 
 - Throughput decreases with larger payloads, complex queries, or spinning disks
 - The connection pool size (default: 8) controls read concurrency — tune it based on your read/write ratio
 
-**When to consider alternatives:**
+**When to upgrade to Postgres:**
 
 - You need multi-machine distributed workers
 - You consistently exceed ~5,000 jobs/second sustained throughput
 - Multiple processes contend heavily for writes (high lock wait times)
 - You need sub-millisecond dequeue latency under high load
+
+taskito's [Postgres backend](postgres.md) addresses all of these limitations while keeping the same API. See the [Postgres Backend guide](postgres.md) for setup instructions.
 
 **Connection pool tuning.** The default pool size of 8 connections works well for most workloads. If you're running many concurrent readers (e.g., a dashboard alongside workers), you can increase it:
 
@@ -290,5 +339,5 @@ Increasing the pool beyond ~16 typically doesn't help, since SQLite write serial
 - [ ] Set `timeout` on tasks to recover from worker crashes
 - [ ] Configure `SIGINT` as the stop signal in your process manager
 - [ ] Set up failure hooks or monitoring for alerting
-- [ ] Back up the database using `sqlite3 .backup` (not file copy)
+- [ ] Back up the database using `sqlite3 .backup` (not file copy), or `pg_dump` for Postgres
 - [ ] Place the dashboard behind a reverse proxy with authentication

--- a/docs/guide/postgres.md
+++ b/docs/guide/postgres.md
@@ -1,0 +1,229 @@
+# Postgres Backend
+
+taskito supports PostgreSQL as an alternative storage backend for production deployments that need multi-machine workers or higher write throughput.
+
+## When to Use Postgres
+
+Choose Postgres over the default SQLite backend when you need:
+
+- **Multi-machine workers** — run workers on separate hosts against a shared database
+- **Higher write throughput** — Postgres handles concurrent writes without SQLite's single-writer constraint
+- **Existing Postgres infrastructure** — reuse your existing database server instead of managing SQLite files
+
+For single-machine workloads, SQLite remains the simpler choice — no external dependencies required.
+
+## Installation
+
+```bash
+pip install taskito[postgres]
+```
+
+!!! warning "Linux only"
+    The Postgres backend currently requires Linux. macOS and Windows are not yet supported for the `postgres` extra.
+
+## Configuration
+
+```python
+from taskito import Queue
+
+queue = Queue(
+    backend="postgres",
+    db_url="postgresql://user:password@localhost:5432/myapp",
+    schema="taskito",  # optional, default: "taskito"
+)
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `backend` | `str` | `"sqlite"` | Set to `"postgres"` or `"postgresql"` |
+| `db_url` | `str` | `None` | PostgreSQL connection URL (required for Postgres) |
+| `schema` | `str` | `"taskito"` | PostgreSQL schema for all tables |
+| `workers` | `int` | `0` (auto) | Number of worker threads |
+
+All other `Queue` parameters (`default_retry`, `default_timeout`, `default_priority`, `result_ttl`) work identically to the SQLite backend.
+
+## Django Integration
+
+Configure the Postgres backend via Django settings:
+
+```python
+# settings.py
+TASKITO_BACKEND = "postgres"
+TASKITO_DB_URL = "postgresql://user:password@localhost:5432/myapp"
+TASKITO_SCHEMA = "taskito"
+```
+
+Then use the Django integration as normal:
+
+```python
+from taskito.contrib.django.settings import get_queue
+
+queue = get_queue()
+```
+
+All Django settings:
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `TASKITO_BACKEND` | `"sqlite"` | Storage backend (`"sqlite"` or `"postgres"`) |
+| `TASKITO_DB_URL` | `None` | PostgreSQL connection URL |
+| `TASKITO_SCHEMA` | `"taskito"` | PostgreSQL schema name |
+| `TASKITO_DB_PATH` | `".taskito/taskito.db"` | SQLite database path (ignored with Postgres) |
+| `TASKITO_WORKERS` | `0` | Worker thread count (0 = auto-detect) |
+| `TASKITO_DEFAULT_RETRY` | `3` | Default max retries |
+| `TASKITO_DEFAULT_TIMEOUT` | `300` | Default task timeout in seconds |
+| `TASKITO_DEFAULT_PRIORITY` | `0` | Default task priority |
+| `TASKITO_RESULT_TTL` | `None` | Result TTL in seconds |
+
+## Schema Isolation
+
+taskito creates all tables inside a dedicated PostgreSQL schema (default: `taskito`). The schema is created automatically if it doesn't exist.
+
+```python
+# Use a custom schema
+queue = Queue(backend="postgres", db_url="postgresql://...", schema="myapp_tasks")
+```
+
+Schema names must contain only alphanumeric characters and underscores. Invalid names raise a `ConfigError` at startup.
+
+This lets you run multiple independent taskito instances in the same database by using different schemas, or keep taskito tables separate from your application tables.
+
+## Connection Pooling
+
+The Postgres backend uses Diesel's `r2d2` connection pool with a default size of **10 connections**. Each connection has the `search_path` set to the configured schema on acquisition.
+
+The pool size is configured at the Rust layer. For most workloads, the default of 10 connections is sufficient.
+
+## Migrations
+
+Migrations run automatically on first connection. taskito creates the following **11 tables** inside the configured schema:
+
+| Table | Purpose |
+|-------|---------|
+| `jobs` | Core job storage |
+| `dead_letter` | Dead letter queue |
+| `rate_limits` | Token bucket rate limiting state |
+| `periodic_tasks` | Cron-scheduled task definitions |
+| `job_errors` | Per-attempt error tracking |
+| `job_dependencies` | Task dependency edges |
+| `task_metrics` | Execution time and memory metrics |
+| `replay_history` | Job replay audit trail |
+| `task_logs` | Structured task log entries |
+| `circuit_breakers` | Circuit breaker state |
+| `workers` | Worker heartbeat tracking |
+
+All tables use PostgreSQL-native types (`TEXT`, `BYTEA`, `BIGINT`, `BOOLEAN`, `DOUBLE PRECISION`) rather than SQLite-compatible types.
+
+## Differences from SQLite
+
+| Aspect | SQLite | Postgres |
+|--------|--------|----------|
+| Connection model | Embedded, file-based | Client/server, networked |
+| Write concurrency | Single writer (WAL mode) | Multiple concurrent writers |
+| Distribution | Single machine only | Multi-machine workers |
+| Setup | Zero config, bundled | Requires Postgres server |
+| Connection pool default | 8 connections | 10 connections |
+| Schema isolation | N/A (file per database) | Custom PostgreSQL schema |
+| Tables | 6 tables | 11 tables (additional: `job_dependencies`, `task_metrics`, `replay_history`, `task_logs`, `circuit_breakers`) |
+| Backup | `sqlite3 .backup` | `pg_dump` |
+
+## Deployment
+
+### Docker Compose
+
+```yaml
+services:
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: myapp
+      POSTGRES_USER: taskito
+      POSTGRES_PASSWORD: secret
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+
+  worker:
+    build: .
+    environment:
+      TASKITO_BACKEND: postgres
+      TASKITO_DB_URL: postgresql://taskito:secret@postgres:5432/myapp
+    depends_on:
+      - postgres
+    stop_signal: SIGINT
+    stop_grace_period: 35s
+
+  dashboard:
+    build: .
+    command: taskito dashboard --app myapp:queue --host 0.0.0.0
+    environment:
+      TASKITO_BACKEND: postgres
+      TASKITO_DB_URL: postgresql://taskito:secret@postgres:5432/myapp
+    depends_on:
+      - postgres
+    ports:
+      - "8080:8080"
+
+volumes:
+  pgdata:
+```
+
+With Postgres, there are no shared-file constraints — workers and dashboard connect over the network. You can run multiple worker containers across different hosts.
+
+### systemd
+
+```ini
+[Unit]
+Description=taskito worker
+After=network.target postgresql.service
+
+[Service]
+Type=simple
+User=myapp
+Group=myapp
+WorkingDirectory=/opt/myapp
+ExecStart=/opt/myapp/.venv/bin/taskito worker --app myapp:queue
+Restart=always
+RestartSec=5
+KillSignal=SIGINT
+TimeoutStopSec=35
+
+Environment=PYTHONPATH=/opt/myapp
+Environment=TASKITO_BACKEND=postgres
+Environment=TASKITO_DB_URL=postgresql://taskito:secret@db.internal:5432/myapp
+
+[Install]
+WantedBy=multi-user.target
+```
+
+### Multi-Machine Workers
+
+With Postgres, you can run workers on multiple machines. Each worker connects to the same database and coordinates through PostgreSQL's row-level locking:
+
+```bash
+# Machine 1
+taskito worker --app myapp:queue
+
+# Machine 2
+taskito worker --app myapp:queue
+
+# Machine 3
+taskito worker --app myapp:queue
+```
+
+All workers share the same job queue and dequeue work atomically.
+
+## Backups
+
+Use standard PostgreSQL backup tools instead of SQLite-specific commands:
+
+```bash
+# Dump the taskito schema
+pg_dump -h localhost -U taskito -d myapp -n taskito > backup.sql
+
+# Restore
+psql -h localhost -U taskito -d myapp < backup.sql
+```
+
+For continuous backups, use PostgreSQL's built-in WAL archiving or a tool like [pgBackRest](https://pgbackrest.org/).

--- a/zensical.toml
+++ b/zensical.toml
@@ -28,6 +28,7 @@ nav = [
         { "Testing" = "guide/testing.md" },
         { "Error Handling" = "guide/error-handling.md" },
         { "Deployment" = "guide/deployment.md" },
+        { "Postgres Backend" = "guide/postgres.md" },
         { "Migrating from Celery" = "guide/migration.md" },
         { "Advanced" = "guide/advanced.md" },
     ] },


### PR DESCRIPTION
## Summary
- Add dedicated Postgres backend guide (`docs/guide/postgres.md`) covering installation, configuration, Django integration, schema isolation, connection pooling, migrations, deployment (Docker Compose, systemd, multi-machine), and backups
- Update README to mention Postgres option in tagline, install instructions, features list, comparison table, and "Why taskito?" section
- Update architecture docs with Postgres in the mermaid diagram and a new "Postgres Configuration" subsection
- Update installation guide with `pip install taskito[postgres]` section and requirements
- Update deployment guide with Postgres deployment section, multi-machine worker references, and Postgres as SQLite scaling upgrade path
- Add nav entry in `zensical.toml`