### PR TITLE
chore: bump version to 0.10.1

### DIFF
--- a/crates/taskito-async/Cargo.toml
+++ b/crates/taskito-async/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-async"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/taskito-core/Cargo.toml
+++ b/crates/taskito-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-core"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 
 [features]

--- a/crates/taskito-python/Cargo.toml
+++ b/crates/taskito-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-python"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 
 [features]

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,16 @@
 
 All notable changes to taskito are documented here.
 
+## 0.10.1
+
+### Changed
+
+- Repository transferred to [ByteVeda](https://github.com/ByteVeda/taskito) org
+- Documentation URL updated to [docs.byteveda.org/taskito](https://docs.byteveda.org/taskito)
+- All internal links updated from `pratyush618/taskito` to `ByteVeda/taskito`
+
+---
+
 ## 0.10.0
 
 ### Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "taskito"
-version = "0.10.0"
+version = "0.10.1"
 description = "Rust-powered task queue for Python. No broker required."
 requires-python = ">=3.10"
 license = { file = "LICENSE" }
@@ -25,7 +25,7 @@ classifiers = [
 dependencies = ["cloudpickle>=3.0"]
 [project.urls]
 Homepage = "https://github.com/ByteVeda/taskito"
-Documentation = "https://taskito.grigori.in"
+Documentation = "https://docs.byteveda.org/taskito"
 Repository = "https://github.com/ByteVeda/taskito"
 Changelog = "https://github.com/ByteVeda/taskito/blob/master/docs/changelog.md"
 Issues = "https://github.com/ByteVeda/taskito/issues"


### PR DESCRIPTION
## Summary
- Bump version to 0.10.1 across pyproject.toml and all 3 Cargo.toml files
- Update Documentation URL from `taskito.grigori.in` to `docs.byteveda.org/taskito`
- Add 0.10.1 changelog entry (org transfer, URL updates)

## After merge
```bash
git tag 0.10.1 master && git push origin 0.10.1
```