### PR TITLE
feat(cli): surface --pool prefork in the worker subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ print(job.result(timeout=10))  # 5
 
 Most Python task queues require a separate broker (Redis, RabbitMQ) even for single-machine workloads. taskito embeds everything — storage, scheduling, and worker management — into a single `pip install` with no external dependencies beyond Python itself. For distributed setups, an optional Postgres backend enables multi-machine workers with the same API.
 
-The heavy lifting runs in Rust: a Tokio async scheduler, OS thread worker pool with crossbeam channels, and Diesel ORM over SQLite in WAL mode. Python's GIL is only held during task execution.
+The heavy lifting runs in Rust: a Tokio async scheduler, OS thread worker pool with crossbeam channels, and Diesel ORM over SQLite in WAL mode. Python's GIL is only held during task execution. For CPU-bound workloads, run with `--pool prefork` to spawn child processes with independent GILs and get true parallel speedup — see the [prefork guide](https://taskito.grigori.in/guide/execution/prefork/).
 
 ## Features
 

--- a/py_src/taskito/cli.py
+++ b/py_src/taskito/cli.py
@@ -38,6 +38,12 @@ def main() -> None:
         default=None,
         help="Seconds to wait for in-flight jobs during shutdown (default: 30)",
     )
+    worker_parser.add_argument(
+        "--pool",
+        choices=["thread", "prefork"],
+        default="thread",
+        help="Worker pool: 'thread' (default) or 'prefork' for true CPU parallelism",
+    )
 
     # dashboard subcommand
     dash_parser = subparsers.add_parser("dashboard", help="Start the web dashboard")
@@ -195,7 +201,7 @@ def run_worker(args: argparse.Namespace) -> None:
     if args.drain_timeout is not None:
         queue._drain_timeout = args.drain_timeout
     queues = args.queues.split(",") if args.queues else None
-    queue.run_worker(queues=queues)
+    queue.run_worker(queues=queues, pool=args.pool, app=args.app)
 
 
 def run_dashboard(args: argparse.Namespace) -> None:


### PR DESCRIPTION
## Summary

The prefork worker pool is fully implemented in the Rust core (independent Python interpreters per child, own GIL each, true CPU parallelism), but it was only reachable by calling `queue.run_worker(pool="prefork", app="myapp:queue")` programmatically. The CLI's `taskito worker` subcommand had no way to opt in, and the README's concurrency paragraph didn't mention it — so a user reading either entry point would reasonably conclude Taskito has no answer for CPU-bound work.

- **CLI**: add `--pool {thread,prefork}` to `taskito worker` (default `thread`, behavior unchanged). Forwards to `queue.run_worker(pool=..., app=...)`.
- **README**: extend the concurrency paragraph with a sentence pointing CPU-bound users at `--pool prefork` and link the prefork guide.

## Test plan

- [x] `uv run ruff check py_src/ tests/`
- [x] `uv run mypy py_src/taskito/ --no-incremental`
- [x] `uv run python -m pytest tests/python/test_cli.py -v` (3 passed)
- [x] `taskito worker --help` shows `--pool {thread,prefork}`
- [x] `taskito worker --app x:y --pool bogus` rejected by argparse with exit 2
- [ ] Manual: `taskito worker --app myapp:queue --pool prefork` spawns child processes