### PR TITLE
chore(mixins): use inspect.iscoroutinefunction in decorators

### DIFF
--- a/py_src/taskito/mixins/decorators.py
+++ b/py_src/taskito/mixins/decorators.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-import asyncio
 import contextlib
 import functools
+import inspect
 import os
 import sys
 import typing
@@ -196,7 +196,7 @@ class QueueDecoratorMixin:
             functools.update_wrapper(wrapper, fn)
 
             # Mark async status for native async dispatch
-            is_async = asyncio.iscoroutinefunction(fn)
+            is_async = inspect.iscoroutinefunction(fn)
             wrapper._taskito_is_async = is_async
             if is_async:
                 wrapper._taskito_async_fn = fn


### PR DESCRIPTION
## Summary

- Final P0 fix from the 2026-05-02 pre-release audit (after PRs #104, #105, #106).
- `py_src/taskito/mixins/decorators.py` was the last file in the non-async, non-contrib core that imported `asyncio` — a violation of the project's async-separation boundary (which confines `import asyncio` to `async_support/`, `app.py`, and `contrib/fastapi.py`).
- Replaces `import asyncio` + `asyncio.iscoroutinefunction(fn)` with `import inspect` + `inspect.iscoroutinefunction(fn)`. Identical semantics for detecting `async def` functions.

After this change, the boundary is machine-checkable with a single grep:

\`\`\`
$ grep -rn "import asyncio" py_src/taskito/ | grep -v -E "(async_support/|contrib/fastapi\.py)"
# (empty)
\`\`\`

## Test plan

- [x] `uv run python -m pytest tests/python/ -v` — 488 passed, 9 skipped (no regressions in `test_async_*` which exercise the `_taskito_is_async` flag set at this call site)
- [x] `uv run ruff check py_src/ tests/` — clean
- [x] `uv run mypy py_src/taskito/ --no-incremental` — clean
- [x] `cargo check --workspace` — clean
- [x] `grep -rn "import asyncio" py_src/taskito/ | grep -v -E "(async_support/|contrib/fastapi\.py)"` returns empty