### PR TITLE
chore(release): 0.11.1

### DIFF
--- a/crates/taskito-async/Cargo.toml
+++ b/crates/taskito-async/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-async"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/taskito-core/Cargo.toml
+++ b/crates/taskito-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-core"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 
 [features]

--- a/crates/taskito-python/Cargo.toml
+++ b/crates/taskito-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-python"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 
 [features]

--- a/crates/taskito-workflows/Cargo.toml
+++ b/crates/taskito-workflows/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-workflows"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 
 [dependencies]

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,7 +2,7 @@
 
 All notable changes to taskito are documented here.
 
-## Unreleased
+## 0.11.1
 
 ### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "taskito"
-version = "0.11.0"
+version = "0.11.1"
 description = "Rust-powered task queue for Python. No broker required."
 requires-python = ">=3.10"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary

- Bumps all crates + `pyproject.toml` from `0.11.0` to `0.11.1`.
- Promotes the `Unreleased` changelog section to `0.11.1`.

Covers the audit-correctness merge (#53) — workflow fan-in CAS, sub-workflow compile-failure handling, Redis `purge_execution_claims`, SQLite DLQ cascade propagation, GIL release on workflow ops, tracker state lock, iterative cancel, `PrometheusMiddleware(task_filter=...)`, and related polish. See `docs/changelog.md` for the full list.

## Test plan

- [x] `cargo check --workspace` passes after bump
- [ ] CI green on all backends (default / postgres / redis / workflows / native-async)