### PR TITLE
fix: resolve PyO3 extension-module linking for cargo test and maturin builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ docs = ["zensical"]
 manifest-path = "crates/taskito-python/Cargo.toml"
 python-source = "py_src"
 module-name = "taskito._taskito"
-features = ["pyo3/extension-module", "postgres", "redis"]
+features = ["extension-module", "postgres", "redis"]
 
 [project.scripts]
 taskito = "taskito.cli:main"    


### PR DESCRIPTION
## Problem

Two interacting issues caused builds to break:

1. **CI `rust-test`** — `cargo test --workspace` failed with undefined `Py_*` symbols because `extension-module` was always-on in workspace pyo3 features, telling PyO3 not to link libpython. Test executables need libpython linked.

2. **Publish workflow (maturin builds)** — After fixing (1) by removing `extension-module` from workspace defaults, maturin builds broke. Maturin specially handles `"pyo3/extension-module"` in `pyproject.toml` features by *stripping it* from `--features` and setting `PYO3_BUILD_EXTENSION_MODULE=1` via env instead. Without `extension-module` in workspace defaults, the cargo feature was never activated and pyo3 tried to link libpython (`cannot find -lpython3.9`).

## Fix

- **`Cargo.toml`** — Remove `extension-module` from workspace pyo3 features
- **`crates/taskito-python/Cargo.toml`** — Add `extension-module = ["pyo3/extension-module"]` as an explicit crate feature
- **`pyproject.toml`** — Change `"pyo3/extension-module"` → `"extension-module"` in maturin features so maturin passes it as a normal cargo feature (activating `pyo3/extension-module` through the crate feature, not via env var)
- **`.github/workflows/ci.yml`** — Add Python setup + `LD_LIBRARY_PATH` to `rust-test` so `cargo test --workspace` can link libpython

**Result**: maturin builds activate `pyo3/extension-module` (no libpython linking, correct for `.so`). `cargo test` runs without that feature and links libpython normally.