### PR TITLE
chore(deps): bump rand 0.8 to 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ uuid = { version = "1", features = ["v7"] }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-rand = "0.8"
+rand = "0.10"
 crossbeam-channel = "0.5"
 thiserror = "2"
 chrono = "0.4"


### PR DESCRIPTION
## Summary

Bumps `rand` two majors (0.8 → 0.10). The codebase has exactly one call site — `rand::random::<u64>()` in `crates/taskito-core/src/resilience/retry.rs` — and that function signature is unchanged across 0.8/0.9/0.10, so no migration code needed.

The new lockfile resolves to `rand 0.10.1` and `rand_core 0.10.1`.

## Verification (local)

- `cargo check --workspace --all-features` — clean
- `cargo test --workspace` — all 78 tests pass (43 + 1 + 5 + 29)
- `cargo clippy --workspace --all-features -- -D warnings` — clean

## Test plan

- [ ] CI: SQLite, Postgres, Redis Rust suites green
- [ ] CI: lint job green