### PR TITLE
chore(deps): bump Python dep floors to latest stable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=1.0,<2.0"]
+requires = ["maturin>=1.5,<2.0"]
 build-backend = "maturin"
 
 [project]
@@ -31,9 +31,9 @@ Changelog = "https://github.com/ByteVeda/taskito/blob/master/docs/changelog.md"
 Issues = "https://github.com/ByteVeda/taskito/issues"
 
 [project.optional-dependencies]
-dev = ["pytest>=7.0", "pytest-asyncio>=0.21", "pytest-cov>=4.0", "ruff>=0.8", "mypy>=1.13"]
-fastapi = ["fastapi>=0.100.0", "pydantic>=2.0"]
-django = ["django>=3.2"]
+dev = ["pytest>=8.0", "pytest-asyncio>=0.24", "pytest-cov>=5.0", "ruff>=0.11", "mypy>=1.15"]
+fastapi = ["fastapi>=0.110.0", "pydantic>=2.5"]
+django = ["django>=4.2"]
 postgres = []  # PG driver is bundled in the Rust binary; extra exists for discoverability
 redis = []     # Redis driver is bundled in the Rust binary; extra exists for discoverability
 otel = ["opentelemetry-api", "opentelemetry-sdk"]
@@ -41,9 +41,9 @@ prometheus = ["prometheus-client"]
 sentry = ["sentry-sdk"]
 msgpack = ["msgpack"]
 encryption = ["cryptography"]
-flask = ["flask>=2.0"]
-aws = ["boto3>=1.20"]
-gcs = ["google-cloud-storage>=2.0"]
+flask = ["flask>=3.0"]
+aws = ["boto3>=1.34"]
+gcs = ["google-cloud-storage>=2.10"]
 docs = ["zensical"]
 
 [tool.maturin]


### PR DESCRIPTION
## Summary

Raises minimum-supported floors for Python deps in `pyproject.toml`. uv resolves the latest within each new floor (lockfile is gitignored, so this is a floor-only change). End users picking Python 3.10+ get the new floors at install time.

| Dep | Before | After |
|---|---|---|
| `pytest` | `>=7.0` | `>=8.0` |
| `pytest-asyncio` | `>=0.21` | `>=0.24` |
| `pytest-cov` | `>=4.0` | `>=5.0` |
| `ruff` | `>=0.8` | `>=0.11` |
| `mypy` | `>=1.13` | `>=1.15` |
| `fastapi` | `>=0.100.0` | `>=0.110.0` |
| `pydantic` | `>=2.0` | `>=2.5` |
| `django` | `>=3.2` | `>=4.2` (3.2 EOL April 2024) |
| `flask` | `>=2.0` | `>=3.0` |
| `boto3` | `>=1.20` | `>=1.34` |
| `google-cloud-storage` | `>=2.0` | `>=2.10` |
| `maturin` (build) | `>=1.0,<2.0` | `>=1.5,<2.0` |

`cloudpickle>=3.0` and the unpinned extras (otel, prometheus, sentry, msgpack, encryption) are unchanged.

## Verification (local)

After `uv lock --upgrade && uv sync --extra dev`:

- `uv run ruff check py_src/ tests/` — clean
- `uv run ruff format --check py_src/ tests/` — 142 files already formatted
- `uv run mypy py_src/taskito/ tests/python/ --no-incremental` — 142 source files, no issues
- `uv run python -m pytest tests/python/` — **465 passed, 9 skipped** in 5m18s (9 skips are Windows-only tests, expected)

The new floors picked up these notable lockfile bumps along the way: ruff `0.15.6 → 0.15.12`, mypy `1.19.1 → 1.20.2`, pytest `9.0.2 → 9.0.3`, pydantic `2.12.5 → 2.13.3`, sentry-sdk `2.54.0 → 2.58.0`, starlette `0.52 → 1.0.0`.

## Test plan

- [ ] CI: lint job (ruff + mypy) green
- [ ] CI: full Python test matrix (Linux 3.10/3.11/3.12/3.13, macOS 3.10/3.13, Windows 3.10/3.13) green