### PR TITLE
chore: drop area/ prefix and skip CI jobs by path

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,27 +1,23 @@
-# Path-based PR auto-labels. Drives triage, filtering, and release-notes
-# grouping. Each area label is additive — a PR touching Rust + docs gets
-# both `area/rust` and `area/docs`.
-
-area/rust:
+rust:
   - changed-files:
       - any-glob-to-any-file:
           - "crates/**"
           - "Cargo.toml"
           - "Cargo.lock"
 
-area/python:
+python:
   - changed-files:
       - any-glob-to-any-file:
           - "py_src/**"
           - "pyproject.toml"
           - "uv.lock"
 
-area/dashboard:
+dashboard:
   - changed-files:
       - any-glob-to-any-file:
           - "dashboard/**"
 
-area/docs:
+docs:
   - changed-files:
       - any-glob-to-any-file:
           - "docs/**"
@@ -29,7 +25,7 @@ area/docs:
           - "CHANGELOG.md"
           - "**/*.md"
 
-area/tests:
+tests:
   - changed-files:
       - any-glob-to-any-file:
           - "tests/**"
@@ -38,23 +34,23 @@ area/tests:
           - "**/*.test.ts"
           - "**/*.test.tsx"
 
-area/ci:
+ci:
   - changed-files:
       - any-glob-to-any-file:
           - ".github/**"
           - ".pre-commit-config.yaml"
 
-area/storage:
+storage:
   - changed-files:
       - any-glob-to-any-file:
           - "crates/taskito-core/src/storage/**"
 
-area/scheduler:
+scheduler:
   - changed-files:
       - any-glob-to-any-file:
           - "crates/taskito-core/src/scheduler/**"
 
-area/workflows:
+workflows:
   - changed-files:
       - any-glob-to-any-file:
           - "crates/taskito-core/src/workflow*/**"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,37 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      rust: ${{ steps.filter.outputs.rust }}
+      python: ${{ steps.filter.outputs.python }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Filter paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            rust:
+              - 'crates/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'rust-toolchain.toml'
+              - '.github/workflows/ci.yml'
+            python:
+              - 'py_src/**'
+              - 'tests/python/**'
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - 'crates/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - '.github/workflows/ci.yml'
+
   lint:
     name: Lint & Static Analysis
     runs-on: ubuntu-latest
@@ -57,6 +88,8 @@ jobs:
 
   rust-test:
     name: Rust Tests (SQLite)
+    needs: changes
+    if: needs.changes.outputs.rust == 'true' || github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
@@ -85,6 +118,8 @@ jobs:
 
   rust-test-postgres:
     name: Rust Tests (PostgreSQL)
+    needs: changes
+    if: needs.changes.outputs.rust == 'true' || github.event_name == 'push'
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -125,6 +160,8 @@ jobs:
 
   rust-test-redis:
     name: Rust Tests (Redis)
+    needs: changes
+    if: needs.changes.outputs.rust == 'true' || github.event_name == 'push'
     runs-on: ubuntu-latest
     services:
       redis:
@@ -161,7 +198,8 @@ jobs:
 
   test:
     name: Python Tests (${{ matrix.os }} / Python ${{ matrix.python-version }})
-    needs: lint
+    needs: [lint, changes]
+    if: needs.changes.outputs.python == 'true' || github.event_name == 'push'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -229,3 +267,24 @@ jobs:
           fi
           exit $PYTEST_EXIT
         shell: bash
+
+  ci-status:
+    name: CI status
+    if: always()
+    needs: [lint, rust-test, rust-test-postgres, rust-test-redis, test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check that no required job failed
+        run: |
+          results='${{ toJson(needs) }}'
+          echo "$results"
+          fail=$(echo "$results" | python3 -c "
+          import json, sys
+          data = json.load(sys.stdin)
+          bad = [k for k, v in data.items() if v['result'] not in ('success', 'skipped')]
+          print(','.join(bad))
+          ")
+          if [ -n "$fail" ]; then
+            echo "::error::Failing or cancelled jobs: $fail"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- Removed the `area/` prefix from every entry in `.github/labeler.yml`. Existing repo labels were renamed in place (`area/rust` → `rust`, etc.) so labels stay attached to past PRs/issues; missing labels (`scheduler`, `tests`, `workflows`) were created.
- Added path-based gating to `.github/workflows/ci.yml`:
  - New `changes` job emits `rust` / `python` booleans via `dorny/paths-filter@v3`.
  - `rust-test`, `rust-test-postgres`, `rust-test-redis` only run when Rust paths change (or on `push` to master).
  - Python matrix (`test`) only runs when Python or Rust paths change (PyO3 wheel depends on Rust).
  - `lint` still always runs.
  - New `CI status` aggregator job (`if: always()`) succeeds when every dependency is `success` or `skipped`. Make this the required check in branch protection so legitimately-skipped jobs don't block merges.

## Notes for reviewer
- Master pushes always run the full matrix (defense in depth).
- Before merging, update branch protection on `master` to require `CI status` and `Lint & Static Analysis` instead of the individual `Rust Tests (*)` / `Python Tests (...)` jobs.

## Test plan
- [ ] Open this PR — confirm only `lint`, `changes`, and `CI status` run (no Rust/Python paths touched here besides `.github/workflows/ci.yml`, which is in both filters → full matrix should run).
- [ ] After merge, push a docs-only change on a follow-up branch and confirm the heavy jobs are skipped while `CI status` still reports success.
- [ ] Update branch protection rules accordingly.