### PR TITLE
feat(dashboard): wire TanStack loaders, typed URL search, and barrel cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         run: cargo clippy --all-targets --all-features -- -D warnings
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           version: "0.10.12"
           cache-dependency-glob: pyproject.toml
@@ -118,7 +118,7 @@ jobs:
           save-if: ${{ matrix.os != 'ubuntu-latest' }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           version: "0.10.12"
           cache-dependency-glob: pyproject.toml

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,13 +33,13 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           queries: security-extended
 
       - name: Perform analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: "10.30.3"
 
@@ -77,7 +77,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload built assets
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: dashboard-dist
           path: py_src/taskito/static/dashboard/

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v8.1.0
 
       - name: Install dependencies
         run: uv sync --extra docs
@@ -32,7 +32,7 @@ jobs:
       - name: Build docs
         run: uv run zensical build
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5.0.0
         with:
           path: site
 
@@ -44,4 +44,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5.0.0

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -12,7 +12,7 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@v6.0.1
         with:
           configuration-path: .github/labeler.yml
           sync-labels: true

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,29 @@
+name: Stale PRs
+
+on:
+  schedule:
+    - cron: "0 2 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-pr-stale: 7
+          days-before-pr-close: 3
+          stale-pr-label: stale
+          stale-pr-message: >
+            This PR has had no activity for 7 days and has been marked as stale.
+            It will be closed in 3 days if no further activity occurs.
+          close-pr-message: >
+            Closing this PR due to 10 days of inactivity.
+            Feel free to reopen it once you're ready to continue.
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          exempt-pr-labels: "pinned,security,work-in-progress"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10.2.0
         with:
           days-before-pr-stale: 7
           days-before-pr-close: 3

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -39,7 +39,8 @@
     "react-error-boundary": "^6.1.1",
     "recharts": "^3.8.1",
     "sonner": "^1.7.1",
-    "tailwind-merge": "^2.6.0"
+    "tailwind-merge": "^2.6.0",
+    "valibot": "^1.3.1"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.8",

--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       tailwind-merge:
         specifier: ^2.6.0
         version: 2.6.1
+      valibot:
+        specifier: ^1.3.1
+        version: 1.3.1(typescript@5.9.3)
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.4.8
@@ -2145,6 +2148,14 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  valibot@1.3.1:
+    resolution: {integrity: sha512-sfdRir/QFM0JaF22hqTroPc5xy4DimuGQVKFrzF1YfGwaS1nJot3Y8VqMdLO2Lg27fMzat2yD3pY5PbAYO39Gg==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   victory-vendor@37.3.6:
     resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
@@ -4045,6 +4056,10 @@ snapshots:
   use-sync-external-store@1.6.0(react@18.3.1):
     dependencies:
       react: 18.3.1
+
+  valibot@1.3.1(typescript@5.9.3):
+    optionalDependencies:
+      typescript: 5.9.3
 
   victory-vendor@37.3.6:
     dependencies:

--- a/dashboard/src/components/layout/app-shell.tsx
+++ b/dashboard/src/components/layout/app-shell.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { TooltipProvider } from "@/components/ui/tooltip";
+import { TooltipProvider } from "@/components/ui";
 import { CommandPalette } from "./command-palette";
 import { Header } from "./header";
 import { RouteErrorBoundary } from "./route-error-boundary";

--- a/dashboard/src/components/layout/backend-offline.tsx
+++ b/dashboard/src/components/layout/backend-offline.tsx
@@ -1,0 +1,108 @@
+import { useRouter } from "@tanstack/react-router";
+import { ExternalLink, Power, RefreshCw, Terminal } from "lucide-react";
+import { useTransition } from "react";
+import { Button } from "@/components/ui";
+
+/**
+ * Shown when a route loader (or in-flight query) can't reach the Taskito
+ * backend — either the network request failed outright or the server
+ * replied with a 502/503/504. Gives the user actionable next steps instead
+ * of the generic "something went wrong" screen.
+ */
+export function BackendOffline({ error }: { error: Error }) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+
+  const retry = () => {
+    startTransition(() => {
+      router.invalidate();
+    });
+  };
+
+  return (
+    <div className="grid min-h-[60vh] place-items-center px-4">
+      <div className="w-full max-w-lg">
+        <div className="flex items-center gap-3">
+          <div className="grid size-10 place-items-center rounded-full bg-[var(--surface-2)] text-[var(--fg-muted)]">
+            <Power className="size-5" aria-hidden />
+          </div>
+          <div>
+            <h1 className="text-lg font-semibold tracking-tight">
+              Can't reach the Taskito backend
+            </h1>
+            <p className="text-sm text-[var(--fg-muted)]">
+              The dashboard tried to fetch data but didn't get a response.
+            </p>
+          </div>
+        </div>
+
+        <div className="mt-6 rounded-lg border border-[var(--border)] bg-[var(--surface)] p-4">
+          <p className="text-sm font-medium text-[var(--fg)]">Common causes</p>
+          <ul className="mt-2 flex flex-col gap-2 text-sm text-[var(--fg-muted)]">
+            <li className="flex items-start gap-2">
+              <span
+                className="mt-1 size-1.5 shrink-0 rounded-full bg-[var(--fg-subtle)]"
+                aria-hidden
+              />
+              <span>
+                The dashboard process isn't running. Start it with:
+                <code className="ml-1 rounded bg-[var(--surface-2)] px-1.5 py-0.5 font-mono text-xs text-[var(--fg)]">
+                  taskito dashboard --app myapp:queue
+                </code>
+              </span>
+            </li>
+            <li className="flex items-start gap-2">
+              <span
+                className="mt-1 size-1.5 shrink-0 rounded-full bg-[var(--fg-subtle)]"
+                aria-hidden
+              />
+              <span>
+                The worker process crashed. Tail its logs or restart it with:
+                <code className="ml-1 rounded bg-[var(--surface-2)] px-1.5 py-0.5 font-mono text-xs text-[var(--fg)]">
+                  taskito worker --app myapp:queue
+                </code>
+              </span>
+            </li>
+            <li className="flex items-start gap-2">
+              <span
+                className="mt-1 size-1.5 shrink-0 rounded-full bg-[var(--fg-subtle)]"
+                aria-hidden
+              />
+              <span>
+                A restart or deploy is in progress — the server is up but returning 5xx. Usually
+                resolves in a few seconds.
+              </span>
+            </li>
+          </ul>
+        </div>
+
+        {error.message ? (
+          <details className="mt-3 rounded-lg border border-[var(--border)] bg-[var(--surface)] p-3 text-sm">
+            <summary className="flex cursor-pointer items-center gap-2 text-[var(--fg-muted)]">
+              <Terminal className="size-3.5" aria-hidden />
+              Technical details
+            </summary>
+            <pre className="mt-2 overflow-x-auto whitespace-pre-wrap font-mono text-xs text-[var(--fg-subtle)]">
+              {error.message}
+            </pre>
+          </details>
+        ) : null}
+
+        <div className="mt-5 flex items-center gap-2">
+          <Button onClick={retry} disabled={pending}>
+            <RefreshCw aria-hidden className={pending ? "animate-spin" : undefined} />
+            {pending ? "Retrying…" : "Retry"}
+          </Button>
+          <a
+            href="https://docs.byteveda.org/taskito/guide/observability/dashboard"
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-1.5 text-sm text-[var(--fg-muted)] hover:text-[var(--fg)]"
+          >
+            Docs <ExternalLink className="size-3.5" aria-hidden />
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/components/layout/command-palette.tsx
+++ b/dashboard/src/components/layout/command-palette.tsx
@@ -24,7 +24,7 @@ import {
   CommandList,
   CommandSeparator,
   CommandShortcut,
-} from "@/components/ui/command";
+} from "@/components/ui";
 import { type RefreshOption, useCommandPalette, useRefreshInterval, useTheme } from "@/providers";
 
 interface NavCmd {

--- a/dashboard/src/components/layout/command-palette.tsx
+++ b/dashboard/src/components/layout/command-palette.tsx
@@ -25,9 +25,7 @@ import {
   CommandSeparator,
   CommandShortcut,
 } from "@/components/ui/command";
-import { useCommandPalette } from "@/providers/command-palette-provider";
-import { type RefreshOption, useRefreshInterval } from "@/providers/refresh-interval-provider";
-import { useTheme } from "@/providers/theme-provider";
+import { type RefreshOption, useCommandPalette, useRefreshInterval, useTheme } from "@/providers";
 
 interface NavCmd {
   label: string;

--- a/dashboard/src/components/layout/header.tsx
+++ b/dashboard/src/components/layout/header.tsx
@@ -1,6 +1,5 @@
 import { Search } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import { Kbd } from "@/components/ui/kbd";
+import { Button, Kbd } from "@/components/ui";
 import { useCommandPalette } from "@/providers";
 import { LastRefreshed } from "./last-refreshed";
 import { MobileMenu } from "./mobile-menu";

--- a/dashboard/src/components/layout/header.tsx
+++ b/dashboard/src/components/layout/header.tsx
@@ -1,7 +1,7 @@
 import { Search } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Kbd } from "@/components/ui/kbd";
-import { useCommandPalette } from "@/providers/command-palette-provider";
+import { useCommandPalette } from "@/providers";
 import { LastRefreshed } from "./last-refreshed";
 import { MobileMenu } from "./mobile-menu";
 import { RefreshControl } from "./refresh-control";

--- a/dashboard/src/components/layout/index.ts
+++ b/dashboard/src/components/layout/index.ts
@@ -1,4 +1,5 @@
 export { AppShell } from "./app-shell";
+export { BackendOffline } from "./backend-offline";
 export type { Crumb } from "./breadcrumbs";
 export { Breadcrumbs } from "./breadcrumbs";
 export { CommandPalette } from "./command-palette";

--- a/dashboard/src/components/layout/mobile-menu.tsx
+++ b/dashboard/src/components/layout/mobile-menu.tsx
@@ -14,8 +14,14 @@ import {
   Skull,
 } from "lucide-react";
 import { useEffect, useState } from "react";
-import { Button } from "@/components/ui/button";
-import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
+import {
+  Button,
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui";
 import { cn } from "@/lib/cn";
 import { site } from "@/lib/site";
 

--- a/dashboard/src/components/layout/refresh-control.tsx
+++ b/dashboard/src/components/layout/refresh-control.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@/lib/cn";
-import { type RefreshOption, useRefreshInterval } from "@/providers/refresh-interval-provider";
+import { type RefreshOption, useRefreshInterval } from "@/providers";
 
 const OPTIONS: RefreshOption[] = ["2s", "5s", "10s", "off"];
 

--- a/dashboard/src/components/layout/route-error-boundary.tsx
+++ b/dashboard/src/components/layout/route-error-boundary.tsx
@@ -2,7 +2,7 @@ import { QueryErrorResetBoundary } from "@tanstack/react-query";
 import { AlertTriangle } from "lucide-react";
 import type { ReactNode } from "react";
 import { ErrorBoundary, type FallbackProps } from "react-error-boundary";
-import { Button } from "@/components/ui/button";
+import { Button } from "@/components/ui";
 
 function RouteErrorFallback({ error, resetErrorBoundary }: FallbackProps) {
   return (

--- a/dashboard/src/components/layout/theme-toggle.tsx
+++ b/dashboard/src/components/layout/theme-toggle.tsx
@@ -1,5 +1,5 @@
 import { Laptop, Moon, Sun } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import { Button } from "@/components/ui";
 import { cn } from "@/lib/cn";
 import { type Theme, useTheme } from "@/providers";
 

--- a/dashboard/src/components/layout/theme-toggle.tsx
+++ b/dashboard/src/components/layout/theme-toggle.tsx
@@ -1,7 +1,7 @@
 import { Laptop, Moon, Sun } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/cn";
-import { type Theme, useTheme } from "@/providers/theme-provider";
+import { type Theme, useTheme } from "@/providers";
 
 const OPTIONS: Array<{ value: Theme; label: string; icon: typeof Sun }> = [
   { value: "light", label: "Light", icon: Sun },

--- a/dashboard/src/features/circuit-breakers/hooks.ts
+++ b/dashboard/src/features/circuit-breakers/hooks.ts
@@ -1,12 +1,15 @@
-import { useQuery } from "@tanstack/react-query";
+import { queryOptions, useQuery } from "@tanstack/react-query";
 import { useRefreshInterval } from "@/providers";
 import { fetchCircuitBreakers } from "./api";
 
-export function useCircuitBreakers() {
-  const { intervalMs } = useRefreshInterval();
-  return useQuery({
+export function circuitBreakersQuery() {
+  return queryOptions({
     queryKey: ["circuit-breakers"],
     queryFn: ({ signal }) => fetchCircuitBreakers(signal),
-    refetchInterval: intervalMs,
   });
+}
+
+export function useCircuitBreakers() {
+  const { intervalMs } = useRefreshInterval();
+  return useQuery({ ...circuitBreakersQuery(), refetchInterval: intervalMs });
 }

--- a/dashboard/src/features/dead-letters/hooks.ts
+++ b/dashboard/src/features/dead-letters/hooks.ts
@@ -1,4 +1,10 @@
-import { keepPreviousData, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  keepPreviousData,
+  queryOptions,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import { toast } from "sonner";
 import { useRefreshInterval } from "@/providers";
 import { fetchDeadLetters, purgeDeadLetters, retryDeadLetter } from "./api";
@@ -8,14 +14,17 @@ const KEY = {
   list: (page: number, pageSize: number) => ["dead-letters", "list", page, pageSize] as const,
 };
 
-export function useDeadLetters(page: number, pageSize: number) {
-  const { intervalMs } = useRefreshInterval();
-  return useQuery({
+export function deadLettersQuery(page: number, pageSize: number) {
+  return queryOptions({
     queryKey: KEY.list(page, pageSize),
     queryFn: ({ signal }) => fetchDeadLetters(page, pageSize, signal),
     placeholderData: keepPreviousData,
-    refetchInterval: intervalMs,
   });
+}
+
+export function useDeadLetters(page: number, pageSize: number) {
+  const { intervalMs } = useRefreshInterval();
+  return useQuery({ ...deadLettersQuery(page, pageSize), refetchInterval: intervalMs });
 }
 
 export function useRetryDeadLetter() {

--- a/dashboard/src/features/jobs/hooks.ts
+++ b/dashboard/src/features/jobs/hooks.ts
@@ -1,6 +1,6 @@
 import {
   keepPreviousData,
-  type Query,
+  queryOptions,
   useMutation,
   useQuery,
   useQueryClient,
@@ -31,18 +31,56 @@ const KEY = {
   dag: (id: string) => ["jobs", "detail", id, "dag"] as const,
 };
 
+export function jobsListQuery(query: JobListQuery) {
+  return queryOptions({
+    queryKey: KEY.list(query),
+    queryFn: ({ signal }) => fetchJobs(query, signal),
+    placeholderData: keepPreviousData,
+  });
+}
+
+export function jobDetailQuery(id: string) {
+  return queryOptions({
+    queryKey: KEY.detail(id),
+    queryFn: ({ signal }) => fetchJob(id, signal),
+  });
+}
+
+export function jobLogsQuery(id: string) {
+  return queryOptions({
+    queryKey: KEY.logs(id),
+    queryFn: ({ signal }) => fetchJobLogs(id, signal),
+  });
+}
+
+export function jobErrorsQuery(id: string) {
+  return queryOptions({
+    queryKey: KEY.errors(id),
+    queryFn: ({ signal }) => fetchJobErrors(id, signal),
+  });
+}
+
+export function jobReplayHistoryQuery(id: string) {
+  return queryOptions({
+    queryKey: KEY.replays(id),
+    queryFn: ({ signal }) => fetchReplayHistory(id, signal),
+  });
+}
+
+export function jobDagQuery(id: string) {
+  return queryOptions({
+    queryKey: KEY.dag(id),
+    queryFn: ({ signal }) => fetchJobDag(id, signal),
+  });
+}
+
 /**
  * Paginated job list. Uses `keepPreviousData` to avoid flashing empty state
  * between pages, and polls at the dashboard-wide refresh cadence.
  */
 export function useJobs(query: JobListQuery) {
   const { intervalMs } = useRefreshInterval();
-  return useQuery({
-    queryKey: KEY.list(query),
-    queryFn: ({ signal }) => fetchJobs(query, signal),
-    placeholderData: keepPreviousData,
-    refetchInterval: intervalMs,
-  });
+  return useQuery({ ...jobsListQuery(query), refetchInterval: intervalMs });
 }
 
 /**
@@ -52,11 +90,10 @@ export function useJobs(query: JobListQuery) {
 export function useJob(id: string, enabled = true) {
   const { intervalMs } = useRefreshInterval();
   return useQuery({
-    queryKey: KEY.detail(id),
-    queryFn: ({ signal }) => fetchJob(id, signal),
+    ...jobDetailQuery(id),
     enabled,
-    refetchInterval: (query: Query<Job>) => {
-      const data = query.state.data;
+    refetchInterval: (query) => {
+      const data = query.state.data as Job | undefined;
       if (data && isTerminalStatus(data.status)) return false;
       return intervalMs;
     },
@@ -65,38 +102,20 @@ export function useJob(id: string, enabled = true) {
 
 export function useJobLogs(id: string, enabled = true) {
   const { intervalMs } = useRefreshInterval();
-  return useQuery({
-    queryKey: KEY.logs(id),
-    queryFn: ({ signal }) => fetchJobLogs(id, signal),
-    enabled,
-    refetchInterval: intervalMs,
-  });
+  return useQuery({ ...jobLogsQuery(id), enabled, refetchInterval: intervalMs });
 }
 
 export function useJobErrors(id: string, enabled = true) {
   const { intervalMs } = useRefreshInterval();
-  return useQuery({
-    queryKey: KEY.errors(id),
-    queryFn: ({ signal }) => fetchJobErrors(id, signal),
-    enabled,
-    refetchInterval: intervalMs,
-  });
+  return useQuery({ ...jobErrorsQuery(id), enabled, refetchInterval: intervalMs });
 }
 
 export function useReplayHistory(id: string, enabled = true) {
-  return useQuery({
-    queryKey: KEY.replays(id),
-    queryFn: ({ signal }) => fetchReplayHistory(id, signal),
-    enabled,
-  });
+  return useQuery({ ...jobReplayHistoryQuery(id), enabled });
 }
 
 export function useJobDag(id: string, enabled = true) {
-  return useQuery({
-    queryKey: KEY.dag(id),
-    queryFn: ({ signal }) => fetchJobDag(id, signal),
-    enabled,
-  });
+  return useQuery({ ...jobDagQuery(id), enabled });
 }
 
 interface MutationContext {

--- a/dashboard/src/features/jobs/search-schema.ts
+++ b/dashboard/src/features/jobs/search-schema.ts
@@ -1,0 +1,43 @@
+import * as v from "valibot";
+import type { JobStatus } from "@/lib/api-types";
+
+/**
+ * Ordered list of valid job statuses. Exported so UI components (filters,
+ * dropdowns) can reuse the same set as the search-param validator.
+ */
+export const JOB_STATUS_VALUES = [
+  "pending",
+  "running",
+  "complete",
+  "failed",
+  "dead",
+  "cancelled",
+] as const satisfies readonly JobStatus[];
+
+/**
+ * Schema for the filter fields — everything you might narrow a job query by
+ * except pagination. Reused by the list-search schema below so filters and
+ * pagination stay in lock-step.
+ */
+export const jobFiltersSchema = v.object({
+  status: v.optional(v.picklist(JOB_STATUS_VALUES)),
+  queue: v.optional(v.string()),
+  task: v.optional(v.string()),
+  metadata: v.optional(v.string()),
+  error: v.optional(v.string()),
+  createdAfter: v.optional(v.number()),
+  createdBefore: v.optional(v.number()),
+});
+
+/**
+ * Schema for the full `/jobs` URL search params: filters + pagination.
+ *
+ * `pageSize` is clamped to [10, 200] so a malformed deep link cannot force a
+ * 10k-row fetch. `validateSearch` on the route rejects inputs that escape
+ * this range after normalization, which is treated as a programmer error.
+ */
+export const jobListSearchSchema = v.object({
+  ...jobFiltersSchema.entries,
+  page: v.pipe(v.number(), v.integer(), v.minValue(0)),
+  pageSize: v.pipe(v.number(), v.integer(), v.minValue(10), v.maxValue(200)),
+});

--- a/dashboard/src/features/jobs/types.ts
+++ b/dashboard/src/features/jobs/types.ts
@@ -1,21 +1,13 @@
-import type { JobStatus } from "@/lib/api-types";
+import type * as v from "valibot";
+import type { jobFiltersSchema, jobListSearchSchema } from "./search-schema";
 
 /**
- * Filter criteria for listing jobs. Every field is optional and narrowing
- * — pagination lives alongside so a single `JobListQuery` round-trips
- * through the URL search params.
+ * Filter criteria for listing jobs. Inferred from the valibot schema so the
+ * runtime validator and compile-time type stay in sync.
  */
-export interface JobFilters {
-  status?: JobStatus;
-  queue?: string;
-  task?: string;
-  metadata?: string;
-  error?: string;
-  createdAfter?: number;
-  createdBefore?: number;
-}
+export type JobFilters = v.InferOutput<typeof jobFiltersSchema>;
 
-export interface JobListQuery extends JobFilters {
-  page: number;
-  pageSize: number;
-}
+/**
+ * Full shape of the `/jobs` URL search params: filters plus pagination.
+ */
+export type JobListQuery = v.InferOutput<typeof jobListSearchSchema>;

--- a/dashboard/src/features/jobs/utils.ts
+++ b/dashboard/src/features/jobs/utils.ts
@@ -1,16 +1,11 @@
+import * as v from "valibot";
 import type { JobStatus } from "@/lib/api-types";
+import { JOB_STATUS_VALUES, jobListSearchSchema } from "./search-schema";
 import type { JobFilters, JobListQuery } from "./types";
 
-const STATUS_VALUES: readonly JobStatus[] = [
-  "pending",
-  "running",
-  "complete",
-  "failed",
-  "dead",
-  "cancelled",
-] as const;
-
 const DEFAULT_PAGE_SIZE = 25;
+const MIN_PAGE_SIZE = 10;
+const MAX_PAGE_SIZE = 200;
 
 function asTrimmedString(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined;
@@ -26,16 +21,20 @@ function asNonNegativeInteger(value: unknown): number | undefined {
 }
 
 function asJobStatus(value: unknown): JobStatus | undefined {
-  return STATUS_VALUES.find((s) => s === value);
+  return JOB_STATUS_VALUES.find((s) => s === value);
 }
 
 /**
  * Parse raw search params (from TanStack Router's `validateSearch`) into a
  * strongly-typed query. Missing/invalid fields are dropped silently so deep
  * links never crash the route — an over-strict parser would be a footgun.
+ *
+ * After imperative normalization the result is asserted against
+ * `jobListSearchSchema` to catch any drift between this code and the schema
+ * (e.g. a new filter added to one but not the other).
  */
 export function parseJobListSearch(raw: Record<string, unknown>): JobListQuery {
-  return {
+  const normalized = {
     status: asJobStatus(raw.status),
     queue: asTrimmedString(raw.queue),
     task: asTrimmedString(raw.task),
@@ -44,8 +43,12 @@ export function parseJobListSearch(raw: Record<string, unknown>): JobListQuery {
     createdAfter: asNonNegativeInteger(raw.createdAfter),
     createdBefore: asNonNegativeInteger(raw.createdBefore),
     page: asNonNegativeInteger(raw.page) ?? 0,
-    pageSize: Math.min(Math.max(asNonNegativeInteger(raw.pageSize) ?? DEFAULT_PAGE_SIZE, 10), 200),
+    pageSize: Math.min(
+      Math.max(asNonNegativeInteger(raw.pageSize) ?? DEFAULT_PAGE_SIZE, MIN_PAGE_SIZE),
+      MAX_PAGE_SIZE,
+    ),
   };
+  return v.parse(jobListSearchSchema, normalized);
 }
 
 /**

--- a/dashboard/src/features/logs/hooks.ts
+++ b/dashboard/src/features/logs/hooks.ts
@@ -1,15 +1,18 @@
-import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import { keepPreviousData, queryOptions, useQuery } from "@tanstack/react-query";
 import { useRefreshInterval } from "@/providers";
 import { fetchLogs, type LogsQuery } from "./api";
 
 const KEY = (q: LogsQuery) => ["logs", q.task ?? "", q.level ?? "", q.sinceSeconds, q.limit];
 
-export function useLogs(query: LogsQuery) {
-  const { intervalMs } = useRefreshInterval();
-  return useQuery({
+export function logsListQuery(query: LogsQuery) {
+  return queryOptions({
     queryKey: KEY(query),
     queryFn: ({ signal }) => fetchLogs(query, signal),
     placeholderData: keepPreviousData,
-    refetchInterval: intervalMs,
   });
+}
+
+export function useLogs(query: LogsQuery) {
+  const { intervalMs } = useRefreshInterval();
+  return useQuery({ ...logsListQuery(query), refetchInterval: intervalMs });
 }

--- a/dashboard/src/features/logs/page.tsx
+++ b/dashboard/src/features/logs/page.tsx
@@ -1,39 +1,42 @@
-import { useState } from "react";
+import { getRouteApi } from "@tanstack/react-router";
 import { PageHeader } from "@/components/layout";
 import type { LogLevel } from "./api";
 import { LogFilters, LogStream } from "./components";
 import { useLogs } from "./hooks";
+import { LOGS_DEFAULT_SINCE_SECONDS, LOGS_PAGE_SIZE } from "./search-schema";
 
-const DEFAULT_SINCE_SECONDS = 3_600;
-const PAGE_SIZE = 500;
+const routeApi = getRouteApi("/logs");
 
 /**
  * Logs route body. Default-exported so the route file can lazy-load the
  * entire logs surface (including the virtual list dependency) on demand.
  */
 export default function LogsPage() {
-  const [task, setTask] = useState<string | undefined>(undefined);
-  const [level, setLevel] = useState<LogLevel | undefined>(undefined);
+  const search = routeApi.useSearch();
+  const navigate = routeApi.useNavigate();
+
+  const setFilter = (next: { task?: string; level?: LogLevel }) => {
+    navigate({
+      search: () => ({
+        task: next.task,
+        level: next.level,
+      }),
+      replace: true,
+    });
+  };
 
   const logs = useLogs({
-    task,
-    level,
-    sinceSeconds: DEFAULT_SINCE_SECONDS,
-    limit: PAGE_SIZE,
+    task: search.task,
+    level: search.level,
+    sinceSeconds: LOGS_DEFAULT_SINCE_SECONDS,
+    limit: LOGS_PAGE_SIZE,
   });
 
   return (
     <>
       <PageHeader title="Logs" description="Live-tailing task log stream across all workers." />
       <div className="flex flex-col gap-3">
-        <LogFilters
-          task={task}
-          level={level}
-          onChange={(next) => {
-            setTask(next.task);
-            setLevel(next.level);
-          }}
-        />
+        <LogFilters task={search.task} level={search.level} onChange={setFilter} />
         <LogStream
           logs={logs.data}
           loading={logs.isLoading || (logs.isFetching && !logs.data)}

--- a/dashboard/src/features/logs/search-schema.ts
+++ b/dashboard/src/features/logs/search-schema.ts
@@ -1,0 +1,34 @@
+import * as v from "valibot";
+import { LOG_LEVELS } from "./api";
+
+/**
+ * Default window + page size for the logs feed. Kept here so the route
+ * loader and the page component build identical `LogsQuery` shapes — same
+ * query key, same cache hit.
+ */
+export const LOGS_DEFAULT_SINCE_SECONDS = 3_600;
+export const LOGS_PAGE_SIZE = 500;
+
+/**
+ * Schema for `/logs` URL search params.
+ *
+ * Promotes the previously-local filter state (task, level) to the URL so
+ * filter combinations are shareable and survive refresh. `sinceSeconds` and
+ * `limit` stay non-URL for now — they aren't user-tuned today.
+ */
+export const logsSearchSchema = v.object({
+  task: v.optional(v.string()),
+  level: v.optional(v.picklist(LOG_LEVELS)),
+});
+
+export type LogsSearch = v.InferOutput<typeof logsSearchSchema>;
+
+/**
+ * Normalize raw search-param input into a valid `LogsSearch`. Invalid values
+ * are silently dropped so a hand-typed URL never blanks the page.
+ */
+export function parseLogsSearch(raw: Record<string, unknown>): LogsSearch {
+  const task = typeof raw.task === "string" && raw.task.trim() !== "" ? raw.task.trim() : undefined;
+  const level = LOG_LEVELS.find((l) => l === raw.level);
+  return v.parse(logsSearchSchema, { task, level });
+}

--- a/dashboard/src/features/metrics/hooks.ts
+++ b/dashboard/src/features/metrics/hooks.ts
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { queryOptions, useQuery } from "@tanstack/react-query";
 import { useRefreshInterval } from "@/providers";
 import { fetchMetrics, fetchTimeseries } from "./api";
 import { type TimeRange, timeRangeConfig } from "./types";
@@ -10,22 +10,28 @@ const KEY = {
     ["metrics", "timeseries", task ?? "", range] as const,
 };
 
-export function useMetricsSummary(range: TimeRange, task?: string) {
-  const { intervalMs } = useRefreshInterval();
+export function metricsSummaryQuery(range: TimeRange, task?: string) {
   const { sinceSeconds } = timeRangeConfig(range);
-  return useQuery({
+  return queryOptions({
     queryKey: KEY.summary(task, range),
     queryFn: ({ signal }) => fetchMetrics({ task, sinceSeconds }, signal),
-    refetchInterval: intervalMs,
   });
+}
+
+export function metricsTimeseriesQuery(range: TimeRange, task?: string) {
+  const { sinceSeconds, bucketSeconds } = timeRangeConfig(range);
+  return queryOptions({
+    queryKey: KEY.timeseries(task, range),
+    queryFn: ({ signal }) => fetchTimeseries({ task, sinceSeconds, bucketSeconds }, signal),
+  });
+}
+
+export function useMetricsSummary(range: TimeRange, task?: string) {
+  const { intervalMs } = useRefreshInterval();
+  return useQuery({ ...metricsSummaryQuery(range, task), refetchInterval: intervalMs });
 }
 
 export function useMetricsTimeseries(range: TimeRange, task?: string) {
   const { intervalMs } = useRefreshInterval();
-  const { sinceSeconds, bucketSeconds } = timeRangeConfig(range);
-  return useQuery({
-    queryKey: KEY.timeseries(task, range),
-    queryFn: ({ signal }) => fetchTimeseries({ task, sinceSeconds, bucketSeconds }, signal),
-    refetchInterval: intervalMs,
-  });
+  return useQuery({ ...metricsTimeseriesQuery(range, task), refetchInterval: intervalMs });
 }

--- a/dashboard/src/features/metrics/page.tsx
+++ b/dashboard/src/features/metrics/page.tsx
@@ -1,4 +1,5 @@
-import { useMemo, useState } from "react";
+import { getRouteApi } from "@tanstack/react-router";
+import { useMemo } from "react";
 import { PageHeader } from "@/components/layout";
 import {
   LatencyChart,
@@ -8,18 +9,28 @@ import {
   TimeRangeSelector,
 } from "./components";
 import { useMetricsSummary, useMetricsTimeseries } from "./hooks";
-import { DEFAULT_TIME_RANGE, type TimeRange } from "./types";
+import type { TimeRange } from "./types";
+
+const routeApi = getRouteApi("/metrics");
 
 /**
  * The metrics dashboard.
  *
  * Exported as a default component so the route can dynamically import it
- * and keep Recharts off the main bundle. Time range + task filter live as
- * local state; if they turn out to be shareable we can promote to URL.
+ * and keep Recharts off the main bundle. `range` + `task` are URL-backed so
+ * views (e.g. "send_email, last 24h") are shareable.
  */
 export default function MetricsPage() {
-  const [range, setRange] = useState<TimeRange>(DEFAULT_TIME_RANGE);
-  const [task, setTask] = useState<string | undefined>(undefined);
+  const { range, task } = routeApi.useSearch();
+  const navigate = routeApi.useNavigate();
+
+  const setRange = (next: TimeRange) => {
+    navigate({ search: (prev) => ({ ...prev, range: next }), replace: true });
+  };
+
+  const setTask = (next: string | undefined) => {
+    navigate({ search: (prev) => ({ ...prev, task: next }), replace: true });
+  };
 
   const summary = useMetricsSummary(range, task);
   const series = useMetricsTimeseries(range, task);

--- a/dashboard/src/features/metrics/search-schema.ts
+++ b/dashboard/src/features/metrics/search-schema.ts
@@ -1,0 +1,31 @@
+import * as v from "valibot";
+import { DEFAULT_TIME_RANGE, TIME_RANGES, type TimeRange } from "./types";
+
+const TIME_RANGE_VALUES = TIME_RANGES.map((r) => r.value) as unknown as readonly [
+  TimeRange,
+  ...TimeRange[],
+];
+
+/**
+ * Schema for `/metrics` URL search params.
+ *
+ * Promoting `range` and `task` to the URL so dashboards can be deep-linked
+ * to a specific view (e.g. "send_email, last 24h"). Defaults collapse to
+ * the canonical home state.
+ */
+export const metricsSearchSchema = v.object({
+  range: v.picklist(TIME_RANGE_VALUES),
+  task: v.optional(v.string()),
+});
+
+export type MetricsSearch = v.InferOutput<typeof metricsSearchSchema>;
+
+/**
+ * Normalize raw search-param input into a valid `MetricsSearch`. Unknown
+ * ranges fall back to the default; empty task strings drop to undefined.
+ */
+export function parseMetricsSearch(raw: Record<string, unknown>): MetricsSearch {
+  const range = TIME_RANGE_VALUES.find((r) => r === raw.range) ?? DEFAULT_TIME_RANGE;
+  const task = typeof raw.task === "string" && raw.task.trim() !== "" ? raw.task.trim() : undefined;
+  return v.parse(metricsSearchSchema, { range, task });
+}

--- a/dashboard/src/features/overview/hooks.ts
+++ b/dashboard/src/features/overview/hooks.ts
@@ -1,34 +1,51 @@
-import { useQuery } from "@tanstack/react-query";
+import { queryOptions, useQuery } from "@tanstack/react-query";
 import { useRefreshInterval } from "@/providers";
 import { fetchRecentJobs, fetchStats, fetchThroughput } from "./api";
 
-// Re-export queue hooks so the Overview route can import everything it needs
+// Re-export queue queries so the Overview route can import everything it needs
 // from one module without reaching into a sibling feature directly.
-export { usePausedQueues, useQueueStats } from "../queues/hooks";
+export {
+  pausedQueuesQuery,
+  queueStatsQuery,
+  usePausedQueues,
+  useQueueStats,
+} from "../queues/hooks";
+
+export function statsQuery() {
+  return queryOptions({
+    queryKey: ["stats"],
+    queryFn: ({ signal }) => fetchStats(signal),
+  });
+}
+
+export function recentJobsQuery(limit = 10) {
+  return queryOptions({
+    queryKey: ["jobs", "recent", limit],
+    queryFn: ({ signal }) => fetchRecentJobs(limit, signal),
+  });
+}
+
+export function throughputQuery(bucketSeconds = 60, sinceSeconds = 3600) {
+  return queryOptions({
+    queryKey: ["metrics", "throughput", bucketSeconds, sinceSeconds],
+    queryFn: ({ signal }) => fetchThroughput(bucketSeconds, sinceSeconds, signal),
+  });
+}
 
 export function useStats() {
   const { intervalMs } = useRefreshInterval();
-  return useQuery({
-    queryKey: ["stats"],
-    queryFn: ({ signal }) => fetchStats(signal),
-    refetchInterval: intervalMs,
-  });
+  return useQuery({ ...statsQuery(), refetchInterval: intervalMs });
 }
 
 export function useRecentJobs(limit = 10) {
   const { intervalMs } = useRefreshInterval();
-  return useQuery({
-    queryKey: ["jobs", "recent", limit],
-    queryFn: ({ signal }) => fetchRecentJobs(limit, signal),
-    refetchInterval: intervalMs,
-  });
+  return useQuery({ ...recentJobsQuery(limit), refetchInterval: intervalMs });
 }
 
 export function useThroughput(bucketSeconds = 60, sinceSeconds = 3600) {
   const { intervalMs } = useRefreshInterval();
   return useQuery({
-    queryKey: ["metrics", "throughput", bucketSeconds, sinceSeconds],
-    queryFn: ({ signal }) => fetchThroughput(bucketSeconds, sinceSeconds, signal),
+    ...throughputQuery(bucketSeconds, sinceSeconds),
     refetchInterval: intervalMs,
   });
 }

--- a/dashboard/src/features/queues/hooks.ts
+++ b/dashboard/src/features/queues/hooks.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { queryOptions, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { useRefreshInterval } from "@/providers";
 import { fetchPausedQueues, fetchQueueStats, pauseQueue, resumeQueue } from "./api";
@@ -9,22 +9,28 @@ const KEY = {
   all: ["queues"] as const,
 };
 
-export function useQueueStats() {
-  const { intervalMs } = useRefreshInterval();
-  return useQuery({
+export function queueStatsQuery() {
+  return queryOptions({
     queryKey: KEY.stats,
     queryFn: ({ signal }) => fetchQueueStats(signal),
-    refetchInterval: intervalMs,
   });
+}
+
+export function pausedQueuesQuery() {
+  return queryOptions({
+    queryKey: KEY.paused,
+    queryFn: ({ signal }) => fetchPausedQueues(signal),
+  });
+}
+
+export function useQueueStats() {
+  const { intervalMs } = useRefreshInterval();
+  return useQuery({ ...queueStatsQuery(), refetchInterval: intervalMs });
 }
 
 export function usePausedQueues() {
   const { intervalMs } = useRefreshInterval();
-  return useQuery({
-    queryKey: KEY.paused,
-    queryFn: ({ signal }) => fetchPausedQueues(signal),
-    refetchInterval: intervalMs,
-  });
+  return useQuery({ ...pausedQueuesQuery(), refetchInterval: intervalMs });
 }
 
 interface OptimisticContext {

--- a/dashboard/src/features/resources/hooks.ts
+++ b/dashboard/src/features/resources/hooks.ts
@@ -1,12 +1,15 @@
-import { useQuery } from "@tanstack/react-query";
+import { queryOptions, useQuery } from "@tanstack/react-query";
 import { useRefreshInterval } from "@/providers";
 import { fetchResources } from "./api";
 
-export function useResources() {
-  const { intervalMs } = useRefreshInterval();
-  return useQuery({
+export function resourcesQuery() {
+  return queryOptions({
     queryKey: ["resources"],
     queryFn: ({ signal }) => fetchResources(signal),
-    refetchInterval: intervalMs,
   });
+}
+
+export function useResources() {
+  const { intervalMs } = useRefreshInterval();
+  return useQuery({ ...resourcesQuery(), refetchInterval: intervalMs });
 }

--- a/dashboard/src/features/system/hooks.ts
+++ b/dashboard/src/features/system/hooks.ts
@@ -1,21 +1,27 @@
-import { useQuery } from "@tanstack/react-query";
+import { queryOptions, useQuery } from "@tanstack/react-query";
 import { useRefreshInterval } from "@/providers";
 import { fetchInterceptionStats, fetchProxyStats } from "./api";
 
-export function useProxyStats() {
-  const { intervalMs } = useRefreshInterval();
-  return useQuery({
+export function proxyStatsQuery() {
+  return queryOptions({
     queryKey: ["system", "proxy-stats"],
     queryFn: ({ signal }) => fetchProxyStats(signal),
-    refetchInterval: intervalMs,
   });
+}
+
+export function interceptionStatsQuery() {
+  return queryOptions({
+    queryKey: ["system", "interception-stats"],
+    queryFn: ({ signal }) => fetchInterceptionStats(signal),
+  });
+}
+
+export function useProxyStats() {
+  const { intervalMs } = useRefreshInterval();
+  return useQuery({ ...proxyStatsQuery(), refetchInterval: intervalMs });
 }
 
 export function useInterceptionStats() {
   const { intervalMs } = useRefreshInterval();
-  return useQuery({
-    queryKey: ["system", "interception-stats"],
-    queryFn: ({ signal }) => fetchInterceptionStats(signal),
-    refetchInterval: intervalMs,
-  });
+  return useQuery({ ...interceptionStatsQuery(), refetchInterval: intervalMs });
 }

--- a/dashboard/src/features/workers/hooks.ts
+++ b/dashboard/src/features/workers/hooks.ts
@@ -1,12 +1,15 @@
-import { useQuery } from "@tanstack/react-query";
+import { queryOptions, useQuery } from "@tanstack/react-query";
 import { useRefreshInterval } from "@/providers";
 import { fetchWorkers } from "./api";
 
-export function useWorkers() {
-  const { intervalMs } = useRefreshInterval();
-  return useQuery({
+export function workersQuery() {
+  return queryOptions({
     queryKey: ["workers"],
     queryFn: ({ signal }) => fetchWorkers(signal),
-    refetchInterval: intervalMs,
   });
+}
+
+export function useWorkers() {
+  const { intervalMs } = useRefreshInterval();
+  return useQuery({ ...workersQuery(), refetchInterval: intervalMs });
 }

--- a/dashboard/src/lib/errors.ts
+++ b/dashboard/src/lib/errors.ts
@@ -1,0 +1,32 @@
+import { ApiError } from "./api-client";
+
+/**
+ * Did this error come from the network being unreachable (DNS failure,
+ * connection refused, CORS preflight blocked) rather than a well-formed
+ * HTTP response? `fetch` throws a `TypeError` in these cases.
+ */
+export function isNetworkError(error: unknown): boolean {
+  if (error instanceof TypeError) {
+    // Chrome: "Failed to fetch", Firefox: "NetworkError when attempting to fetch resource",
+    // Safari: "Load failed". Match loosely — all mean the same thing: no response.
+    return /fetch|network|load failed/i.test(error.message);
+  }
+  return false;
+}
+
+/**
+ * HTTP status codes that typically mean the server is running but cannot
+ * serve the request right now (restart in progress, upstream timeout,
+ * explicit 503). Surface these with the same "backend unreachable" page.
+ */
+export function isServerUnavailable(error: unknown): boolean {
+  if (!(error instanceof ApiError)) return false;
+  return error.status === 502 || error.status === 503 || error.status === 504;
+}
+
+/**
+ * Treat the error as a connection problem (vs. a routing or data error).
+ */
+export function isBackendUnreachable(error: unknown): boolean {
+  return isNetworkError(error) || isServerUnavailable(error);
+}

--- a/dashboard/src/lib/query-client.ts
+++ b/dashboard/src/lib/query-client.ts
@@ -1,0 +1,28 @@
+import { QueryClient } from "@tanstack/react-query";
+
+/**
+ * Factory for the app-wide {@link QueryClient}.
+ *
+ * Call once at bootstrap — both the React tree (via `QueryProvider`) and the
+ * router context (for `route.loader` → `ensureQueryData`) must share the same
+ * instance so loader-primed caches are visible to in-component `useQuery`.
+ */
+export function createQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 5_000,
+        gcTime: 5 * 60_000,
+        refetchOnWindowFocus: true,
+        retry: (failureCount, error) => {
+          const status = (error as { status?: number }).status;
+          if (status && status >= 400 && status < 500) return false;
+          return failureCount < 2;
+        },
+      },
+      mutations: {
+        retry: false,
+      },
+    },
+  });
+}

--- a/dashboard/src/main.tsx
+++ b/dashboard/src/main.tsx
@@ -1,13 +1,17 @@
 import { createRouter, RouterProvider } from "@tanstack/react-router";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import { createQueryClient } from "@/lib/query-client";
 import { Providers } from "@/providers";
 import { routeTree } from "./routeTree.gen";
 import "./globals.css";
 
+const queryClient = createQueryClient();
+
 const router = createRouter({
   routeTree,
   defaultPreload: "intent",
+  context: { queryClient },
 });
 
 declare module "@tanstack/react-router" {
@@ -21,7 +25,7 @@ if (!rootEl) throw new Error("#app element not found");
 
 createRoot(rootEl).render(
   <StrictMode>
-    <Providers>
+    <Providers queryClient={queryClient}>
       <RouterProvider router={router} />
     </Providers>
   </StrictMode>,

--- a/dashboard/src/providers/index.tsx
+++ b/dashboard/src/providers/index.tsx
@@ -1,3 +1,4 @@
+import type { QueryClient } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 import { Toaster } from "@/components/ui/toaster";
 import { CommandPaletteProvider } from "./command-palette-provider";
@@ -5,10 +6,16 @@ import { QueryProvider } from "./query-provider";
 import { RefreshIntervalProvider } from "./refresh-interval-provider";
 import { ThemeProvider } from "./theme-provider";
 
-export function Providers({ children }: { children: ReactNode }) {
+export function Providers({
+  queryClient,
+  children,
+}: {
+  queryClient: QueryClient;
+  children: ReactNode;
+}) {
   return (
     <ThemeProvider>
-      <QueryProvider>
+      <QueryProvider client={queryClient}>
         <RefreshIntervalProvider>
           <CommandPaletteProvider>
             {children}

--- a/dashboard/src/providers/query-provider.tsx
+++ b/dashboard/src/providers/query-provider.tsx
@@ -1,29 +1,8 @@
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { type QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
-import { type ReactNode, useState } from "react";
+import type { ReactNode } from "react";
 
-function createQueryClient() {
-  return new QueryClient({
-    defaultOptions: {
-      queries: {
-        staleTime: 5_000,
-        gcTime: 5 * 60_000,
-        refetchOnWindowFocus: true,
-        retry: (failureCount, error) => {
-          const status = (error as { status?: number }).status;
-          if (status && status >= 400 && status < 500) return false;
-          return failureCount < 2;
-        },
-      },
-      mutations: {
-        retry: false,
-      },
-    },
-  });
-}
-
-export function QueryProvider({ children }: { children: ReactNode }) {
-  const [client] = useState(createQueryClient);
+export function QueryProvider({ client, children }: { client: QueryClient; children: ReactNode }) {
   return (
     <QueryClientProvider client={client}>
       {children}

--- a/dashboard/src/routes/__root.tsx
+++ b/dashboard/src/routes/__root.tsx
@@ -1,10 +1,16 @@
-import { createRootRoute, Link, Outlet } from "@tanstack/react-router";
+import type { QueryClient } from "@tanstack/react-query";
+import { createRootRouteWithContext, Link, Outlet } from "@tanstack/react-router";
 import { AlertTriangle, ArrowLeft, Home } from "lucide-react";
-import { AppShell } from "@/components/layout";
+import { AppShell, BackendOffline } from "@/components/layout";
 import { Button, buttonVariants } from "@/components/ui";
 import { cn } from "@/lib/cn";
+import { isBackendUnreachable } from "@/lib/errors";
 
-export const Route = createRootRoute({
+export interface RouterContext {
+  queryClient: QueryClient;
+}
+
+export const Route = createRootRouteWithContext<RouterContext>()({
   component: RootLayout,
   errorComponent: ErrorView,
   notFoundComponent: NotFoundView,
@@ -18,7 +24,21 @@ function RootLayout() {
   );
 }
 
+/**
+ * Top-level error boundary for loader failures and uncaught render errors.
+ *
+ * Network/5xx failures get a dedicated "backend unreachable" page with
+ * actionable steps. Everything else falls through to the generic error
+ * view — usually a programming bug the user can't fix on their own.
+ */
 function ErrorView({ error }: { error: Error }) {
+  if (isBackendUnreachable(error)) {
+    return (
+      <AppShell>
+        <BackendOffline error={error} />
+      </AppShell>
+    );
+  }
   return (
     <AppShell>
       <div className="grid min-h-[50vh] place-items-center">

--- a/dashboard/src/routes/circuit-breakers.tsx
+++ b/dashboard/src/routes/circuit-breakers.tsx
@@ -1,8 +1,13 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { PageHeader } from "@/components/layout";
-import { CircuitBreakersTable, useCircuitBreakers } from "@/features/circuit-breakers";
+import {
+  CircuitBreakersTable,
+  circuitBreakersQuery,
+  useCircuitBreakers,
+} from "@/features/circuit-breakers";
 
 export const Route = createFileRoute("/circuit-breakers")({
+  loader: ({ context: { queryClient } }) => queryClient.ensureQueryData(circuitBreakersQuery()),
   component: CircuitBreakersPage,
 });
 

--- a/dashboard/src/routes/dead-letters.tsx
+++ b/dashboard/src/routes/dead-letters.tsx
@@ -6,6 +6,7 @@ import { Button, DestructiveConfirmDialog, Pagination } from "@/components/ui";
 import {
   DeadLetterList,
   type DeadLetterView,
+  deadLettersQuery,
   useDeadLetters,
   usePurgeDeadLetters,
 } from "@/features/dead-letters";
@@ -14,6 +15,8 @@ import { cn } from "@/lib/cn";
 const PAGE_SIZE = 25;
 
 export const Route = createFileRoute("/dead-letters")({
+  loader: ({ context: { queryClient } }) =>
+    queryClient.ensureQueryData(deadLettersQuery(0, PAGE_SIZE)),
   component: DeadLettersPage,
 });
 

--- a/dashboard/src/routes/index.tsx
+++ b/dashboard/src/routes/index.tsx
@@ -1,10 +1,15 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { PageHeader } from "@/components/layout";
 import {
+  pausedQueuesQuery,
   QueueBreakdown,
+  queueStatsQuery,
   RecentJobs,
+  recentJobsQuery,
   StatsGrid,
+  statsQuery,
   ThroughputSparkline,
+  throughputQuery,
   usePausedQueues,
   useQueueStats,
   useRecentJobs,
@@ -13,6 +18,14 @@ import {
 } from "@/features/overview";
 
 export const Route = createFileRoute("/")({
+  loader: ({ context: { queryClient } }) =>
+    Promise.all([
+      queryClient.ensureQueryData(statsQuery()),
+      queryClient.ensureQueryData(queueStatsQuery()),
+      queryClient.ensureQueryData(pausedQueuesQuery()),
+      queryClient.ensureQueryData(recentJobsQuery(10)),
+      queryClient.ensureQueryData(throughputQuery(60, 3600)),
+    ]),
   component: OverviewPage,
 });
 

--- a/dashboard/src/routes/jobs/$id.tsx
+++ b/dashboard/src/routes/jobs/$id.tsx
@@ -16,6 +16,7 @@ import {
   JobLogsTab,
   JobOverviewTab,
   JobReplayTab,
+  jobDetailQuery,
   useJob,
   useJobDag,
   useJobErrors,
@@ -25,6 +26,8 @@ import {
 import { JOB_STATUS_LABEL, JOB_STATUS_TONE } from "@/lib/status";
 
 export const Route = createFileRoute("/jobs/$id")({
+  loader: ({ context: { queryClient }, params: { id } }) =>
+    queryClient.ensureQueryData(jobDetailQuery(id)),
   component: JobDetailPage,
 });
 

--- a/dashboard/src/routes/jobs/index.tsx
+++ b/dashboard/src/routes/jobs/index.tsx
@@ -1,23 +1,26 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { PageHeader } from "@/components/layout";
 import { Pagination } from "@/components/ui";
-import { JobFiltersBar, JobSearchBar, JobTable, useJobs } from "@/features/jobs";
+import { JobFiltersBar, JobSearchBar, JobTable, jobsListQuery, useJobs } from "@/features/jobs";
 import type { JobFilters, JobListQuery } from "@/features/jobs/types";
 import { parseJobListSearch } from "@/features/jobs/utils";
 
 export const Route = createFileRoute("/jobs/")({
+  validateSearch: (search): JobListQuery => parseJobListSearch(search),
+  loaderDeps: ({ search }) => ({ search }),
+  loader: ({ context: { queryClient }, deps: { search } }) =>
+    queryClient.ensureQueryData(jobsListQuery(search)),
   component: JobsListPage,
-  validateSearch: (search) => parseJobListSearch(search),
 });
 
 function JobsListPage() {
-  const search = Route.useSearch() as JobListQuery;
+  const search = Route.useSearch();
   const navigate = Route.useNavigate();
 
   const updateFilters = (filters: JobFilters) => {
     navigate({
       search: (prev) => ({
-        ...(prev as JobListQuery),
+        ...prev,
         ...filters,
         // Reset to first page whenever filters change
         page: 0,
@@ -27,7 +30,7 @@ function JobsListPage() {
   };
 
   const setPage = (page: number) => {
-    navigate({ search: (prev) => ({ ...(prev as JobListQuery), page }) });
+    navigate({ search: (prev) => ({ ...prev, page }) });
   };
 
   const jobs = useJobs(search);

--- a/dashboard/src/routes/jobs/index.tsx
+++ b/dashboard/src/routes/jobs/index.tsx
@@ -1,8 +1,15 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { PageHeader } from "@/components/layout";
 import { Pagination } from "@/components/ui";
-import { JobFiltersBar, JobSearchBar, JobTable, jobsListQuery, useJobs } from "@/features/jobs";
-import type { JobFilters, JobListQuery } from "@/features/jobs/types";
+import {
+  type JobFilters,
+  JobFiltersBar,
+  type JobListQuery,
+  JobSearchBar,
+  JobTable,
+  jobsListQuery,
+  useJobs,
+} from "@/features/jobs";
 import { parseJobListSearch } from "@/features/jobs/utils";
 
 export const Route = createFileRoute("/jobs/")({

--- a/dashboard/src/routes/logs.tsx
+++ b/dashboard/src/routes/logs.tsx
@@ -1,5 +1,26 @@
 import { createFileRoute } from "@tanstack/react-router";
+// Import query helpers from the hooks module directly (not the feature
+// barrel) so the non-lazy route file doesn't drag the virtualized log
+// components into the main bundle.
+import { logsListQuery } from "@/features/logs/hooks";
+import {
+  LOGS_DEFAULT_SINCE_SECONDS,
+  LOGS_PAGE_SIZE,
+  parseLogsSearch,
+} from "@/features/logs/search-schema";
 
 // Lazy route: the virtual-list + log stream load only on demand. See
 // `logs.lazy.tsx` for the actual component.
-export const Route = createFileRoute("/logs")({});
+export const Route = createFileRoute("/logs")({
+  validateSearch: parseLogsSearch,
+  loaderDeps: ({ search }) => ({ search }),
+  loader: ({ context: { queryClient }, deps: { search } }) =>
+    queryClient.ensureQueryData(
+      logsListQuery({
+        task: search.task,
+        level: search.level,
+        sinceSeconds: LOGS_DEFAULT_SINCE_SECONDS,
+        limit: LOGS_PAGE_SIZE,
+      }),
+    ),
+});

--- a/dashboard/src/routes/metrics.tsx
+++ b/dashboard/src/routes/metrics.tsx
@@ -1,6 +1,19 @@
 import { createFileRoute } from "@tanstack/react-router";
+// Import query helpers from the hooks module directly (not the feature
+// barrel) so the non-lazy route file doesn't drag Recharts into the main
+// bundle.
+import { metricsSummaryQuery, metricsTimeseriesQuery } from "@/features/metrics/hooks";
+import { parseMetricsSearch } from "@/features/metrics/search-schema";
 
 // Component lives in the `.lazy.tsx` counterpart so Recharts only loads when
 // the user actually opens the metrics screen. Keeping this file
-// component-less makes TanStack's lazy-route convention kick in.
-export const Route = createFileRoute("/metrics")({});
+// component-less lets TanStack's lazy-route convention kick in.
+export const Route = createFileRoute("/metrics")({
+  validateSearch: parseMetricsSearch,
+  loaderDeps: ({ search }) => ({ search }),
+  loader: ({ context: { queryClient }, deps: { search } }) =>
+    Promise.all([
+      queryClient.ensureQueryData(metricsSummaryQuery(search.range, search.task)),
+      queryClient.ensureQueryData(metricsTimeseriesQuery(search.range, search.task)),
+    ]),
+});

--- a/dashboard/src/routes/queues.tsx
+++ b/dashboard/src/routes/queues.tsx
@@ -1,8 +1,19 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { PageHeader } from "@/components/layout";
-import { QueuesTable, usePausedQueues, useQueueStats } from "@/features/queues";
+import {
+  pausedQueuesQuery,
+  QueuesTable,
+  queueStatsQuery,
+  usePausedQueues,
+  useQueueStats,
+} from "@/features/queues";
 
 export const Route = createFileRoute("/queues")({
+  loader: ({ context: { queryClient } }) =>
+    Promise.all([
+      queryClient.ensureQueryData(queueStatsQuery()),
+      queryClient.ensureQueryData(pausedQueuesQuery()),
+    ]),
   component: QueuesPage,
 });
 

--- a/dashboard/src/routes/resources.tsx
+++ b/dashboard/src/routes/resources.tsx
@@ -1,8 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { PageHeader } from "@/components/layout";
-import { ResourcesTable, useResources } from "@/features/resources";
+import { ResourcesTable, resourcesQuery, useResources } from "@/features/resources";
 
 export const Route = createFileRoute("/resources")({
+  loader: ({ context: { queryClient } }) => queryClient.ensureQueryData(resourcesQuery()),
   component: ResourcesPage,
 });
 

--- a/dashboard/src/routes/system.tsx
+++ b/dashboard/src/routes/system.tsx
@@ -2,12 +2,19 @@ import { createFileRoute } from "@tanstack/react-router";
 import { PageHeader } from "@/components/layout";
 import {
   InterceptionTable,
+  interceptionStatsQuery,
   ProxyTable,
+  proxyStatsQuery,
   useInterceptionStats,
   useProxyStats,
 } from "@/features/system";
 
 export const Route = createFileRoute("/system")({
+  loader: ({ context: { queryClient } }) =>
+    Promise.all([
+      queryClient.ensureQueryData(proxyStatsQuery()),
+      queryClient.ensureQueryData(interceptionStatsQuery()),
+    ]),
   component: SystemPage,
 });
 

--- a/dashboard/src/routes/workers.tsx
+++ b/dashboard/src/routes/workers.tsx
@@ -1,9 +1,10 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { PageHeader } from "@/components/layout";
-import { useWorkers, WorkersTable } from "@/features/workers";
+import { useWorkers, WorkersTable, workersQuery } from "@/features/workers";
 import { formatCount } from "@/lib/number";
 
 export const Route = createFileRoute("/workers")({
+  loader: ({ context: { queryClient } }) => queryClient.ensureQueryData(workersQuery()),
   component: WorkersPage,
 });
 

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -3,8 +3,48 @@ import { tanstackRouter } from "@tanstack/router-plugin/vite";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
+import type { ProxyOptions } from "vite";
 
 const backend = "http://127.0.0.1:8080";
+
+/**
+ * Vite's default proxy error handler logs a full stack trace per failed
+ * request. The dashboard polls ~6 endpoints every 5s, so an offline
+ * backend would fill the terminal with noise within seconds. We replace
+ * the default handler with a throttled one (a single warning every 30s)
+ * that still returns a 503 to the browser so `BackendOffline` triggers.
+ *
+ * `lastLogAt` is shared across every proxy entry (one warning total, not
+ * one-per-path).
+ */
+let lastProxyErrorAt = 0;
+const PROXY_LOG_THROTTLE_MS = 30_000;
+
+const quietProxy = (target: string): ProxyOptions => ({
+  target,
+  changeOrigin: false,
+  configure: (proxy) => {
+    proxy.removeAllListeners("error");
+    proxy.on("error", (err, _req, res) => {
+      const now = Date.now();
+      if (now - lastProxyErrorAt > PROXY_LOG_THROTTLE_MS) {
+        lastProxyErrorAt = now;
+        const code = (err as NodeJS.ErrnoException).code ?? err.message;
+        console.warn(
+          `[vite] taskito backend offline (${code}). Start it with: ` +
+            `'taskito dashboard --app myapp:queue'. Further proxy errors suppressed for 30s.`,
+        );
+      }
+      // Mimic the original handler: respond with a 5xx so the browser
+      // sees a real error, then the dashboard's BackendOffline page kicks
+      // in. Guard against the response being already-written.
+      if (res && "writeHead" in res && !res.headersSent) {
+        res.writeHead(503, { "content-type": "application/json" });
+        res.end('{"error":"backend offline"}');
+      }
+    });
+  },
+});
 
 export default defineConfig({
   plugins: [
@@ -31,10 +71,10 @@ export default defineConfig({
   },
   server: {
     proxy: {
-      "/api": backend,
-      "/health": backend,
-      "/readiness": backend,
-      "/metrics": backend,
+      "/api": quietProxy(backend),
+      "/health": quietProxy(backend),
+      "/readiness": quietProxy(backend),
+      "/metrics": quietProxy(backend),
     },
   },
 });

--- a/docs/api/queue/workers.md
+++ b/docs/api/queue/workers.md
@@ -61,10 +61,12 @@ Async version of `workers()`.
 await queue.arun_worker(
     queues: Sequence[str] | None = None,
     tags: list[str] | None = None,
+    pool: str = "thread",
+    app: str | None = None,
 ) -> None
 ```
 
-Async version of `run_worker()`. Runs the worker in a thread pool without blocking the event loop.
+Async version of `run_worker()`. Runs the blocking worker loop in a thread executor so it does not block the asyncio event loop. Accepts the same `pool` and `app` kwargs as the sync variant (`app` is required when `pool="prefork"`).
 
 ## Circuit Breakers
 

--- a/docs/guide/observability/dashboard.md
+++ b/docs/guide/observability/dashboard.md
@@ -49,15 +49,17 @@ taskito dashboard --app myapp:queue --host 0.0.0.0 --port 9000
 
 ## Dashboard Features
 
-The dashboard is built with Preact, Tailwind CSS, and TypeScript, compiled into a single self-contained HTML file.
+The dashboard is a React + Vite + TypeScript SPA routed via TanStack Router, styled with Tailwind v4 and shadcn/ui, and shipped as hash-busted multi-file assets under `py_src/taskito/static/dashboard/`.
 
 ### Design
 
-- **Dark and light mode** -- Toggle between themes via the sun/moon button in the header. Preference is stored in `localStorage` and persists across sessions.
-- **Auto-refresh** -- Configurable refresh interval (2s, 5s, 10s, or off) via the header dropdown. All pages auto-refresh at the selected interval.
+- **Dark and light mode** -- Toggle between themes via the sun/moon button in the header. Preference is stored in `localStorage` and follows the system scheme by default.
+- **Auto-refresh** -- Configurable refresh interval (2s, 5s, 10s, or off) via the header dropdown. All pages auto-refresh at the selected interval; TanStack Query handles caching and background revalidation.
+- **Command palette** -- `⌘K` / `Ctrl+K` opens a cmdk palette for route navigation and common actions.
 - **Icons** -- Lucide icons throughout for visual clarity — every nav item, stat card, and action button has a meaningful icon.
-- **Toast notifications** -- Every action (cancel, retry, replay, pause, resume, purge) shows a success or error toast in the bottom-right corner. Toasts auto-dismiss after 3 seconds.
-- **Loading states** -- Spinners while data loads, skeleton screens for tables and cards.
+- **Toast notifications** -- Every action (cancel, retry, replay, pause, resume, purge) shows a success or error toast via sonner. Optimistic mutations update the UI immediately and roll back on error.
+- **Destructive confirms** -- Irreversible actions (purge, retry all) use a type-to-confirm dialog.
+- **Loading states** -- Skeleton screens for tables and cards, error boundaries with retry.
 - **Responsive layout** -- Sidebar navigation with grouped sections (Monitoring, Infrastructure, Advanced). The main content area scrolls independently.
 
 ### Pages
@@ -76,8 +78,8 @@ The dashboard is built with Preact, Tailwind CSS, and TypeScript, compiled into 
 | **Dead Letters** | Failed jobs that exhausted retries -- retry individual entries or purge all |
 | **System** | Proxy reconstruction and interception strategy metrics |
 
-!!! info "Zero extra dependencies"
-    The SPA is embedded directly in the Python package. No Node.js, no pnpm, no CDN -- just `pip install taskito`. Node.js is only needed by contributors who modify the dashboard source.
+!!! info "Zero extra dependencies at runtime"
+    The built SPA ships inside the Python wheel under `py_src/taskito/static/dashboard/` and is served by the Python dashboard process. No Node.js, no pnpm, no CDN at runtime -- just `pip install taskito`. Node.js and pnpm are only needed by contributors rebuilding the dashboard source in `dashboard/`.
 
 ## Tutorial
 


### PR DESCRIPTION
## Summary

Completes the dashboard rewrite cycle with route-level loaders, typed URL search schemas, quieter dev ergonomics, and import cleanup. Also adds a stale-PR automation workflow.

### Dashboard

- **Typed URL search params (valibot)** — `jobListSearchSchema`, `logsSearchSchema`, `metricsSearchSchema` back each route's `validateSearch`; `JobListQuery` / `JobFilters` are inferred from the schema so the runtime validator and compile-time type stay in lock-step. `parseJobListSearch` keeps silent-drop semantics so a malformed deep link doesn't blank the page.
- **Query-client context + backend-offline shell** — `queryClient` is plumbed through `RouterProvider` context; `BackendOffline` error page renders when the app detects the backend is unreachable (`isBackendUnreachable` helper in `lib/errors.ts`).
- **TanStack route loaders** — new `*Query` / `queryOptions` factories on every feature's `hooks.ts`. Routes prefetch via `queryClient.ensureQueryData(...)` so navigation lands on warm data and eliminates the post-navigation fetch waterfall. `useJobs` / `useJob` / etc. now spread the factory and layer on `refetchInterval`.
- **Quiet vite proxy** — replaces vite's default proxy error handler with a throttled one (one warning per 30 s, shared across proxy entries). An offline backend no longer floods the dev terminal, while the response is still `503` so `BackendOffline` triggers.
- **Barrel-import consistency** — layout files (`command-palette`, `refresh-control`, `theme-toggle`, `header`, `app-shell`, `mobile-menu`, `route-error-boundary`) now use `@/providers` and `@/components/ui` barrels to match the pattern used in routes. `providers/index.tsx` and `components/ui/toaster.tsx` keep their direct imports to avoid a `providers ↔ toaster` cycle; `routes/logs.tsx` and `routes/metrics.tsx` keep theirs per inline comments (bundle-splitting: the non-lazy routes must not pull Recharts or virtualized-log components into the main chunk).

### Docs

- Observability dashboard guide rewritten to describe the React + Vite + TanStack stack and the bundled-asset delivery model (`py_src/taskito/static/dashboard/`).
- `arun_worker` now documents the `pool` and `app` kwargs.

### CI

- `.github/workflows/stale.yml` marks PRs inactive for 7 days as `stale`, closes them after 3 more days (10 total), and posts a closing comment. Daily cron at 02:00 UTC, manual dispatch supported. Exempts `pinned` / `security` / `work-in-progress`. Issues opt-out.

## Test plan

- [x] `pnpm run typecheck` (dashboard): 153 files, clean
- [x] `pnpm exec biome check src/`: clean
- [x] `pnpm run test --run`: 34/34 passing
- [ ] Manual: start `taskito dashboard --app ...:queue` and confirm Jobs/Logs/Metrics/Queues/Workers/Resources/System/Dead-Letters/Circuit-Breakers/Overview render with loader-prefetched data
- [ ] Manual: deep-link to `/jobs?task=foo&page=2&pageSize=50` and confirm filters + pagination survive reload; deep-link with invalid params and confirm silent drop
- [ ] Manual: stop the backend, confirm `BackendOffline` renders and the vite dev terminal shows a single throttled warning (not a stack trace flood)
- [ ] Manual (post-merge): confirm the stale workflow's next cron run completes successfully