### PR TITLE
chore(deps): bump pq-sys and cron to latest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ rand = "0.8"
 crossbeam-channel = "0.5"
 thiserror = "1"
 chrono = "0.4"
-cron = "0.13"
+cron = "0.16"
 chrono-tz = "0.10"
 log = "0.4"
 redis = { version = "1.2", features = ["script"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.dependencies]
 diesel = { version = "2.2", features = ["sqlite", "r2d2", "returning_clauses_for_sqlite_3_35"] }
 libsqlite3-sys = { version = "0.37", features = ["bundled"] }
-pq-sys = { version = "0.6", features = ["bundled"] }
+pq-sys = { version = "0.7", features = ["bundled"] }
 uuid = { version = "1", features = ["v7"] }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## Summary

Two 0.x dependency bumps where the lockfile already maxed out within the existing range. Each lands as its own commit so either can be reverted independently.

| Crate | Before | After | Notes |
|---|---|---|---|
| `pq-sys` | `0.6` | `0.7` | libpq bindings; postgres feature only |
| `cron` | `0.13` | `0.16` | `Schedule::from_str` + `.after().next()` API surface unchanged across 0.13→0.16 |

All other workspace deps (`tokio`, `serde`, `diesel 2.x`, `redis 1.2`, `chrono`, `chrono-tz`, `libsqlite3-sys`, `uuid`, `crossbeam-channel`, `thiserror`, `log`, `openssl-sys`, `async-trait`, `base64`, `gethostname`, `tempfile`) are already at their latest within the current `^` range; `cargo update` reports 0 packages to refresh. PyO3, rand, and thiserror major bumps are deferred to their own PRs (2b/2c/2d).

## Verification (local)

- `cargo check --workspace --features postgres` — pq-sys 0.7.5 builds clean
- `cargo test --workspace` — 78 tests pass (43 unit + 1 storage + 5 + 29 across crates)
- `cargo clippy --workspace --all-features -- -D warnings` — clean
- `cargo clippy --workspace --features postgres` — clean
- `cargo clippy --workspace --features redis` — clean
- `cargo fmt --all --check` — clean

## Test plan

- [ ] CI: SQLite, Postgres, Redis backend Rust suites green
- [ ] CI: lint job (clippy + fmt) green