### PR TITLE
ci: use floating major tags for action references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Restore Cargo cache
-        uses: Swatinem/rust-cache@v2.9.1
+        uses: Swatinem/rust-cache@v2
 
       - name: Check Rust formatting
         run: cargo fmt --all --check
@@ -104,7 +104,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Restore Cargo cache
-        uses: Swatinem/rust-cache@v2.9.1
+        uses: Swatinem/rust-cache@v2
         with:
           save-if: false
 
@@ -148,7 +148,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Restore Cargo cache
-        uses: Swatinem/rust-cache@v2.9.1
+        uses: Swatinem/rust-cache@v2
         with:
           save-if: false
 
@@ -186,7 +186,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Restore Cargo cache
-        uses: Swatinem/rust-cache@v2.9.1
+        uses: Swatinem/rust-cache@v2
         with:
           save-if: false
 
@@ -234,7 +234,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Restore Cargo cache
-        uses: Swatinem/rust-cache@v2.9.1
+        uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ matrix.os != 'ubuntu-latest' }}
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Build docs
         run: uv run zensical build
 
-      - uses: actions/upload-pages-artifact@v5.0.0
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: site
 
@@ -44,4 +44,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v5.0.0
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -12,7 +12,7 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v6.0.1
+      - uses: actions/labeler@v6
         with:
           configuration-path: .github/labeler.yml
           sync-labels: true

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
-      - uses: amannn/action-semantic-pull-request@v6.1.1
+      - uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v10.2.0
+      - uses: actions/stale@v10
         with:
           days-before-pr-stale: 7
           days-before-pr-close: 3


### PR DESCRIPTION
## Summary

Drops minor/patch pins from six GitHub Actions and switches them to floating major tags, matching the pattern already used by the rest of the workflows. Picks up upstream patch fixes automatically without further PR churn.

| Action | Before | After |
|---|---|---|
| `Swatinem/rust-cache` | `v2.9.1` | `v2` (5 occurrences in ci.yml) |
| `actions/upload-pages-artifact` | `v5.0.0` | `v5` |
| `actions/deploy-pages` | `v5.0.0` | `v5` |
| `actions/labeler` | `v6.0.1` | `v6` |
| `actions/stale` | `v10.2.0` | `v10` |
| `amannn/action-semantic-pull-request` | `v6.1.1` | `v6` |

`astral-sh/setup-uv` is intentionally left at `v8.1.0` — that repo doesn't publish a floating `v8` tag (only specific minors).

All workflows already on `@vN` floating major (checkout, setup-python, setup-node, upload-artifact, download-artifact, dorny/paths-filter, PyO3/maturin-action, pnpm/action-setup, codeql-action, raven-actions/actionlint) are unchanged — they're already on the latest major.

## Test plan

- [x] All 10 workflow files validate as YAML
- [ ] CI passes (lint, rust-test x3, python-test matrix, codeql, actionlint, semantic-pr, label)