### PR TITLE
docs: redesign landing comparison as side-by-side + table

### DIFF
--- a/docs/src/app/(home)/comparison.tsx
+++ b/docs/src/app/(home)/comparison.tsx
@@ -1,3 +1,5 @@
+import { highlight } from "fumadocs-core/highlight";
+
 const TASKITO_CODE = `from taskito import Queue
 
 queue = Queue(db_path="tasks.db")
@@ -59,7 +61,12 @@ const ROWS: { label: string; taskito: string; celery: string }[] = [
   },
 ];
 
-export function Comparison() {
+export async function Comparison() {
+  const [taskitoHighlighted, celeryHighlighted] = await Promise.all([
+    renderHighlighted(TASKITO_CODE),
+    renderHighlighted(CELERY_CODE),
+  ]);
+
   return (
     <div className="space-y-6">
       <div className="grid md:grid-cols-2 gap-4">
@@ -67,30 +74,52 @@ export function Comparison() {
           label="taskito"
           caption="Brokerless · single process"
           tone="primary"
-          code={TASKITO_CODE}
-        />
+        >
+          {taskitoHighlighted}
+        </CodePanel>
         <CodePanel
           label="Celery + Redis"
           caption="Requires Redis · 3 processes"
           tone="muted"
-          code={CELERY_CODE}
-        />
+        >
+          {celeryHighlighted}
+        </CodePanel>
       </div>
       <DifferentiatorTable />
     </div>
   );
 }
 
+async function renderHighlighted(code: string) {
+  return highlight(code, {
+    lang: "python",
+    themes: {
+      light: "github-light",
+      dark: "github-dark",
+    },
+    components: {
+      pre: ({ children, ...props }) => (
+        <pre
+          {...props}
+          className="p-5 text-sm leading-relaxed overflow-x-auto bg-fd-card"
+        >
+          {children}
+        </pre>
+      ),
+    },
+  });
+}
+
 function CodePanel({
   label,
   caption,
   tone,
-  code,
+  children,
 }: {
   label: string;
   caption: string;
   tone: Tone;
-  code: string;
+  children: React.ReactNode;
 }) {
   const accent =
     tone === "primary" ? "border-t-fd-primary" : "border-t-fd-border";
@@ -108,9 +137,7 @@ function CodePanel({
         </span>
         <span className="text-xs text-fd-muted-foreground">{caption}</span>
       </div>
-      <pre className="p-5 text-sm font-mono leading-relaxed overflow-x-auto bg-fd-card">
-        <code>{code}</code>
-      </pre>
+      {children}
     </div>
   );
 }

--- a/docs/src/app/(home)/comparison.tsx
+++ b/docs/src/app/(home)/comparison.tsx
@@ -1,23 +1,4 @@
-"use client";
-
-import { useState } from "react";
-
-type Stack = "taskito" | "celery";
-
-const STACKS: Record<
-  Stack,
-  {
-    label: string;
-    services: string;
-    install: string;
-    code: string;
-  }
-> = {
-  taskito: {
-    label: "taskito",
-    services: "1 process",
-    install: "pip install taskito",
-    code: `from taskito import Queue
+const TASKITO_CODE = `from taskito import Queue
 
 queue = Queue(db_path="tasks.db")
 
@@ -29,13 +10,9 @@ def send_email(to, subject, body):
 send_email.delay("alice@example.com", "Hi", "Body")
 
 # Run the worker
-# $ taskito worker --app tasks:queue`,
-  },
-  celery: {
-    label: "Celery + Redis",
-    services: "3 processes (Redis + worker + beat)",
-    install: "pip install celery[redis]\n# also: install + run Redis server",
-    code: `from celery import Celery
+# $ taskito worker --app tasks:queue`;
+
+const CELERY_CODE = `from celery import Celery
 
 app = Celery(
     "myapp",
@@ -55,75 +32,139 @@ def send_email(self, to, subject, body):
 send_email.delay("alice@example.com", "Hi", "Body")
 
 # Run the worker (in a separate terminal, plus Redis)
-# $ celery -A myapp worker --loglevel=info`,
+# $ celery -A myapp worker --loglevel=info`;
+
+type Tone = "primary" | "muted";
+
+const ROWS: { label: string; taskito: string; celery: string }[] = [
+  {
+    label: "Install",
+    taskito: "pip install taskito",
+    celery: "pip install celery[redis] + run Redis daemon",
   },
-};
+  {
+    label: "Background services",
+    taskito: "1 (worker)",
+    celery: "3 (worker, beat, Redis)",
+  },
+  {
+    label: "Default storage",
+    taskito: "SQLite file (built-in)",
+    celery: "Redis (separate daemon)",
+  },
+  {
+    label: "Retry config in the example above",
+    taskito: "max_retries=3 decorator arg",
+    celery: "try/except + self.retry(exc=…)",
+  },
+];
 
 export function Comparison() {
-  const [stack, setStack] = useState<Stack>("taskito");
-  const data = STACKS[stack];
-
   return (
-    <div className="rounded-lg border border-fd-border bg-fd-card overflow-hidden">
-      <div className="flex border-b border-fd-border" role="tablist">
-        {(Object.keys(STACKS) as Stack[]).map((key) => {
-          const active = stack === key;
-          return (
-            <button
-              key={key}
-              type="button"
-              role="tab"
-              aria-selected={active}
-              onClick={() => setStack(key)}
-              className={`flex-1 px-4 py-3 text-sm font-medium transition-colors ${
-                active
-                  ? "bg-fd-primary/10 text-fd-foreground border-b-2 border-fd-primary -mb-px"
-                  : "text-fd-muted-foreground hover:text-fd-foreground hover:bg-fd-accent/50"
-              }`}
-            >
-              {STACKS[key].label}
-            </button>
-          );
-        })}
-      </div>
-      <div className="grid sm:grid-cols-3 gap-px bg-fd-border">
-        <Stat label="Install" value={data.install} mono />
-        <Stat label="Services to run" value={data.services} />
-        <Stat
-          label="Background"
-          value={
-            stack === "taskito"
-              ? "Single Python process"
-              : "Worker process + Redis daemon"
-          }
+    <div className="space-y-6">
+      <div className="grid md:grid-cols-2 gap-4">
+        <CodePanel
+          label="taskito"
+          caption="Brokerless · single process"
+          tone="primary"
+          code={TASKITO_CODE}
+        />
+        <CodePanel
+          label="Celery + Redis"
+          caption="Requires Redis · 3 processes"
+          tone="muted"
+          code={CELERY_CODE}
         />
       </div>
+      <DifferentiatorTable />
+    </div>
+  );
+}
+
+function CodePanel({
+  label,
+  caption,
+  tone,
+  code,
+}: {
+  label: string;
+  caption: string;
+  tone: Tone;
+  code: string;
+}) {
+  const accent =
+    tone === "primary" ? "border-t-fd-primary" : "border-t-fd-border";
+  return (
+    <div
+      className={`rounded-lg border border-fd-border border-t-2 bg-fd-card overflow-hidden ${accent}`}
+    >
+      <div className="flex items-baseline justify-between px-4 py-3 border-b border-fd-border bg-fd-muted">
+        <span
+          className={`text-sm font-semibold ${
+            tone === "primary" ? "text-fd-primary" : "text-fd-foreground"
+          }`}
+        >
+          {label}
+        </span>
+        <span className="text-xs text-fd-muted-foreground">{caption}</span>
+      </div>
       <pre className="p-5 text-sm font-mono leading-relaxed overflow-x-auto bg-fd-card">
-        <code>{data.code}</code>
+        <code>{code}</code>
       </pre>
     </div>
   );
 }
 
-function Stat({
-  label,
-  value,
-  mono,
-}: {
-  label: string;
-  value: string;
-  mono?: boolean;
-}) {
+function DifferentiatorTable() {
   return (
-    <div className="bg-fd-card px-4 py-3">
-      <div className="text-xs uppercase tracking-wider text-fd-muted-foreground mb-1">
-        {label}
-      </div>
-      <div
-        className={`text-sm whitespace-pre-line ${mono ? "font-mono" : "font-medium"}`}
-      >
-        {value}
-      </div>
+    <div className="rounded-lg border border-fd-border bg-fd-card overflow-hidden">
+      <table className="w-full border-collapse text-xs sm:text-sm">
+        <thead>
+          <tr className="border-b border-fd-border bg-fd-muted">
+            <th
+              scope="col"
+              className="text-left px-4 py-3 font-medium text-fd-muted-foreground"
+            >
+              <span className="sr-only">Property</span>
+            </th>
+            <th
+              scope="col"
+              className="text-left px-4 py-3 font-semibold text-fd-primary"
+            >
+              taskito
+            </th>
+            <th
+              scope="col"
+              className="text-left px-4 py-3 font-semibold text-fd-foreground"
+            >
+              Celery + Redis
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {ROWS.map((row, i) => (
+            <tr
+              key={row.label}
+              className={
+                i < ROWS.length - 1 ? "border-b border-fd-border" : undefined
+              }
+            >
+              <th
+                scope="row"
+                className="text-left px-4 py-3 font-medium text-fd-muted-foreground align-top"
+              >
+                {row.label}
+              </th>
+              <td className="px-4 py-3 align-top text-fd-foreground">
+                {row.taskito}
+              </td>
+              <td className="px-4 py-3 align-top text-fd-muted-foreground">
+                {row.celery}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 }

--- a/docs/src/app/(home)/page.tsx
+++ b/docs/src/app/(home)/page.tsx
@@ -196,7 +196,7 @@ function ComparisonSection() {
           Less to operate
         </h2>
         <p className="text-fd-muted-foreground text-lg">
-          The same task, two stacks. Pick the one with fewer moving parts.
+          The same task, two stacks. Side by side, with the operational delta.
         </p>
       </div>
       <Comparison />


### PR DESCRIPTION
Reviewer feedback on the **"Less to operate"** section of the landing page:

> currently user cannot comprehend the benefit without comparing and using tabs its not giving a good look for the use case of comparing. Showcase in a table where user can clearly see that its better faster and more convenient.

The reviewer is right — tabs hide one side of a comparison while showing the other, which is the opposite of what a comparison wants. This PR replaces the tab UI with both panels visible at once, plus a small operational matrix below.

## What changes

### `docs/src/app/(home)/comparison.tsx` (full rewrite)

**Before** — tabbed: clicking a tab swaps the visible code block.

**After** — two `<CodePanel>` components rendered side by side on `md` and up, stacked vertically on mobile (taskito on top), followed by a 4-row `<table>` showing the operational delta:

| Property | taskito | Celery + Redis |
|---|---|---|
| Install | \`pip install taskito\` | \`pip install celery[redis]\` + run Redis daemon |
| Background services | 1 (worker) | 3 (worker, beat, Redis) |
| Default storage | SQLite file (built-in) | Redis (separate daemon) |
| Retry config in the example above | \`max_retries=3\` decorator arg | \`try/except\` + \`self.retry(exc=…)\` |

Last row points the reader's eye back at the literal difference visible in the code panels above it.

### Visual cues

- taskito panel gets a faint amber \`border-t-2 border-fd-primary\` accent + amber label text. Celery panel uses neutral \`border-fd-border\`. No checkmarks, no "✓ winner" iconography — the data speaks.
- Captions in the panel headers (\`Brokerless · single process\` vs \`Requires Redis · 3 processes\`) frame each side without bloating the chrome.

### Side wins

- Component is now **stateless** — dropped \`useState\`, dropped \`"use client"\`. Renders on the server, smaller client bundle.
- Dropped the previous 3-stat grid (\`Install\` / \`Services to run\` / \`Background\`) — the differentiator table carries the same information more legibly.
- Dropped the \`Stat\` helper component and tab-button plumbing.

### `docs/src/app/(home)/page.tsx`

Sub-copy under the **Less to operate** heading tweaked from *"The same task, two stacks. Pick the one with fewer moving parts."* → *"The same task, two stacks. Side by side, with the operational delta."* — frames the new layout instead of the old tab framing.

## Test plan

- [x] \`pnpm --dir docs types:check\` — clean
- [x] \`pnpm --dir docs lint\` — clean (2 known pre-existing scaffold-CSS warnings unchanged)
- [x] \`pnpm --dir docs build\` — clean static export
- [ ] CI: \`Deploy Docs\` job on this PR
- [ ] Manual visual check on the deploy preview / locally:
  - Both code blocks visible side by side at desktop width
  - taskito panel on the left has the amber top accent
  - Differentiator table below renders 4 rows with the right column emphasis
  - At 375px viewport: panels stack (taskito first), table stays legible
  - Dark mode: both panels and table respect theme tokens

## Non-goals

- Not adding a checkmark/cross "winner" column to the table — keeps it factual.
- Not duplicating the README's 13-row comparison matrix here — landing page wants the punch, full matrix lives at \`/docs/more/comparison\`.
- Not changing the section headline — "Less to operate" still works.