### PR TITLE
fix(docs-next): scope basePath to production

### DIFF
--- a/docs-next/next.config.mjs
+++ b/docs-next/next.config.mjs
@@ -2,10 +2,16 @@ import { createMDX } from "fumadocs-mdx/next";
 
 const withMDX = createMDX();
 
+// `basePath` is only needed for the deployed GH Pages URL
+// (docs.byteveda.org/taskito). In dev (`pnpm dev`) it makes `localhost:3000`
+// 404 because the app moves to `localhost:3000/taskito`. Scope it to
+// production so dev hits the root.
+const isProd = process.env.NODE_ENV === "production";
+
 /** @type {import('next').NextConfig} */
 const config = {
   output: "export",
-  basePath: "/taskito",
+  basePath: isProd ? "/taskito" : "",
   reactStrictMode: true,
   images: {
     unoptimized: true,


### PR DESCRIPTION
`basePath: '/taskito'` was set unconditionally in PR #111 (Phase 1) so the deployed GH Pages site at `docs.byteveda.org/taskito` would resolve correctly. Side effect: `pnpm dev` returns 404 at `localhost:3000` because the dev server applies the basePath, so the home page lives at `localhost:3000/taskito` instead.

Wraps `basePath` with `process.env.NODE_ENV === 'production'` so:
- Dev: `localhost:3000` → home page (no prefix)
- Production: `/taskito` prefix preserved (GH Pages URL unchanged)

## Test plan

- [x] `pnpm build` — clean (production build still emits `/taskito`-prefixed paths)
- [x] Inspected `out/index.html` — still references `/taskito/_next/...` chunks correctly
- [ ] Manual smoke: `pnpm --dir docs-next dev` and confirm `localhost:3000` and `localhost:3000/docs` both render