### PR TITLE
fix: postgres backend connection pooling and worker GIL handling

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish to PyPI
 
 on:
   push:
-    tags: ["[0-9]*"]
+    tags: ["[0-9]+.[0-9]+.[0-9]+*"]
 
 permissions:
   contents: read
@@ -24,7 +24,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --features postgres,redis
+          args: --release --out dist --features postgres,redis --interpreter 3.9 3.10 3.11 3.12 3.13
           manylinux: 2_28
           before-script-linux: dnf install -y openssl-devel perl-IPC-Cmd
 
@@ -50,7 +50,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --features postgres,redis
+          args: --release --out dist --features postgres,redis --interpreter 3.9 3.10 3.11 3.12 3.13
           manylinux: musllinux_1_2
           before-script-linux: apk add --no-cache openssl-dev perl make
 
@@ -65,7 +65,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-latest
+          - os: macos-13
             target: x86_64-apple-darwin
           - os: macos-latest
             target: aarch64-apple-darwin
@@ -111,6 +111,10 @@ jobs:
 
   build-wheels-windows:
     runs-on: windows-latest
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-pc-windows-msvc
     steps:
       - uses: actions/checkout@v4
 
@@ -142,12 +146,13 @@ jobs:
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
+          target: ${{ matrix.target }}
           args: --release --out dist --features postgres,redis --interpreter 3.9 3.10 3.11 3.12 3.13
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-windows
+          name: wheels-windows-${{ matrix.target }}
           path: dist/*.whl
 
   build-sdist:

--- a/crates/taskito-core/src/storage/postgres/mod.rs
+++ b/crates/taskito-core/src/storage/postgres/mod.rs
@@ -12,7 +12,7 @@ mod workers;
 
 use diesel::pg::PgConnection;
 use diesel::prelude::*;
-use diesel::r2d2::{self, ConnectionManager, Pool};
+use diesel::r2d2::{ConnectionManager, Pool};
 
 use crate::error::Result;
 
@@ -44,21 +44,6 @@ fn validate_schema_name(schema: &str) -> Result<()> {
     Ok(())
 }
 
-/// Sets `search_path` on every new pooled connection.
-#[derive(Debug)]
-struct SetSearchPath {
-    schema: String,
-}
-
-impl r2d2::CustomizeConnection<PgConnection, r2d2::Error> for SetSearchPath {
-    fn on_acquire(&self, conn: &mut PgConnection) -> std::result::Result<(), r2d2::Error> {
-        diesel::sql_query(format!("SET search_path TO {}", self.schema))
-            .execute(conn)
-            .map_err(r2d2::Error::QueryError)?;
-        Ok(())
-    }
-}
-
 /// PostgreSQL-backed storage for the task queue, using Diesel ORM.
 #[derive(Clone)]
 pub struct PostgresStorage {
@@ -83,16 +68,25 @@ impl PostgresStorage {
         Self::build(database_url, pool_size, "taskito")
     }
 
+    /// Connect with a custom schema name and connection pool size.
+    pub fn with_schema_and_pool_size(
+        database_url: &str,
+        schema: &str,
+        pool_size: u32,
+    ) -> Result<Self> {
+        Self::build(database_url, pool_size, schema)
+    }
+
     fn build(database_url: &str, pool_size: u32, schema: &str) -> Result<Self> {
         validate_schema_name(schema)?;
 
         let manager = ConnectionManager::<PgConnection>::new(database_url);
-        let customizer = SetSearchPath {
-            schema: schema.to_string(),
-        };
         let pool = Pool::builder()
             .max_size(pool_size)
-            .connection_customizer(Box::new(customizer))
+            .min_idle(Some(1))
+            .idle_timeout(Some(std::time::Duration::from_secs(300)))
+            .max_lifetime(Some(std::time::Duration::from_secs(1800)))
+            .connection_timeout(std::time::Duration::from_secs(10))
             .build(manager)?;
 
         let storage = Self {
@@ -106,7 +100,11 @@ impl PostgresStorage {
     pub(crate) fn conn(
         &self,
     ) -> Result<diesel::r2d2::PooledConnection<ConnectionManager<PgConnection>>> {
-        Ok(self.pool.get()?)
+        let mut conn = self.pool.get()?;
+        diesel::sql_query(format!("SET search_path TO {}", self.schema))
+            .execute(&mut conn)
+            .map_err(crate::error::QueueError::Storage)?;
+        Ok(conn)
     }
 
     fn run_migrations(&self) -> Result<()> {

--- a/crates/taskito-python/src/py_queue.rs
+++ b/crates/taskito-python/src/py_queue.rs
@@ -12,7 +12,7 @@ use taskito_core::periodic::next_cron_time;
 use taskito_core::resilience::circuit_breaker::CircuitBreakerConfig;
 use taskito_core::resilience::rate_limiter::RateLimitConfig;
 use taskito_core::resilience::retry::RetryPolicy;
-use taskito_core::scheduler::{Scheduler, SchedulerConfig, TaskConfig};
+use taskito_core::scheduler::{JobResult, Scheduler, SchedulerConfig, TaskConfig};
 use taskito_core::storage::models::NewPeriodicTaskRow;
 #[cfg(feature = "postgres")]
 use taskito_core::storage::postgres::PostgresStorage;
@@ -46,7 +46,7 @@ pub struct PyQueue {
 )]
 impl PyQueue {
     #[new]
-    #[pyo3(signature = (db_path=".taskito/taskito.db", workers=0, default_retry=3, default_timeout=300, default_priority=0, result_ttl=None, backend="sqlite", db_url=None, schema="taskito"))]
+    #[pyo3(signature = (db_path=".taskito/taskito.db", workers=0, default_retry=3, default_timeout=300, default_priority=0, result_ttl=None, backend="sqlite", db_url=None, schema="taskito", pool_size=None))]
     pub fn new(
         db_path: &str,
         workers: usize,
@@ -57,6 +57,7 @@ impl PyQueue {
         backend: &str,
         db_url: Option<&str>,
         schema: &str,
+        pool_size: Option<u32>,
     ) -> PyResult<Self> {
         let storage = match backend {
             "sqlite" => {
@@ -71,8 +72,12 @@ impl PyQueue {
                         "db_url is required for postgres backend",
                     )
                 })?;
-                let s = PostgresStorage::with_schema(url, schema)
-                    .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+                let s = PostgresStorage::with_schema_and_pool_size(
+                    url,
+                    schema,
+                    pool_size.unwrap_or(10),
+                )
+                .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
                 StorageBackend::Postgres(s)
             }
             #[cfg(feature = "redis")]
@@ -85,6 +90,7 @@ impl PyQueue {
                 StorageBackend::Redis(s)
             }
             _ => {
+                #[allow(unused_mut, clippy::useless_vec)]
                 let mut available = vec!["sqlite"];
                 #[cfg(feature = "postgres")]
                 available.push("postgres");
@@ -705,50 +711,82 @@ impl PyQueue {
         let scheduler_for_results = scheduler_arc.clone();
         let flag = self.shutdown_flag.clone();
 
-        py.allow_threads(move || {
-            let drain_timeout = std::time::Duration::from_secs(drain_timeout_secs.unwrap_or(30));
+        // Poll action enum for communicating between GIL-released and
+        // GIL-held sections of the result loop.
+        enum PollAction {
+            Shutdown,
+            Result(JobResult),
+            Continue,
+            Done,
+        }
 
-            loop {
-                // Check if graceful shutdown was requested
+        let drain_timeout = std::time::Duration::from_secs(drain_timeout_secs.unwrap_or(30));
+
+        loop {
+            // Release GIL for one iteration of result polling
+            let action = py.allow_threads(|| {
                 if flag.load(Ordering::SeqCst) {
+                    return PollAction::Shutdown;
+                }
+                match result_rx.recv_timeout(std::time::Duration::from_millis(100)) {
+                    Ok(result) => PollAction::Result(result),
+                    Err(crossbeam_channel::RecvTimeoutError::Timeout) => PollAction::Continue,
+                    Err(crossbeam_channel::RecvTimeoutError::Disconnected) => PollAction::Done,
+                }
+            });
+
+            // Re-acquire GIL briefly to let Python signal handlers run
+            py.check_signals()?;
+
+            match action {
+                PollAction::Shutdown => {
                     // Stop the scheduler from dispatching new jobs
-                    shutdown.notify_one();
+                    py.allow_threads(|| shutdown.notify_one());
 
                     // Drain remaining results with a timeout
                     let drain_start = std::time::Instant::now();
                     while drain_start.elapsed() < drain_timeout {
-                        match result_rx.recv_timeout(std::time::Duration::from_millis(100)) {
-                            Ok(result) => {
-                                if let Err(e) = scheduler_for_results.handle_result(result) {
-                                    eprintln!("[taskito] result handling error: {e}");
+                        let drain_action = py.allow_threads(|| {
+                            match result_rx.recv_timeout(std::time::Duration::from_millis(100)) {
+                                Ok(result) => PollAction::Result(result),
+                                Err(crossbeam_channel::RecvTimeoutError::Timeout) => {
+                                    PollAction::Continue
+                                }
+                                Err(crossbeam_channel::RecvTimeoutError::Disconnected) => {
+                                    PollAction::Done
                                 }
                             }
-                            Err(crossbeam_channel::RecvTimeoutError::Timeout) => {
-                                continue;
+                        });
+
+                        // Allow signal handlers to run during drain too
+                        py.check_signals()?;
+
+                        match drain_action {
+                            PollAction::Result(result) => {
+                                py.allow_threads(|| {
+                                    if let Err(e) = scheduler_for_results.handle_result(result) {
+                                        eprintln!("[taskito] result handling error: {e}");
+                                    }
+                                });
                             }
-                            Err(crossbeam_channel::RecvTimeoutError::Disconnected) => {
-                                break;
-                            }
+                            PollAction::Continue => continue,
+                            PollAction::Done => break,
+                            PollAction::Shutdown => unreachable!(),
                         }
                     }
                     break;
                 }
-
-                match result_rx.recv_timeout(std::time::Duration::from_millis(100)) {
-                    Ok(result) => {
+                PollAction::Result(result) => {
+                    py.allow_threads(|| {
                         if let Err(e) = scheduler_for_results.handle_result(result) {
                             eprintln!("[taskito] result handling error: {e}");
                         }
-                    }
-                    Err(crossbeam_channel::RecvTimeoutError::Timeout) => {
-                        continue;
-                    }
-                    Err(crossbeam_channel::RecvTimeoutError::Disconnected) => {
-                        break;
-                    }
+                    });
                 }
+                PollAction::Continue => continue,
+                PollAction::Done => break,
             }
-        });
+        }
 
         let _ = scheduler_handle.join();
         let _ = heartbeat_handle.join();

--- a/crates/taskito-python/src/py_worker.rs
+++ b/crates/taskito-python/src/py_worker.rs
@@ -65,6 +65,7 @@ fn worker_loop(
         let max_retries = job.max_retries;
 
         let start = std::time::Instant::now();
+        eprintln!("[taskito] Task {task_name}[{job_id}] received");
 
         let result = Python::with_gil(|py| -> PyResult<Option<Vec<u8>>> {
             execute_task(py, &task_registry, &job)
@@ -73,12 +74,16 @@ fn worker_loop(
         let wall_time_ns: i64 = start.elapsed().as_nanos().try_into().unwrap_or(i64::MAX);
 
         let job_result = match result {
-            Ok(result_bytes) => JobResult::Success {
-                job_id,
-                result: result_bytes,
-                task_name: task_name.clone(),
-                wall_time_ns,
-            },
+            Ok(result_bytes) => {
+                let secs = start.elapsed().as_secs_f64();
+                eprintln!("[taskito] Task {task_name}[{job_id}] succeeded in {secs:.3}s");
+                JobResult::Success {
+                    job_id,
+                    result: result_bytes,
+                    task_name: task_name.clone(),
+                    wall_time_ns,
+                }
+            }
             Err(e) => {
                 let (error_msg, is_cancelled, exc_class_name) = Python::with_gil(|py| {
                     let msg = format_python_error(py, &e);
@@ -99,6 +104,7 @@ fn worker_loop(
                         check_should_retry(py, &retry_filters, &task_name, &exc_class_name, &e)
                     });
 
+                    eprintln!("[taskito] Task {task_name}[{job_id}] failed: {error_msg}");
                     JobResult::Failure {
                         job_id,
                         error: error_msg,
@@ -124,9 +130,30 @@ fn execute_task(py: Python<'_>, task_registry: &PyObject, job: &Job) -> PyResult
 
     // Look up the task function
     let registry_dict: &Bound<'_, PyDict> = registry.downcast()?;
-    let task_fn = registry_dict.get_item(&job.task_name)?.ok_or_else(|| {
-        pyo3::exceptions::PyKeyError::new_err(format!("task '{}' not registered", job.task_name))
-    })?;
+    let task_fn = registry_dict
+        .get_item(&job.task_name)?
+        .or_else(|| {
+            // Fallback: if task_name starts with "__main__.", try matching by suffix
+            if job.task_name.starts_with("__main__.") {
+                let suffix = &job.task_name["__main__".len()..]; // ".process_user"
+                registry_dict.iter().find_map(|(key, val)| {
+                    let key_str = key.extract::<String>().ok()?;
+                    if key_str.ends_with(suffix) {
+                        Some(val)
+                    } else {
+                        None
+                    }
+                })
+            } else {
+                None
+            }
+        })
+        .ok_or_else(|| {
+            pyo3::exceptions::PyKeyError::new_err(format!(
+                "task '{}' not registered",
+                job.task_name
+            ))
+        })?;
 
     // Set job context before execution
     let context_mod = py.import_bound("taskito.context")?;

--- a/py_src/taskito/_taskito.pyi
+++ b/py_src/taskito/_taskito.pyi
@@ -73,6 +73,7 @@ class PyQueue:
         backend: str = "sqlite",
         db_url: str | None = None,
         schema: str = "taskito",
+        pool_size: int | None = None,
     ) -> None: ...
     def request_shutdown(self) -> None: ...
     def enqueue(

--- a/py_src/taskito/app.py
+++ b/py_src/taskito/app.py
@@ -36,6 +36,23 @@ from taskito.webhooks import WebhookManager
 logger = logging.getLogger("taskito")
 
 
+def _resolve_module_name(module_name: str) -> str:
+    """Resolve __main__ to the actual module name."""
+    if module_name != "__main__":
+        return module_name
+    import sys
+
+    main = sys.modules.get("__main__")
+    if main is not None:
+        spec = getattr(main, "__spec__", None)
+        if spec and spec.name:
+            return str(spec.name)
+        f = getattr(main, "__file__", None)
+        if f:
+            return str(os.path.splitext(os.path.basename(f))[0])
+    return module_name
+
+
 class Queue(
     QueueMetricsMixin,
     QueueDeadLettersMixin,
@@ -72,6 +89,7 @@ class Queue(
         backend: str = "sqlite",
         db_url: str | None = None,
         schema: str = "taskito",
+        pool_size: int | None = None,
         drain_timeout: int = 30,
     ):
         """Initialize a new task queue.
@@ -93,6 +111,9 @@ class Queue(
                 Example: ``"postgresql://user:pass@localhost/taskito"``.
             schema: PostgreSQL schema name for all taskito tables. Defaults to
                 ``"taskito"``. Ignored when backend is ``"sqlite"``.
+            pool_size: Maximum number of connections in the database connection
+                pool. Defaults to 10. Useful for managed services like Supabase
+                that have low connection limits.
             drain_timeout: Seconds to wait for in-flight jobs to finish during
                 graceful shutdown. Defaults to 30.
         """
@@ -112,6 +133,7 @@ class Queue(
             backend=backend,
             db_url=db_url,
             schema=schema,
+            pool_size=pool_size,
         )
         self._backend = backend
         self._db_url = db_url
@@ -172,7 +194,7 @@ class Queue(
         """
 
         def decorator(fn: Callable) -> TaskWrapper:
-            task_name = name or f"{fn.__module__}.{fn.__qualname__}"
+            task_name = name or f"{_resolve_module_name(fn.__module__)}.{fn.__qualname__}"
 
             # Store retry filters
             if retry_on or dont_retry_on:
@@ -259,7 +281,7 @@ class Queue(
             payload = self._serializer.dumps((args, kwargs or {}))
             self._periodic_configs.append(
                 {
-                    "name": name or f"{fn.__module__}.{fn.__qualname__}",
+                    "name": name or f"{_resolve_module_name(fn.__module__)}.{fn.__qualname__}",
                     "task_name": wrapper.name,
                     "cron_expr": cron,
                     "payload": payload,
@@ -742,6 +764,13 @@ class Queue(
                 timezone=pc.get("timezone"),
             )
 
+        if not logging.root.handlers:
+            logging.basicConfig(
+                level=logging.INFO,
+                format="[%(asctime)s] %(levelname)s %(message)s",
+                datefmt="%Y-%m-%d %H:%M:%S",
+            )
+
         worker_queues = queue_list or ["default"]
         self._print_banner(worker_queues)
 
@@ -758,7 +787,7 @@ class Queue(
             original_sigterm = signal.getsignal(signal.SIGTERM)
 
             def shutdown_handler(signum: int, frame: Any) -> None:
-                logger.info("Shutting down gracefully (waiting for in-flight jobs)...")
+                logger.info("Warm shutdown (waiting for running tasks to finish)...")
                 self._inner.request_shutdown()
                 # Restore original handlers so a second signal force-kills
                 signal.signal(signal.SIGINT, original_sigint)
@@ -776,7 +805,7 @@ class Queue(
                 tags=",".join(tags) if tags else None,
             )
         except KeyboardInterrupt:
-            logger.info("Worker force-stopped.")
+            logger.info("Cold shutdown (terminating immediately)")
         finally:
             self._stop_async_loop()
             logger.info("Worker stopped.")
@@ -821,7 +850,7 @@ class Queue(
         original_sigterm = signal.getsignal(signal.SIGTERM)
 
         def _shutdown_once() -> None:
-            logger.info("Shutting down gracefully (waiting for in-flight jobs)...")
+            logger.info("Warm shutdown (waiting for running tasks to finish)...")
             self._inner.request_shutdown()
             with contextlib.suppress(NotImplementedError):
                 loop.remove_signal_handler(signal.SIGINT)

--- a/py_src/taskito/cli.py
+++ b/py_src/taskito/cli.py
@@ -115,6 +115,10 @@ def _load_queue(app_path: str) -> Queue:
 
     module_path, attr_name = app_path.rsplit(":", 1)
 
+    # Ensure cwd is on sys.path so local modules can be imported
+    if "" not in sys.path and "." not in sys.path:
+        sys.path.insert(0, "")
+
     try:
         module = importlib.import_module(module_path)
     except ImportError as e:

--- a/py_src/taskito/dashboard.py
+++ b/py_src/taskito/dashboard.py
@@ -96,6 +96,8 @@ def _make_handler(queue: Queue) -> type:
         def do_GET(self) -> None:
             try:
                 self._handle_get()
+            except BrokenPipeError:
+                pass
             except Exception:
                 logger.exception("Error handling GET %s", self.path)
                 self._json_response({"error": "Internal server error"}, status=500)
@@ -174,6 +176,8 @@ def _make_handler(queue: Queue) -> type:
         def do_POST(self) -> None:
             try:
                 self._handle_post()
+            except BrokenPipeError:
+                pass
             except Exception:
                 logger.exception("Error handling POST %s", self.path)
                 self._json_response({"error": "Internal server error"}, status=500)


### PR DESCRIPTION
- Replace per-connection SetSearchPath customizer with per-checkout SET search_path for correctness with pooled connections
- Add pool_size parameter (default 10) for managed DB services with low connection limits (e.g. Supabase)
- Configure pool idle timeout, max lifetime, and connection timeout
- Fix worker result loop to periodically release GIL so Python signal handlers (SIGINT/SIGTERM) fire promptly
- Resolve __main__ module names to actual module for consistent task naming across CLI and programmatic usage
- Add fallback task lookup for __main__-prefixed task names
- Ensure cwd is on sys.path in CLI loader
- Handle BrokenPipeError in dashboard HTTP handlers
- Improve shutdown log messages (warm/cold shutdown)