### PR TITLE
fix: publish workflow and restore CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,176 +1,118 @@
-name: Publish to PyPI
+name: CI
 
 on:
   push:
-    tags: ["[0-9]*"]
+    branches: [master]
+  pull_request:
+    branches: [master]
 
-permissions:
-  contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  build-wheels-linux:
+  lint:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        target: [x86_64-unknown-linux-gnu, aarch64-unknown-linux-gnu]
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build wheels
-        uses: PyO3/maturin-action@v1
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          target: ${{ matrix.target }}
-          args: --release --out dist --features postgres,redis
-          manylinux: 2_28
+          python-version: "3.12"
 
-      - name: Upload wheels
-        uses: actions/upload-artifact@v4
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
         with:
-          name: wheels-linux-${{ matrix.target }}
-          path: dist/*.whl
+          components: rustfmt, clippy
 
-  build-wheels-musllinux:
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Cargo fmt
+        run: cargo fmt --all --check
+
+      - name: Cargo clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: Install Python dev deps
+        run: pip install -e ".[dev]"
+
+      - name: Ruff check
+        run: ruff check py_src/ tests/
+
+      - name: Ruff format check
+        run: ruff format --check py_src/ tests/
+
+      - name: Mypy
+        run: mypy py_src/taskito/
+
+  rust-test:
+    needs: lint
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        target: [x86_64-unknown-linux-musl, aarch64-unknown-linux-musl]
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build wheels
-        uses: PyO3/maturin-action@v1
-        with:
-          target: ${{ matrix.target }}
-          args: --release --out dist --features postgres,redis
-          manylinux: musllinux_1_2
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
 
-      - name: Upload wheels
-        uses: actions/upload-artifact@v4
-        with:
-          name: wheels-musllinux-${{ matrix.target }}
-          path: dist/*.whl
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
 
-  build-wheels-macos:
+      - name: Run Rust tests
+        run: cargo test --workspace
+
+  test:
+    needs: [lint, rust-test]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         include:
-          - os: macos-13
-            target: x86_64-apple-darwin
           - os: macos-latest
-            target: aarch64-apple-darwin
+            python-version: "3.13"
+          - os: macos-latest
+            python-version: "3.9"
+          - os: windows-latest
+            python-version: "3.13"
+          - os: windows-latest
+            python-version: "3.9"
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.9
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: ${{ matrix.python-version }}
 
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
 
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
 
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
+      - name: Create virtualenv (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          python -m venv .venv
+          echo "${{ github.workspace }}/.venv/bin" >> $GITHUB_PATH
+          echo "VIRTUAL_ENV=${{ github.workspace }}/.venv" >> $GITHUB_ENV
 
-      - name: Set up Python 3.13
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.13"
+      - name: Create virtualenv (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          python -m venv .venv
+          echo "${{ github.workspace }}\.venv\Scripts" >> $env:GITHUB_PATH
+          echo "VIRTUAL_ENV=${{ github.workspace }}\.venv" >> $env:GITHUB_ENV
 
-      - name: Build wheels
-        uses: PyO3/maturin-action@v1
-        with:
-          target: ${{ matrix.target }}
-          args: --release --out dist --features postgres,redis --interpreter 3.9 3.10 3.11 3.12 3.13
+      - name: Install maturin
+        run: pip install maturin
 
-      - name: Upload wheels
-        uses: actions/upload-artifact@v4
-        with:
-          name: wheels-macos-${{ matrix.os }}
-          path: dist/*.whl
+      - name: Build and install
+        run: |
+          pip install -e ".[dev]"
+          maturin develop --release
 
-  build-wheels-windows:
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.9"
-
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
-
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Set up Python 3.13
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.13"
-
-      - name: Build wheels
-        uses: PyO3/maturin-action@v1
-        with:
-          args: --release --out dist --features postgres,redis --interpreter 3.9 3.10 3.11 3.12 3.13
-
-      - name: Upload wheels
-        uses: actions/upload-artifact@v4
-        with:
-          name: wheels-windows
-          path: dist/*.whl
-
-  build-sdist:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Build sdist
-        uses: PyO3/maturin-action@v1
-        with:
-          command: sdist
-          args: --out dist
-
-      - name: Upload sdist
-        uses: actions/upload-artifact@v4
-        with:
-          name: sdist
-          path: dist/*.tar.gz
-
-  publish:
-    needs: [build-wheels-linux, build-wheels-musllinux, build-wheels-macos, build-wheels-windows, build-sdist]
-    runs-on: ubuntu-latest
-    environment: pypi
-    permissions:
-      id-token: write
-    steps:
-      - name: Download all artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: dist
-          merge-multiple: true
-
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: dist/
+      - name: Run Python tests
+        run: pytest tests/python/ -v

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish to PyPI
 
 on:
   push:
-    tags: ["v*"]
+    tags: ["[0-9]*"]
 
 permissions:
   contents: read
@@ -22,6 +22,7 @@ jobs:
           target: ${{ matrix.target }}
           args: --release --out dist --features postgres,redis
           manylinux: 2_28
+          before-script-linux: dnf install -y openssl-devel perl-IPC-Cmd
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4
@@ -43,6 +44,7 @@ jobs:
           target: ${{ matrix.target }}
           args: --release --out dist --features postgres,redis
           manylinux: musllinux_1_2
+          before-script-linux: apk add --no-cache openssl-dev perl make
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4
@@ -55,7 +57,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-13
+          - os: macos-latest
             target: x86_64-apple-darwin
           - os: macos-latest
             target: aarch64-apple-darwin
@@ -96,7 +98,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-macos-${{ matrix.os }}
+          name: wheels-macos-${{ matrix.target }}
           path: dist/*.whl
 
   build-wheels-windows:


### PR DESCRIPTION
## Summary
- **publish.yml**: Fix `macos-13` → `macos-latest`, add `before-script-linux` for OpenSSL deps on manylinux/musllinux builds, fix macOS artifact naming collision
- **ci.yml**: Restore original CI workflow (lint, rust-test, python-test) that was accidentally overwritten with the publish workflow