### PR TITLE
fix(ci): drop duplicated (deps) prefix in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,14 @@
 version: 2
 
 # Weekly grouped updates per ecosystem; major bumps open as their own PRs.
+#
+# Note on commit prefix: `include: scope` auto-appends the ecosystem scope
+# (`deps` / `deps-dev`), so the configured `prefix` must be the bare type
+# to avoid the doubled `chore(deps)(deps): bump X`.
 updates:
   - package-ecosystem: cargo
     directory: /
-    schedule: &weekly
+    schedule:
       interval: weekly
       day: monday
       time: "06:00"
@@ -13,9 +17,7 @@ updates:
     labels:
       - dependencies
       - area/rust
-    # `include: scope` auto-appends the ecosystem scope, so prefix must be
-    # the bare type to avoid the doubled `chore(deps)(deps): bump X`.
-    commit-message: &chore-deps-scoped
+    commit-message:
       prefix: chore
       include: scope
     groups:
@@ -26,12 +28,18 @@ updates:
 
   - package-ecosystem: pip
     directory: /
-    schedule: *weekly
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: UTC
     open-pull-requests-limit: 5
     labels:
       - dependencies
       - area/python
-    commit-message: *chore-deps-scoped
+    commit-message:
+      prefix: chore
+      include: scope
     groups:
       python-deps:
         update-types:
@@ -40,12 +48,18 @@ updates:
 
   - package-ecosystem: npm
     directory: /dashboard
-    schedule: *weekly
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: UTC
     open-pull-requests-limit: 5
     labels:
       - dependencies
       - area/dashboard
-    commit-message: *chore-deps-scoped
+    commit-message:
+      prefix: chore
+      include: scope
     groups:
       dashboard-deps:
         update-types:
@@ -61,7 +75,11 @@ updates:
 
   - package-ecosystem: github-actions
     directory: /
-    schedule: *weekly
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: UTC
     open-pull-requests-limit: 3
     labels:
       - dependencies

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,10 @@
 version: 2
 
-# Weekly dependency updates across every ecosystem taskito uses.
-# Patch + minor updates are grouped into one PR per ecosystem to keep
-# review traffic low; major updates get their own PRs so they can be
-# evaluated individually. Security advisories always open dedicated PRs.
+# Weekly grouped updates per ecosystem; major bumps open as their own PRs.
 updates:
-  # Rust (workspace Cargo.toml + per-crate)
   - package-ecosystem: cargo
     directory: /
-    schedule:
+    schedule: &weekly
       interval: weekly
       day: monday
       time: "06:00"
@@ -17,8 +13,10 @@ updates:
     labels:
       - dependencies
       - area/rust
-    commit-message:
-      prefix: "chore(deps)"
+    # `include: scope` auto-appends the ecosystem scope, so prefix must be
+    # the bare type to avoid the doubled `chore(deps)(deps): bump X`.
+    commit-message: &chore-deps-scoped
+      prefix: chore
       include: scope
     groups:
       rust-deps:
@@ -26,49 +24,34 @@ updates:
           - patch
           - minor
 
-  # Python (pyproject.toml — uv manages resolution)
   - package-ecosystem: pip
     directory: /
-    schedule:
-      interval: weekly
-      day: monday
-      time: "06:00"
-      timezone: UTC
+    schedule: *weekly
     open-pull-requests-limit: 5
     labels:
       - dependencies
       - area/python
-    commit-message:
-      prefix: "chore(deps)"
-      include: scope
+    commit-message: *chore-deps-scoped
     groups:
       python-deps:
         update-types:
           - patch
           - minor
 
-  # Dashboard (pnpm)
   - package-ecosystem: npm
     directory: /dashboard
-    schedule:
-      interval: weekly
-      day: monday
-      time: "06:00"
-      timezone: UTC
+    schedule: *weekly
     open-pull-requests-limit: 5
     labels:
       - dependencies
       - area/dashboard
-    commit-message:
-      prefix: "chore(deps)"
-      include: scope
+    commit-message: *chore-deps-scoped
     groups:
       dashboard-deps:
         update-types:
           - patch
           - minor
-      # Surface Radix + TanStack ecosystem upgrades together when they
-      # co-release — lets us pin compatible sets in a single PR.
+      # Co-released ecosystems pinned together so compatible sets land in one PR.
       radix:
         patterns:
           - "@radix-ui/*"
@@ -76,20 +59,15 @@ updates:
         patterns:
           - "@tanstack/*"
 
-  # GitHub Actions used in .github/workflows/*.yml
   - package-ecosystem: github-actions
     directory: /
-    schedule:
-      interval: weekly
-      day: monday
-      time: "06:00"
-      timezone: UTC
+    schedule: *weekly
     open-pull-requests-limit: 3
     labels:
       - dependencies
       - area/ci
     commit-message:
-      prefix: "chore(ci)"
+      prefix: chore(ci)
     groups:
       actions:
         update-types:


### PR DESCRIPTION
## Summary
Dependabot was producing PR titles like \`chore(deps)(deps): bump tailwind-merge from 2.6.1 to 3.5.0\` — the \`(deps)\` was doubled.

\`include: scope\` makes dependabot auto-append the ecosystem scope (\`deps\`, \`deps-dev\`), so the configured \`prefix\` must be the bare type. Three ecosystems (cargo / pip / npm) had \`prefix: \"chore(deps)\"\` + \`include: scope\`, producing the doubled rendering.

Now the rendered titles are clean — \`chore(deps): bump X\` for runtime deps and \`chore(deps-dev): bump X\` for dev deps.

While in here, anchored the now-identical \`schedule\` and \`commit-message\` blocks so the convention can't drift between ecosystems.

## Test plan
- [x] \`python3 -c \"import yaml; …\"\` confirms every entry resolves to \`prefix: chore\` + \`include: scope\` (the \`github-actions\` entry intentionally keeps its own \`chore(ci)\` prefix without \`include: scope\`).
- [ ] Next dependabot run renders titles as \`chore(deps): …\` instead of \`chore(deps)(deps): …\`.