### PR TITLE
refactor(async): enforce async-separation + arun_worker kwarg parity

### DIFF
--- a/py_src/taskito/async_support/canvas.py
+++ b/py_src/taskito/async_support/canvas.py
@@ -1,0 +1,90 @@
+"""Async canvas mixins.
+
+Hosts the ``apply_async`` methods for :class:`~taskito.canvas.group` and
+:class:`~taskito.canvas.chord`. Lives under ``async_support/`` so that
+``taskito/canvas.py`` itself does not need to import ``asyncio`` — keeping the
+module async-agnostic and consistent with the ``JobResult``/``AsyncJobResultMixin``
+split in ``async_support/result.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from taskito.app import Queue
+    from taskito.canvas import Signature, group
+    from taskito.result import JobResult
+
+
+_DEFAULT_TIMEOUT = 300
+
+
+def _signature_timeout(sig: Signature) -> float:
+    """Per-signature timeout for awaiting results, falling back to the default."""
+    timeout = sig.options.get("timeout", _DEFAULT_TIMEOUT)
+    return float(timeout)
+
+
+async def _await_wave(wave_jobs: list[JobResult], wave: list[Signature]) -> None:
+    """Await every job in a wave in parallel, honoring per-signature timeouts."""
+    await asyncio.gather(
+        *(
+            job.aresult(timeout=_signature_timeout(sig))
+            for job, sig in zip(wave_jobs, wave, strict=True)
+        )
+    )
+
+
+class AsyncGroupMixin:
+    """Provides ``apply_async`` for :class:`~taskito.canvas.group`."""
+
+    if TYPE_CHECKING:
+        signatures: list[Signature]
+        max_concurrency: int | None
+
+    async def apply_async(self, queue: Queue | None = None) -> list[JobResult]:
+        """Enqueue all signatures for parallel execution (async-safe).
+
+        With ``max_concurrency`` set, dispatches in waves, awaiting each
+        wave before starting the next.
+        """
+        q = queue or self.signatures[0].task._queue
+
+        if self.max_concurrency is None:
+            return [sig.apply(q) for sig in self.signatures]
+
+        all_jobs: list[JobResult] = []
+        step = self.max_concurrency
+        for start in range(0, len(self.signatures), step):
+            wave = self.signatures[start : start + step]
+            wave_jobs = [sig.apply(q) for sig in wave]
+            await _await_wave(wave_jobs, wave)
+            all_jobs.extend(wave_jobs)
+        return all_jobs
+
+
+class AsyncChordMixin:
+    """Provides ``apply_async`` for :class:`~taskito.canvas.chord`."""
+
+    if TYPE_CHECKING:
+        group: group
+        callback: Signature
+
+    async def apply_async(self, queue: Queue | None = None) -> JobResult:
+        """Execute group, await all results, then run the callback (async-safe)."""
+        q = queue or self.callback.task._queue
+
+        jobs = self.group.apply(queue=q)
+        max_timeout = max(
+            (_signature_timeout(sig) for sig in self.group.signatures),
+            default=_DEFAULT_TIMEOUT,
+        )
+        results = await asyncio.gather(*(job.aresult(timeout=max_timeout) for job in jobs))
+
+        callback = self.callback
+        if not callback.immutable:
+            callback = dataclasses.replace(callback, args=(list(results), *callback.args))
+        return callback.apply(q)

--- a/py_src/taskito/async_support/mixins.py
+++ b/py_src/taskito/async_support/mixins.py
@@ -83,7 +83,11 @@ class AsyncQueueMixin:
         def circuit_breakers(self) -> list[dict]: ...
         def workers(self) -> list[dict]: ...
         def run_worker(
-            self, queues: Sequence[str] | None = ..., tags: list[str] | None = ...
+            self,
+            queues: Sequence[str] | None = ...,
+            tags: list[str] | None = ...,
+            pool: str = ...,
+            app: str | None = ...,
         ) -> None: ...
         def purge_completed(self, older_than: int = ...) -> int: ...
         def purge_dead(self, older_than: int = ...) -> int: ...
@@ -268,6 +272,8 @@ class AsyncQueueMixin:
         self,
         queues: Sequence[str] | None = None,
         tags: list[str] | None = None,
+        pool: str = "thread",
+        app: str | None = None,
     ) -> None:
         """Async version of :meth:`run_worker`.
 
@@ -277,6 +283,9 @@ class AsyncQueueMixin:
         Args:
             queues: List of queue names to consume from.
             tags: Optional tags for worker specialization / routing.
+            pool: Worker pool type — ``"thread"`` (default) or ``"prefork"``.
+            app: Import path to the Queue instance (e.g. ``"myapp:queue"``).
+                Required when ``pool="prefork"``.
         """
         loop = asyncio.get_running_loop()
 
@@ -296,7 +305,10 @@ class AsyncQueueMixin:
         loop.add_signal_handler(signal.SIGTERM, _shutdown_once)
 
         try:
-            await loop.run_in_executor(None, lambda: self.run_worker(queues=queues, tags=tags))
+            await loop.run_in_executor(
+                None,
+                lambda: self.run_worker(queues=queues, tags=tags, pool=pool, app=app),
+            )
         finally:
             with contextlib.suppress(NotImplementedError):
                 loop.remove_signal_handler(signal.SIGINT)

--- a/py_src/taskito/async_support/result.py
+++ b/py_src/taskito/async_support/result.py
@@ -3,18 +3,31 @@
 from __future__ import annotations
 
 import asyncio
+import json
+import logging
 import time
-from typing import TYPE_CHECKING, Any
+from collections.abc import AsyncIterator
+from typing import TYPE_CHECKING, Any, ClassVar
+
+if TYPE_CHECKING:
+    from taskito._taskito import PyJob
+    from taskito.app import Queue
+
+log = logging.getLogger("taskito.result")
 
 
 class AsyncJobResultMixin:
-    """Provides the async ``aresult()`` method for JobResult."""
+    """Provides the async ``aresult()`` and ``astream()`` methods for JobResult."""
 
     if TYPE_CHECKING:
+        _TERMINAL_STATUSES: ClassVar[frozenset[str]]
+        _queue: Queue
+        _py_job: PyJob
 
         @property
         def id(self) -> str: ...
         def _poll_once(self) -> tuple[str, Any]: ...
+        def refresh(self) -> None: ...
 
     async def aresult(
         self,
@@ -62,3 +75,46 @@ class AsyncJobResultMixin:
 
             await asyncio.sleep(min(current_interval, max(0, deadline - time.monotonic())))
             current_interval = min(current_interval * 1.5, max_poll_interval)
+
+    async def astream(
+        self,
+        timeout: float = 60.0,
+        poll_interval: float = 0.5,
+    ) -> AsyncIterator[Any]:
+        """Async iterate over partial results published by the task.
+
+        Async version of :meth:`JobResult.stream`. Uses ``asyncio.sleep`` so it
+        won't block the event loop.
+
+        Args:
+            timeout: Maximum seconds to wait for results.
+            poll_interval: Seconds between polls.
+
+        Yields:
+            Deserialized partial result data.
+        """
+        deadline = time.monotonic() + timeout
+        last_seen_at: int = 0
+
+        while time.monotonic() < deadline:
+            logs = self._queue._inner.get_task_logs(self.id)
+            for entry in logs:
+                if entry["level"] != "result":
+                    continue
+                logged_at = entry.get("logged_at", 0)
+                if logged_at <= last_seen_at:
+                    continue
+                last_seen_at = logged_at
+                extra = entry.get("extra")
+                if extra:
+                    try:
+                        yield json.loads(extra)
+                    except (json.JSONDecodeError, TypeError):
+                        log.warning("failed to deserialize partial result for job %s", self.id)
+                        yield extra
+
+            self.refresh()
+            if self._py_job.status in self._TERMINAL_STATUSES:
+                return
+
+            await asyncio.sleep(min(poll_interval, max(0, deadline - time.monotonic())))

--- a/py_src/taskito/canvas.py
+++ b/py_src/taskito/canvas.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-import asyncio
 import math
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
+
+from taskito.async_support.canvas import AsyncChordMixin, AsyncGroupMixin
 
 if TYPE_CHECKING:
     from taskito.app import Queue
@@ -101,7 +102,7 @@ class chain:
         return last_job  # type: ignore[return-value]
 
 
-class group:
+class group(AsyncGroupMixin):
     """Execute signatures in parallel and collect all results.
 
     Args:
@@ -156,51 +157,8 @@ class group:
 
         return all_jobs
 
-    async def apply_async(self, queue: Queue | None = None) -> list[JobResult]:
-        """Enqueue all signatures for parallel execution (async-safe).
 
-        With ``max_concurrency`` set, dispatches in waves, awaiting each
-        wave before starting the next.
-        """
-        q = queue or self.signatures[0].task._queue
-
-        if self.max_concurrency is None:
-            jobs: list[JobResult] = []
-            for sig in self.signatures:
-                job = q.enqueue(
-                    task_name=sig.task.name,
-                    args=sig.args,
-                    kwargs=sig.kwargs if sig.kwargs else None,
-                    **sig.options,
-                )
-                jobs.append(job)
-            return jobs
-
-        all_jobs: list[JobResult] = []
-        mc = self.max_concurrency
-        for i in range(0, len(self.signatures), mc):
-            wave = self.signatures[i : i + mc]
-            wave_jobs: list[JobResult] = []
-            for sig in wave:
-                job = q.enqueue(
-                    task_name=sig.task.name,
-                    args=sig.args,
-                    kwargs=sig.kwargs if sig.kwargs else None,
-                    **sig.options,
-                )
-                wave_jobs.append(job)
-            await asyncio.gather(
-                *(
-                    wj.aresult(timeout=sig.options.get("timeout", 300))
-                    for wj, sig in zip(wave_jobs, wave, strict=True)
-                )
-            )
-            all_jobs.extend(wave_jobs)
-
-        return all_jobs
-
-
-class chord:
+class chord(AsyncChordMixin):
     """Run a group in parallel, then a callback with all results."""
 
     def __init__(self, group_: group, callback: Signature):
@@ -222,28 +180,6 @@ class chord:
         args = self.callback.args
         if not self.callback.immutable:
             args = (results, *self.callback.args)
-
-        return q.enqueue(
-            task_name=self.callback.task.name,
-            args=args,
-            kwargs=self.callback.kwargs if self.callback.kwargs else None,
-            **self.callback.options,
-        )
-
-    async def apply_async(self, queue: Queue | None = None) -> JobResult:
-        """Execute group, await all results, then run the callback (async-safe)."""
-        q = queue or self.callback.task._queue
-
-        jobs = self.group.apply(queue=q)
-        max_timeout = max(
-            (sig.options.get("timeout", 300) for sig in self.group.signatures),
-            default=300,
-        )
-        results = await asyncio.gather(*(job.aresult(timeout=max_timeout) for job in jobs))
-
-        args = self.callback.args
-        if not self.callback.immutable:
-            args = (list(results), *self.callback.args)
 
         return q.enqueue(
             task_name=self.callback.task.name,

--- a/py_src/taskito/result.py
+++ b/py_src/taskito/result.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
 import time
-from collections.abc import AsyncIterator, Iterator
+from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any
 
 from taskito.async_support.result import AsyncJobResultMixin
@@ -206,49 +205,6 @@ class JobResult(AsyncJobResultMixin):
                 return
 
             time.sleep(min(poll_interval, max(0, deadline - time.monotonic())))
-
-    async def astream(
-        self,
-        timeout: float = 60.0,
-        poll_interval: float = 0.5,
-    ) -> AsyncIterator[Any]:
-        """Async iterate over partial results published by the task.
-
-        Async version of :meth:`stream`. Uses ``asyncio.sleep`` so it won't
-        block the event loop.
-
-        Args:
-            timeout: Maximum seconds to wait for results.
-            poll_interval: Seconds between polls.
-
-        Yields:
-            Deserialized partial result data.
-        """
-        deadline = time.monotonic() + timeout
-        last_seen_at: int = 0
-
-        while time.monotonic() < deadline:
-            logs = self._queue._inner.get_task_logs(self.id)
-            for entry in logs:
-                if entry["level"] != "result":
-                    continue
-                logged_at = entry.get("logged_at", 0)
-                if logged_at <= last_seen_at:
-                    continue
-                last_seen_at = logged_at
-                extra = entry.get("extra")
-                if extra:
-                    try:
-                        yield json.loads(extra)
-                    except (json.JSONDecodeError, TypeError):
-                        log.warning("failed to deserialize partial result for job %s", self.id)
-                        yield extra
-
-            self.refresh()
-            if self._py_job.status in self._TERMINAL_STATUSES:
-                return
-
-            await asyncio.sleep(min(poll_interval, max(0, deadline - time.monotonic())))
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to a plain dictionary for JSON serialization.


### PR DESCRIPTION
## Summary

Closes two P1 items from the 2026-04-23 audit that were still open after PR #53 landed the P0 fixes.

- **Async-separation** — `py_src/taskito/canvas.py` and `py_src/taskito/result.py` no longer `import asyncio`. `JobResult.astream` is moved into `AsyncJobResultMixin` alongside `aresult`. `group.apply_async` / `chord.apply_async` are extracted into a new `async_support/canvas.py` as `AsyncGroupMixin` / `AsyncChordMixin`, and the sync classes inherit from them. This keeps the project's rule that `asyncio` lives only under `async_support/` (plus the two documented exceptions).
- **`arun_worker` kwarg parity** — `AsyncQueueMixin.arun_worker` now accepts `pool` and `app`, matching the sync `run_worker` signature introduced with the prefork pool. The Protocol `run_worker` stub inside `AsyncQueueMixin` is updated to match.
- **Tightening while here** — the new async canvas mixins delegate to `Signature.apply()` and use `dataclasses.replace()` for the chord callback rebuild, collapsing the inline enqueue-loop duplication that existed before.

## Verification

- `cargo check --workspace` + `--features postgres` + `--features redis` + `--features native-async` — all clean
- `cargo test --workspace` — all pass
- `uv run pytest tests/python/` — 432 passed, 9 skipped
- `uv run ruff check py_src/ tests/` — clean
- `uv run mypy py_src/taskito/` + tests — clean
- Pre-commit hooks (ruff, ruff format, mypy) — all pass

## Test plan

- [x] Full Python test suite (432 passed, 9 skipped)
- [x] Rust workspace tests across all feature combinations
- [x] Ruff + mypy on `py_src/` and `tests/`
- [x] Verified no `asyncio` references remain in `canvas.py` or `result.py`
- [x] Verified `arun_worker` forwards `pool` and `app` to `run_worker`