### PR TITLE
chore: update repo references after ByteVeda transfer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Thanks for your interest in contributing! taskito is a hybrid Rust + Python proj
 ### Clone and Install
 
 ```bash
-git clone https://github.com/pratyush618/taskito.git
+git clone https://github.com/ByteVeda/taskito.git
 cd taskito
 
 # Create a virtual environment

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![PyPI version](https://img.shields.io/pypi/v/taskito.svg)](https://pypi.org/project/taskito/)
 [![Python versions](https://img.shields.io/pypi/pyversions/taskito.svg)](https://pypi.org/project/taskito/)
-[![License](https://img.shields.io/pypi/l/taskito.svg)](https://github.com/pratyush618/taskito/blob/master/LICENSE)
+[![License](https://img.shields.io/pypi/l/taskito.svg)](https://github.com/ByteVeda/taskito/blob/master/LICENSE)
 
 A Rust-powered task queue for Python. No broker required — just SQLite or Postgres.
 

--- a/docs/assets/js/copy-markdown.js
+++ b/docs/assets/js/copy-markdown.js
@@ -1,6 +1,6 @@
 document.addEventListener("DOMContentLoaded", function () {
   const GITHUB_RAW_BASE =
-    "https://raw.githubusercontent.com/pratyush618/taskito/master/docs/";
+    "https://raw.githubusercontent.com/ByteVeda/taskito/master/docs/";
 
   function getSourcePath() {
     // Try the edit button first (most reliable)

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -30,7 +30,7 @@ Building from source requires a Rust toolchain (1.70+).
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
 # Clone and build
-git clone https://github.com/pratyush618/taskito.git
+git clone https://github.com/ByteVeda/taskito.git
 cd taskito
 python -m venv .venv
 source .venv/bin/activate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,11 +24,11 @@ classifiers = [
 ]
 dependencies = ["cloudpickle>=3.0"]
 [project.urls]
-Homepage = "https://github.com/pratyush618/taskito"
+Homepage = "https://github.com/ByteVeda/taskito"
 Documentation = "https://taskito.grigori.in"
-Repository = "https://github.com/pratyush618/taskito"
-Changelog = "https://github.com/pratyush618/taskito/blob/master/docs/changelog.md"
-Issues = "https://github.com/pratyush618/taskito/issues"
+Repository = "https://github.com/ByteVeda/taskito"
+Changelog = "https://github.com/ByteVeda/taskito/blob/master/docs/changelog.md"
+Issues = "https://github.com/ByteVeda/taskito/issues"
 
 [project.optional-dependencies]
 dev = ["pytest>=7.0", "pytest-asyncio>=0.21", "pytest-cov>=4.0", "ruff>=0.8", "mypy>=1.13"]

--- a/zensical.toml
+++ b/zensical.toml
@@ -2,8 +2,8 @@
 site_name = "taskito"
 site_description = "Rust-powered task queue for Python. No broker required."
 site_url = "https://taskito.grigori.in"
-repo_url = "https://github.com/pratyush618/taskito"
-repo_name = "pratyush618/taskito"
+repo_url = "https://github.com/ByteVeda/taskito"
+repo_name = "ByteVeda/taskito"
 
 extra_javascript = ["assets/js/copy-markdown.js"]
 extra_css = ["assets/css/custom.css"]
@@ -150,7 +150,7 @@ search = {}
 
 [[project.extra.social]]
 icon = "fontawesome/brands/github"
-link = "https://github.com/pratyush618/taskito"
+link = "https://github.com/ByteVeda/taskito"
 
 [[project.extra.social]]
 icon = "fontawesome/brands/python"

--- a/zensical.toml
+++ b/zensical.toml
@@ -1,7 +1,7 @@
 [project]
 site_name = "taskito"
 site_description = "Rust-powered task queue for Python. No broker required."
-site_url = "https://taskito.grigori.in"
+site_url = "https://docs.byteveda.org/taskito"
 repo_url = "https://github.com/ByteVeda/taskito"
 repo_name = "ByteVeda/taskito"
 


### PR DESCRIPTION
## Summary
- Replace all `pratyush618/taskito` references with `ByteVeda/taskito` across 6 files
- README badge, pyproject.toml URLs, docs, zensical config, contributing guide