### PR TITLE
feat(docs-next): polish landing page (phase 5)

### DIFF
--- a/docs-next/content/docs/guides/observability/meta.json
+++ b/docs-next/content/docs/guides/observability/meta.json
@@ -1,10 +1,4 @@
 {
   "title": "Observability",
-  "pages": [
-    "index",
-    "monitoring",
-    "logging",
-    "dashboard",
-    "dashboard-api"
-  ]
+  "pages": ["index", "monitoring", "logging", "dashboard", "dashboard-api"]
 }

--- a/docs-next/src/app/(home)/comparison.tsx
+++ b/docs-next/src/app/(home)/comparison.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useState } from "react";
+
+type Stack = "taskito" | "celery";
+
+const STACKS: Record<
+  Stack,
+  {
+    label: string;
+    services: string;
+    install: string;
+    code: string;
+  }
+> = {
+  taskito: {
+    label: "taskito",
+    services: "1 process",
+    install: "pip install taskito",
+    code: `from taskito import Queue
+
+queue = Queue(db_path="tasks.db")
+
+@queue.task(max_retries=3, rate_limit="100/m")
+def send_email(to, subject, body):
+    smtp.send(to, subject, body)
+
+# Enqueue
+send_email.delay("alice@example.com", "Hi", "Body")
+
+# Run the worker
+# $ taskito worker --app tasks:queue`,
+  },
+  celery: {
+    label: "Celery + Redis",
+    services: "3 processes (Redis + worker + beat)",
+    install: "pip install celery[redis]\n# also: install + run Redis server",
+    code: `from celery import Celery
+
+app = Celery(
+    "myapp",
+    broker="redis://localhost:6379/0",
+    backend="redis://localhost:6379/1",
+)
+app.conf.task_default_rate_limit = "100/m"
+
+@app.task(bind=True, max_retries=3)
+def send_email(self, to, subject, body):
+    try:
+        smtp.send(to, subject, body)
+    except SMTPError as exc:
+        raise self.retry(exc=exc, countdown=60)
+
+# Enqueue
+send_email.delay("alice@example.com", "Hi", "Body")
+
+# Run the worker (in a separate terminal, plus Redis)
+# $ celery -A myapp worker --loglevel=info`,
+  },
+};
+
+export function Comparison() {
+  const [stack, setStack] = useState<Stack>("taskito");
+  const data = STACKS[stack];
+
+  return (
+    <div className="rounded-lg border border-fd-border bg-fd-card overflow-hidden">
+      <div className="flex border-b border-fd-border" role="tablist">
+        {(Object.keys(STACKS) as Stack[]).map((key) => {
+          const active = stack === key;
+          return (
+            <button
+              key={key}
+              type="button"
+              role="tab"
+              aria-selected={active}
+              onClick={() => setStack(key)}
+              className={`flex-1 px-4 py-3 text-sm font-medium transition-colors ${
+                active
+                  ? "bg-fd-primary/10 text-fd-foreground border-b-2 border-fd-primary -mb-px"
+                  : "text-fd-muted-foreground hover:text-fd-foreground hover:bg-fd-accent/50"
+              }`}
+            >
+              {STACKS[key].label}
+            </button>
+          );
+        })}
+      </div>
+      <div className="grid sm:grid-cols-3 gap-px bg-fd-border">
+        <Stat label="Install" value={data.install} mono />
+        <Stat label="Services to run" value={data.services} />
+        <Stat
+          label="Background"
+          value={
+            stack === "taskito"
+              ? "Single Python process"
+              : "Worker process + Redis daemon"
+          }
+        />
+      </div>
+      <pre className="p-5 text-sm font-mono leading-relaxed overflow-x-auto bg-fd-card">
+        <code>{data.code}</code>
+      </pre>
+    </div>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  mono,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+}) {
+  return (
+    <div className="bg-fd-card px-4 py-3">
+      <div className="text-xs uppercase tracking-wider text-fd-muted-foreground mb-1">
+        {label}
+      </div>
+      <div
+        className={`text-sm whitespace-pre-line ${mono ? "font-mono" : "font-medium"}`}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}

--- a/docs-next/src/app/(home)/page.tsx
+++ b/docs-next/src/app/(home)/page.tsx
@@ -1,52 +1,238 @@
+import {
+  Activity,
+  ArrowRight,
+  Cpu,
+  Layers,
+  Shield,
+  Workflow,
+  Zap,
+} from "lucide-react";
 import Link from "next/link";
+import { Comparison } from "./comparison";
 
 export default function HomePage() {
   return (
     <main className="flex flex-col flex-1">
-      <section className="flex flex-col items-center justify-center text-center px-4 py-24 flex-1">
-        <h1 className="text-5xl font-bold tracking-tight mb-4">Taskito</h1>
-        <p className="text-xl text-fd-muted-foreground max-w-2xl mb-8">
-          Rust-powered task queue for Python. Replace Celery without Redis.
-          Start with SQLite, scale to Postgres. No broker required.
+      <Hero />
+      <Features />
+      <ComparisonSection />
+      <CTA />
+    </main>
+  );
+}
+
+function Hero() {
+  return (
+    <section className="relative px-4 pt-20 pb-24 sm:pt-28 sm:pb-32 overflow-hidden">
+      <div
+        aria-hidden
+        className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_50%_0%,var(--color-fd-primary)/10%,transparent_60%)]"
+      />
+      <div className="max-w-5xl mx-auto grid lg:grid-cols-[1.2fr,1fr] gap-12 items-center">
+        <div>
+          <div className="inline-flex items-center gap-2 rounded-full border border-fd-border bg-fd-card px-3 py-1 text-xs font-medium text-fd-muted-foreground mb-6">
+            <span className="size-1.5 rounded-full bg-fd-primary" />
+            v0.12 — Rust core, native async, DAG workflows
+          </div>
+          <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tight mb-5 leading-[1.05]">
+            Task queue
+            <br />
+            without the broker.
+          </h1>
+          <p className="text-lg sm:text-xl text-fd-muted-foreground max-w-xl mb-8 leading-relaxed">
+            Rust-powered task queue for Python. Replace Celery without Redis or
+            RabbitMQ. Start with SQLite, scale to Postgres.
+          </p>
+          <div className="flex flex-wrap gap-3">
+            <Link
+              href="/docs/getting-started/quickstart"
+              className="inline-flex items-center gap-2 rounded-md bg-fd-primary px-5 py-2.5 text-sm font-medium text-fd-primary-foreground hover:opacity-90 transition-opacity"
+            >
+              Quickstart
+              <ArrowRight className="size-4" />
+            </Link>
+            <Link
+              href="/docs/getting-started/installation"
+              className="inline-flex items-center gap-2 rounded-md border border-fd-border bg-fd-card px-5 py-2.5 text-sm font-medium hover:bg-fd-accent transition-colors"
+            >
+              Install
+            </Link>
+            <Link
+              href="https://github.com/ByteVeda/taskito"
+              className="inline-flex items-center gap-2 rounded-md px-5 py-2.5 text-sm font-medium text-fd-muted-foreground hover:text-fd-foreground transition-colors"
+            >
+              GitHub →
+            </Link>
+          </div>
+        </div>
+        <CodePreview />
+      </div>
+    </section>
+  );
+}
+
+function CodePreview() {
+  return (
+    <div className="rounded-lg border border-fd-border bg-fd-card overflow-hidden shadow-xl shadow-fd-primary/5">
+      <div className="flex items-center gap-2 px-4 py-2 border-b border-fd-border bg-fd-muted">
+        <div className="flex gap-1.5">
+          <div className="size-2.5 rounded-full bg-red-500/70" />
+          <div className="size-2.5 rounded-full bg-yellow-500/70" />
+          <div className="size-2.5 rounded-full bg-green-500/70" />
+        </div>
+        <span className="text-xs text-fd-muted-foreground ml-2 font-mono">
+          tasks.py
+        </span>
+      </div>
+      <pre className="p-5 text-sm font-mono leading-relaxed overflow-x-auto">
+        <code>
+          <span className="text-fd-muted-foreground">
+            # pip install taskito
+          </span>
+          {"\n"}
+          <span className="text-purple-500 dark:text-purple-400">from</span>{" "}
+          taskito{" "}
+          <span className="text-purple-500 dark:text-purple-400">import</span>{" "}
+          Queue{"\n\n"}
+          queue ={" "}
+          <span className="text-blue-500 dark:text-blue-400">Queue</span>
+          (db_path=
+          <span className="text-emerald-600 dark:text-emerald-400">
+            "tasks.db"
+          </span>
+          ){"\n\n"}
+          <span className="text-fd-muted-foreground">@queue.task()</span>
+          {"\n"}
+          <span className="text-purple-500 dark:text-purple-400">def</span>{" "}
+          <span className="text-blue-500 dark:text-blue-400">add</span>(a, b):
+          {"\n"}
+          {"    "}
+          <span className="text-purple-500 dark:text-purple-400">return</span> a
+          + b{"\n\n"}
+          job = add.
+          <span className="text-blue-500 dark:text-blue-400">delay</span>(
+          <span className="text-amber-600 dark:text-amber-400">2</span>,{" "}
+          <span className="text-amber-600 dark:text-amber-400">3</span>){"\n"}
+          <span className="text-fd-muted-foreground">print</span>(job.
+          <span className="text-blue-500 dark:text-blue-400">result</span>())
+          {"  "}
+          <span className="text-fd-muted-foreground"># 5</span>
+        </code>
+      </pre>
+    </div>
+  );
+}
+
+const FEATURES = [
+  {
+    icon: Zap,
+    title: "Brokerless",
+    body: "No Redis, no RabbitMQ. Everything in a single SQLite file — queue, results, rate limits, schedules. Just `pip install` and go.",
+  },
+  {
+    icon: Cpu,
+    title: "Rust-powered",
+    body: "The scheduler, dispatcher, and storage engine are all Rust. Tokio runtime, OS-thread worker pool, thin PyO3 boundary keeps the Python overhead negligible.",
+  },
+  {
+    icon: Activity,
+    title: "Async-first",
+    body: "`async def` tasks dispatch onto a dedicated event loop — no `asyncio.run()` wrapping, no thread-pool bridging. Sync and async tasks coexist transparently.",
+  },
+  {
+    icon: Workflow,
+    title: "DAG workflows",
+    body: "Multi-step pipelines as directed acyclic graphs. Fan-out, fan-in, conditions, approval gates, sub-workflows, incremental re-runs, Mermaid visualization.",
+  },
+  {
+    icon: Layers,
+    title: "Resource system",
+    body: "Inject database connections, HTTP clients, and cloud SDKs by name. Three-layer pipeline: argument interception, worker DI, transparent proxy reconstruction.",
+  },
+  {
+    icon: Shield,
+    title: "Production-ready",
+    body: "Retries with exponential backoff, dead letter queue, rate limits, circuit breakers, distributed locks, structured logs, OTel/Sentry/Prometheus middleware.",
+  },
+];
+
+function Features() {
+  return (
+    <section className="px-4 py-20 max-w-6xl mx-auto w-full">
+      <div className="text-center mb-12">
+        <h2 className="text-3xl sm:text-4xl font-bold tracking-tight mb-3">
+          What you get
+        </h2>
+        <p className="text-fd-muted-foreground text-lg">
+          The convenience of Celery, the performance of Rust, the simplicity of
+          SQLite.
         </p>
-        <div className="flex gap-3">
+      </div>
+      <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-5">
+        {FEATURES.map(({ icon: Icon, title, body }) => (
+          <div
+            key={title}
+            className="rounded-lg border border-fd-border bg-fd-card p-6 hover:border-fd-primary/40 transition-colors"
+          >
+            <div className="size-10 rounded-md bg-fd-primary/10 flex items-center justify-center mb-4">
+              <Icon className="size-5 text-fd-primary" />
+            </div>
+            <h3 className="text-lg font-semibold mb-2">{title}</h3>
+            <p className="text-sm text-fd-muted-foreground leading-relaxed">
+              {body}
+            </p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function ComparisonSection() {
+  return (
+    <section className="px-4 py-20 max-w-6xl mx-auto w-full">
+      <div className="text-center mb-12">
+        <h2 className="text-3xl sm:text-4xl font-bold tracking-tight mb-3">
+          Less to operate
+        </h2>
+        <p className="text-fd-muted-foreground text-lg">
+          The same task, two stacks. Pick the one with fewer moving parts.
+        </p>
+      </div>
+      <Comparison />
+    </section>
+  );
+}
+
+function CTA() {
+  return (
+    <section className="px-4 py-20 mb-12">
+      <div className="max-w-3xl mx-auto rounded-xl border border-fd-border bg-fd-card p-10 text-center">
+        <h2 className="text-2xl sm:text-3xl font-bold tracking-tight mb-3">
+          Five minutes from{" "}
+          <code className="font-mono text-fd-primary">pip install</code> to your
+          first job.
+        </h2>
+        <p className="text-fd-muted-foreground mb-7 max-w-xl mx-auto">
+          The quickstart walks you through defining a task, enqueuing it, and
+          watching the worker run it — no Redis, no broker, no config.
+        </p>
+        <div className="flex flex-wrap gap-3 justify-center">
           <Link
             href="/docs/getting-started/quickstart"
-            className="rounded-md bg-fd-primary px-5 py-2.5 text-fd-primary-foreground font-medium hover:opacity-90"
+            className="inline-flex items-center gap-2 rounded-md bg-fd-primary px-5 py-2.5 text-sm font-medium text-fd-primary-foreground hover:opacity-90 transition-opacity"
           >
-            Quickstart
+            Start the quickstart
+            <ArrowRight className="size-4" />
           </Link>
           <Link
-            href="/docs/getting-started/installation"
-            className="rounded-md border border-fd-border px-5 py-2.5 font-medium hover:bg-fd-accent"
+            href="/docs/more/comparison"
+            className="inline-flex items-center gap-2 rounded-md border border-fd-border px-5 py-2.5 text-sm font-medium hover:bg-fd-accent transition-colors"
           >
-            Install
+            See the full comparison
           </Link>
         </div>
-      </section>
-      <section className="grid sm:grid-cols-3 gap-6 px-4 py-16 max-w-6xl mx-auto w-full">
-        <div className="text-center">
-          <h3 className="text-lg font-semibold mb-2">Brokerless</h3>
-          <p className="text-sm text-fd-muted-foreground">
-            Start with SQLite, scale to Postgres. No Redis or RabbitMQ to
-            install, configure, or operate.
-          </p>
-        </div>
-        <div className="text-center">
-          <h3 className="text-lg font-semibold mb-2">Rust-powered</h3>
-          <p className="text-sm text-fd-muted-foreground">
-            Scheduler, dispatcher, and storage are Rust. Async worker pool,
-            native tokio runtime, thin PyO3 boundary.
-          </p>
-        </div>
-        <div className="text-center">
-          <h3 className="text-lg font-semibold mb-2">Python-native</h3>
-          <p className="text-sm text-fd-muted-foreground">
-            Decorate a function. Async tasks, periodic schedules, DAG workflows,
-            resource injection — all from a clean Python API.
-          </p>
-        </div>
-      </section>
-    </main>
+      </div>
+    </section>
   );
 }


### PR DESCRIPTION
Phase 5 of the docs migration. Replaces the Phase 1 stub home page (`src/app/(home)/page.tsx`) with a polished landing.

## Changes

- **Hero** — version pill (`v0.12 — Rust core, native async, DAG workflows`), bigger headline, code-preview pane with traffic-light header showing the minimal taskito example, three CTAs (Quickstart / Install / GitHub).
- **Feature grid** — 6 cards with lucide icons covering brokerless / Rust-powered / async-first / DAG workflows / resource system / production-ready. Each card has an accent-colored icon, hover affordance, and a tight 2-3 sentence pitch.
- **Comparison section** — new client component `comparison.tsx` with tabs for taskito vs Celery+Redis. Side-by-side install commands, services-to-run summary, and the same email task implemented in each stack.
- **CTA card** — closing rounded card pointing at the quickstart and full comparison page.
- **Lucide icon fix** — `Github` doesn't exist in `lucide-react@1.14.0` (the lucide team removed it for trademark reasons); replaced with text-only "GitHub →" link.
- **Lint clean** — biome auto-fixed import ordering, JSON formatting, template literals, and JSX whitespace. Two pre-existing scaffold-CSS `!important` warnings remain (intentional, they're for body-scroll-locked).

## What's NOT in here (deferred)

- Animated typing for the hero code preview — value/effort isn't there for v0.12. Static is fine.
- shadcn/ui setup — Tailwind primitives + lucide cover the landing page well enough; not worth the dependency surface. If we add a design system later it would benefit `docs/` MDX components more than this single page.
- Taskito logo SVG — placeholder still uses the Fumadocs scaffold logo. Logo work is separate.

## Test plan

- [x] `pnpm types:check` — clean
- [x] `pnpm lint` — exit 0 (2 known scaffold-CSS warnings, no errors)
- [x] `pnpm build` — clean, all routes generate
- [ ] CI: `Build Docs (Next)` job stays green
- [ ] Manual smoke once merged: open dev server, switch tabs in the comparison, verify CTAs all resolve, hover affordances on feature cards work, dark + light mode both look good

After this lands, only Phase 7 (cutover — repoint DNS, decommission Zensical, remove `docs/` and `zensical.toml`) remains.