### PR TITLE
chore(dashboard): wave 2 of code-health audit fixes

### DIFF
--- a/dashboard/biome.json
+++ b/dashboard/biome.json
@@ -5,8 +5,8 @@
     "rules": {
       "recommended": true,
       "a11y": {
-        "noStaticElementInteractions": "off",
-        "useKeyWithClickEvents": "off"
+        "noStaticElementInteractions": "error",
+        "useKeyWithClickEvents": "error"
       },
       "complexity": {
         "noForEach": "off"

--- a/dashboard/src/providers/refresh-interval-provider.test.ts
+++ b/dashboard/src/providers/refresh-interval-provider.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { parseRefreshOption, refreshIntervalMs } from "./refresh-interval-provider";
+
+describe("parseRefreshOption", () => {
+  it("returns each known option verbatim", () => {
+    expect(parseRefreshOption("2s")).toBe("2s");
+    expect(parseRefreshOption("5s")).toBe("5s");
+    expect(parseRefreshOption("10s")).toBe("10s");
+    expect(parseRefreshOption("off")).toBe("off");
+  });
+
+  it("falls back to 5s when storage is empty", () => {
+    expect(parseRefreshOption(null)).toBe("5s");
+    expect(parseRefreshOption("")).toBe("5s");
+  });
+
+  it("falls back to 5s on unknown values", () => {
+    expect(parseRefreshOption("3s")).toBe("5s");
+    expect(parseRefreshOption("nonsense")).toBe("5s");
+    expect(parseRefreshOption("0")).toBe("5s");
+  });
+
+  it("is case-sensitive — does not normalise casing or whitespace", () => {
+    expect(parseRefreshOption("2S")).toBe("5s");
+    expect(parseRefreshOption("OFF")).toBe("5s");
+    expect(parseRefreshOption(" 2s")).toBe("5s");
+    expect(parseRefreshOption("2s ")).toBe("5s");
+  });
+});
+
+describe("refreshIntervalMs", () => {
+  it("maps each option to its polling interval", () => {
+    expect(refreshIntervalMs("2s")).toBe(2_000);
+    expect(refreshIntervalMs("5s")).toBe(5_000);
+    expect(refreshIntervalMs("10s")).toBe(10_000);
+  });
+
+  it("returns false for off so consumers can disable polling", () => {
+    expect(refreshIntervalMs("off")).toBe(false);
+  });
+});

--- a/dashboard/src/providers/refresh-interval-provider.tsx
+++ b/dashboard/src/providers/refresh-interval-provider.tsx
@@ -10,6 +10,7 @@ const REFRESH_MS: Record<RefreshOption, number | false> = {
 };
 
 const STORAGE_KEY = "taskito.refresh";
+const DEFAULT_OPTION: RefreshOption = "5s";
 
 interface RefreshContextValue {
   option: RefreshOption;
@@ -19,10 +20,17 @@ interface RefreshContextValue {
 
 const RefreshContext = createContext<RefreshContextValue | null>(null);
 
-function readStored(): RefreshOption {
-  const stored = localStorage.getItem(STORAGE_KEY);
+export function parseRefreshOption(stored: string | null): RefreshOption {
   if (stored === "2s" || stored === "5s" || stored === "10s" || stored === "off") return stored;
-  return "5s";
+  return DEFAULT_OPTION;
+}
+
+export function refreshIntervalMs(option: RefreshOption): number | false {
+  return REFRESH_MS[option];
+}
+
+function readStored(): RefreshOption {
+  return parseRefreshOption(localStorage.getItem(STORAGE_KEY));
 }
 
 export function RefreshIntervalProvider({ children }: { children: ReactNode }) {
@@ -31,7 +39,7 @@ export function RefreshIntervalProvider({ children }: { children: ReactNode }) {
   const value = useMemo<RefreshContextValue>(
     () => ({
       option,
-      intervalMs: REFRESH_MS[option],
+      intervalMs: refreshIntervalMs(option),
       setOption: (next) => {
         setOptionState(next);
         localStorage.setItem(STORAGE_KEY, next);


### PR DESCRIPTION
## Summary

Follow-up to PR #102. Picks up two of the three audit items deferred from
that PR:

1. **Test coverage for `refresh-interval-provider`** — extracts
   `parseRefreshOption()` and `refreshIntervalMs()` as pure helpers and
   adds 6 tests covering the localStorage guard logic (the audit's flagged
   regression risk). Avoids dragging in `jsdom` + `@testing-library/react`
   for what is essentially validation of a string union.
2. **Re-enables two a11y Biome rules** — `noStaticElementInteractions` and
   `useKeyWithClickEvents`, both previously toggled off. Running
   `biome check` confirms zero current violations across all 170 files;
   the rules act as a guard against future div-with-onClick regressions.

## Deliberately deferred

The third audit item (hoisting `ToggleBtn`/`ViewToggle` out of
`routes/dead-letters.tsx` and `DateInput`/`msToLocalDatetime` out of
`features/jobs/components/job-filters.tsx`) is **not** in this PR. Both
have exactly one consumer each — hoisting them now would be premature
abstraction. Worth revisiting only when a second feature actually needs
them.

## Test plan

- [x] `pnpm run ci` (biome ci, typecheck, 87 vitest tests, vite build) clean locally
- [ ] CI green