### PR TITLE
fix: correct __version__ fallback to 0.11.1

### DIFF
--- a/py_src/taskito/__init__.py
+++ b/py_src/taskito/__init__.py
@@ -99,4 +99,4 @@ try:
 
     __version__ = _get_version("taskito")
 except PackageNotFoundError:
-    __version__ = "0.10.0"
+    __version__ = "0.11.1"


### PR DESCRIPTION
## Summary

The `PackageNotFoundError` fallback in `py_src/taskito/__init__.py:102` was left at `"0.10.0"` across the 0.11.0 and 0.11.1 release bumps. This PR corrects it to `"0.11.1"` to match `pyproject.toml`.

This only surfaces when taskito is imported from a source checkout without an installed wheel (e.g. an editable install that has not yet been built via `uv run maturin develop`), so users on a published wheel are unaffected.

## Background

Caught during the audit residue sweep (audit-summary-2026-04-23.md, Section H — memory/skills + version drift). All other Section H items are documentation/memory files outside the repo's tracked tree (`.claude/` and `CLAUDE.md` are gitignored), so this one-line correction is the only change that lands in git history.

## Test plan

- [ ] `uv run python -m pytest tests/python/ -v` continues to pass
- [ ] In a fresh source checkout without an installed wheel, `python -c "import taskito; print(taskito.__version__)"` reports `0.11.1`