### PR TITLE
chore: audit P2 cleanup pass (storage DRY + canvas docs)

### DIFF
--- a/crates/taskito-core/src/storage/mod.rs
+++ b/crates/taskito-core/src/storage/mod.rs
@@ -13,6 +13,14 @@ pub use traits::Storage;
 use crate::error::Result;
 use crate::job::{Job, NewJob};
 
+// ── Shared constants ───────────────────────────────────────────────────
+
+/// Maximum gap between worker heartbeats before a worker is considered dead.
+///
+/// Used by every backend's `reap_dead_workers()` to compute the `now - 30s`
+/// cutoff. Kept in one place so SQLite, Postgres, and Redis can never drift.
+pub const DEAD_WORKER_THRESHOLD_MS: i64 = 30_000;
+
 // ── Shared helper types ────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Default)]

--- a/crates/taskito-core/src/storage/postgres/workers.rs
+++ b/crates/taskito-core/src/storage/postgres/workers.rs
@@ -2,12 +2,10 @@ use diesel::prelude::*;
 
 use super::super::models::*;
 use super::super::schema::{execution_claims, workers};
+use super::super::DEAD_WORKER_THRESHOLD_MS;
 use super::PostgresStorage;
 use crate::error::Result;
 use crate::job::now_millis;
-
-/// Dead worker threshold: 30 seconds without heartbeat.
-const DEAD_WORKER_THRESHOLD_MS: i64 = 30_000;
 
 impl PostgresStorage {
     /// Register a new worker or update an existing one.

--- a/crates/taskito-core/src/storage/redis_backend/jobs.rs
+++ b/crates/taskito-core/src/storage/redis_backend/jobs.rs
@@ -14,32 +14,43 @@ fn dequeue_score(priority: i32, scheduled_at: i64) -> f64 {
 }
 
 impl RedisStorage {
+    /// Validate that each `dep_id` references a job that exists and isn't
+    /// in `Dead` / `Cancelled` state.
+    ///
+    /// `skip` short-circuits intra-batch dependencies for `enqueue_batch`,
+    /// where some dep ids point at jobs being created in the same call.
+    fn validate_dep_ids(
+        &self,
+        conn: &mut redis::Connection,
+        dep_ids: &[String],
+        skip: Option<&std::collections::HashSet<&str>>,
+    ) -> Result<()> {
+        const DEP_MISSING: &str = "dependency not found or already dead/cancelled";
+        for dep_id in dep_ids {
+            if skip.is_some_and(|s| s.contains(dep_id.as_str())) {
+                continue;
+            }
+            let dep_key = self.key(&["job", dep_id]);
+            let data: Option<String> = conn.get(&dep_key).map_err(map_err)?;
+            let dep_job: Job = match data {
+                None => return Err(QueueError::DependencyNotFound(DEP_MISSING.to_string())),
+                Some(d) => {
+                    serde_json::from_str(&d).map_err(|e| QueueError::Other(e.to_string()))?
+                }
+            };
+            if dep_job.status == JobStatus::Dead || dep_job.status == JobStatus::Cancelled {
+                return Err(QueueError::DependencyNotFound(DEP_MISSING.to_string()));
+            }
+        }
+        Ok(())
+    }
+
     pub fn enqueue(&self, new_job: NewJob) -> Result<Job> {
         let depends_on = new_job.depends_on.clone();
         let job = new_job.into_job();
         let mut conn = self.conn()?;
 
-        // Validate dependencies exist and aren't dead/cancelled
-        for dep_id in &depends_on {
-            let job_key = self.key(&["job", dep_id]);
-            let data: Option<String> = conn.get(&job_key).map_err(map_err)?;
-            match data {
-                None => {
-                    return Err(QueueError::DependencyNotFound(
-                        "dependency not found or already dead/cancelled".to_string(),
-                    ));
-                }
-                Some(d) => {
-                    let dep_job: Job =
-                        serde_json::from_str(&d).map_err(|e| QueueError::Other(e.to_string()))?;
-                    if dep_job.status == JobStatus::Dead || dep_job.status == JobStatus::Cancelled {
-                        return Err(QueueError::DependencyNotFound(
-                            "dependency not found or already dead/cancelled".to_string(),
-                        ));
-                    }
-                }
-            }
-        }
+        self.validate_dep_ids(&mut conn, &depends_on, None)?;
 
         let job_json = serde_json::to_string(&job).map_err(|e| QueueError::Other(e.to_string()))?;
         let job_key = self.key(&["job", &job.id]);
@@ -81,33 +92,8 @@ impl RedisStorage {
         let batch_ids: std::collections::HashSet<&str> =
             jobs.iter().map(|j| j.id.as_str()).collect();
 
-        // Validate dependencies exist and aren't dead/cancelled
         for depends_on in &dep_lists {
-            for dep_id in depends_on {
-                if batch_ids.contains(dep_id.as_str()) {
-                    continue; // intra-batch dependency
-                }
-                let dep_key = self.key(&["job", dep_id]);
-                let data: Option<String> = conn.get(&dep_key).map_err(map_err)?;
-                match data {
-                    None => {
-                        return Err(QueueError::DependencyNotFound(
-                            "dependency not found or already dead/cancelled".to_string(),
-                        ));
-                    }
-                    Some(d) => {
-                        let dep_job: Job = serde_json::from_str(&d)
-                            .map_err(|e| QueueError::Other(e.to_string()))?;
-                        if dep_job.status == JobStatus::Dead
-                            || dep_job.status == JobStatus::Cancelled
-                        {
-                            return Err(QueueError::DependencyNotFound(
-                                "dependency not found or already dead/cancelled".to_string(),
-                            ));
-                        }
-                    }
-                }
-            }
+            self.validate_dep_ids(&mut conn, depends_on, Some(&batch_ids))?;
         }
 
         let pipe = &mut redis::pipe();
@@ -200,29 +186,7 @@ impl RedisStorage {
             let job_json =
                 serde_json::to_string(&job).map_err(|e| QueueError::Other(e.to_string()))?;
 
-            // Validate dependencies
-            for dep_id in &depends_on {
-                let dep_key = self.key(&["job", dep_id]);
-                let data: Option<String> = conn.get(&dep_key).map_err(map_err)?;
-                match data {
-                    None => {
-                        return Err(QueueError::DependencyNotFound(
-                            "dependency not found or already dead/cancelled".to_string(),
-                        ));
-                    }
-                    Some(d) => {
-                        let dep_job: Job = serde_json::from_str(&d)
-                            .map_err(|e| QueueError::Other(e.to_string()))?;
-                        if dep_job.status == JobStatus::Dead
-                            || dep_job.status == JobStatus::Cancelled
-                        {
-                            return Err(QueueError::DependencyNotFound(
-                                "dependency not found or already dead/cancelled".to_string(),
-                            ));
-                        }
-                    }
-                }
-            }
+            self.validate_dep_ids(&mut conn, &depends_on, None)?;
 
             // Store everything atomically via Lua. Active-status names are
             // passed via ARGV (positions 7-8) for the same reason as above —

--- a/crates/taskito-core/src/storage/redis_backend/workers.rs
+++ b/crates/taskito-core/src/storage/redis_backend/workers.rs
@@ -4,8 +4,7 @@ use super::{map_err, RedisStorage};
 use crate::error::Result;
 use crate::job::now_millis;
 use crate::storage::models::WorkerRow;
-
-const DEAD_WORKER_THRESHOLD_MS: i64 = 30_000;
+use crate::storage::DEAD_WORKER_THRESHOLD_MS;
 
 impl RedisStorage {
     #[allow(clippy::too_many_arguments)]

--- a/crates/taskito-core/src/storage/sqlite/workers.rs
+++ b/crates/taskito-core/src/storage/sqlite/workers.rs
@@ -2,12 +2,10 @@ use diesel::prelude::*;
 
 use super::super::models::*;
 use super::super::schema::{execution_claims, workers};
+use super::super::DEAD_WORKER_THRESHOLD_MS;
 use super::SqliteStorage;
 use crate::error::Result;
 use crate::job::now_millis;
-
-/// Dead worker threshold: 30 seconds without heartbeat.
-const DEAD_WORKER_THRESHOLD_MS: i64 = 30_000;
 
 impl SqliteStorage {
     /// Register a new worker or update an existing one.

--- a/docs/api/canvas.md
+++ b/docs/api/canvas.md
@@ -5,7 +5,7 @@
 Canvas primitives for composing task workflows. Import directly from the package:
 
 ```python
-from taskito import chain, group, chord
+from taskito import chain, group, chord, chunks, starmap
 ```
 
 ---
@@ -229,6 +229,69 @@ await chord.apply_async(queue: Queue | None = None) -> JobResult
 ```
 
 Async version of `apply()`. Awaits all group results using `asyncio.gather`, then enqueues the callback.
+
+---
+
+## chunks
+
+Split an iterable into fixed-size chunks and process each chunk in parallel.
+
+### Constructor
+
+```python
+chunks(task: TaskWrapper, items: list, chunk_size: int) -> group
+```
+
+| Parameter | Type | Description |
+|---|---|---|
+| `task` | `TaskWrapper` | The task to call for each chunk. Receives the chunk as a single positional argument. |
+| `items` | `list` | The full list to split. Must be non-empty. |
+| `chunk_size` | `int` | Items per chunk. Must be positive. |
+
+Returns a [`group`](#group) of signatures — one per chunk. Apply it the same way as any other group.
+
+```python
+@queue.task()
+def process_batch(records):
+    return [transform(r) for r in records]
+
+records = load_records()  # 10_000 items
+jobs = chunks(process_batch, records, 100).apply()  # → 100 parallel jobs
+
+results = [j.result(timeout=60) for j in jobs]
+```
+
+Raises `ValueError` if `chunk_size <= 0` or `items` is empty.
+
+---
+
+## starmap
+
+Spread an iterable of argument tuples over parallel task invocations.
+
+### Constructor
+
+```python
+starmap(task: TaskWrapper, args_list: list[tuple]) -> group
+```
+
+| Parameter | Type | Description |
+|---|---|---|
+| `task` | `TaskWrapper` | The task to call. Each tuple is unpacked into positional args. |
+| `args_list` | `list[tuple]` | One tuple per invocation. Must be non-empty. |
+
+Returns a [`group`](#group) of signatures — one per tuple. Equivalent to `group(task.s(*a) for a in args_list)`.
+
+```python
+@queue.task()
+def add(x, y):
+    return x + y
+
+jobs = starmap(add, [(1, 2), (3, 4), (5, 6)]).apply()
+results = [j.result(timeout=10) for j in jobs]  # [3, 7, 11]
+```
+
+Raises `ValueError` if `args_list` is empty.
 
 ---
 


### PR DESCRIPTION
## Summary
Three small, independently-reviewable cleanups from the 2026-04-23 audit's P2 list. No behavior change in any commit.

- **`refactor(storage): consolidate DEAD_WORKER_THRESHOLD_MS`** — `const i64 = 30_000` was triplicated across `sqlite/workers.rs`, `postgres/workers.rs`, and `redis_backend/workers.rs`. Lifted to `crates/taskito-core/src/storage/mod.rs` so the three backends can never drift.
- **`refactor(redis): extract validate_dep_ids helper`** — the same dep-existence + non-Dead/Cancelled check was open-coded in `enqueue` / `enqueue_batch` / `enqueue_unique`. Now a private `RedisStorage::validate_dep_ids` method that takes an optional skip-set for the intra-batch case. Net **−36 LOC**.
- **`docs(canvas): document chunks() and starmap()`** — the audit flagged `docs/api/canvas.md` as missing these two helpers. Added with the same Constructor / parameter-table / example pattern used by `chain` / `group` / `chord`. Also updated the import line at the top to include them.

## Test plan
- [x] `cargo test --workspace` — 78 tests pass
- [x] `cargo test --features redis -p taskito-core --test rust redis_storage_tests` — passes against `redis:7-alpine` (verifies validate_dep_ids extraction is behavior-preserving)
- [x] `cargo clippy --workspace --features redis -- -D warnings` — clean
- [x] CI's `Rust Tests (PostgreSQL)` and `Rust Tests (Redis)` jobs (PR #73) will exercise the consolidated const + new helper across all three backends