### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/crates/taskito-core/Cargo.toml
+++ b/crates/taskito-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-core"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 
 [features]

--- a/crates/taskito-python/Cargo.toml
+++ b/crates/taskito-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-python"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 
 [features]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "taskito"
-version = "0.3.0"
+version = "0.4.0"
 description = "Rust-powered task queue for Python. No broker required."
 requires-python = ">=3.9"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary

- Bump `pyproject.toml` version from 0.3.0 to 0.4.0
- Bump `taskito-python` crate version from 0.3.0 to 0.4.0
- Bump `taskito-core` crate version from 0.3.0 to 0.4.0

This ensures wheels built by the publish workflow are named `taskito-0.4.0-*.whl` and are accepted by PyPI.