### PR TITLE
feat(docs): add How It Works job-flow strip

### DIFF
--- a/docs/biome.json
+++ b/docs/biome.json
@@ -7,7 +7,15 @@
   },
   "files": {
     "ignoreUnknown": true,
-    "includes": ["**", "!node_modules", "!.next", "!dist", "!build", "!.source"]
+    "includes": [
+      "**",
+      "!node_modules",
+      "!.next",
+      "!dist",
+      "!build",
+      "!.source",
+      "!src/app/global.css"
+    ]
   },
   "formatter": {
     "enabled": true,

--- a/docs/content/docs/api-reference/index.mdx
+++ b/docs/content/docs/api-reference/index.mdx
@@ -1,0 +1,77 @@
+---
+title: API Reference
+description: Every public class, method, and CLI command in taskito.
+---
+
+import { Cards, Card } from "fumadocs-ui/components/card";
+import {
+  Compass,
+  Inbox,
+  ListTodo,
+  CheckCircle2,
+  Variable,
+  GitFork,
+  Workflow,
+  TestTube,
+  Terminal,
+} from "lucide-react";
+
+Reference docs for everything taskito exposes. Each page lists the full
+signature, parameters, return values, and a short example.
+
+<Cards>
+  <Card
+    icon={<Compass />}
+    title="Overview"
+    href="/docs/api-reference/overview"
+    description="The shape of the public API — what's stable, what's experimental."
+  />
+  <Card
+    icon={<Inbox />}
+    title="Queue"
+    href="/docs/api-reference/queue"
+    description="Construct queues, enqueue jobs, manage workers, inspect state."
+  />
+  <Card
+    icon={<ListTodo />}
+    title="Task"
+    href="/docs/api-reference/task"
+    description="The @queue.task decorator — options, methods, async variants."
+  />
+  <Card
+    icon={<CheckCircle2 />}
+    title="Result"
+    href="/docs/api-reference/result"
+    description="JobResult, polling, awaiting, timeouts, sync and async APIs."
+  />
+  <Card
+    icon={<Variable />}
+    title="Context"
+    href="/docs/api-reference/context"
+    description="current_job — progress, logging, cancellation, timeouts inside a task."
+  />
+  <Card
+    icon={<GitFork />}
+    title="Canvas"
+    href="/docs/api-reference/canvas"
+    description="chain, group, chord — the Celery-compatible composition primitives."
+  />
+  <Card
+    icon={<Workflow />}
+    title="Workflows"
+    href="/docs/api-reference/workflows"
+    description="The DAG builder — fan-out, fan-in, gates, conditions, sub-workflows."
+  />
+  <Card
+    icon={<TestTube />}
+    title="Testing"
+    href="/docs/api-reference/testing"
+    description="test_mode, MockResource, fixtures for synchronous in-process verification."
+  />
+  <Card
+    icon={<Terminal />}
+    title="CLI"
+    href="/docs/api-reference/cli"
+    description="taskito worker, dashboard, info — every flag and subcommand."
+  />
+</Cards>

--- a/docs/content/docs/architecture/index.mdx
+++ b/docs/content/docs/architecture/index.mdx
@@ -1,0 +1,70 @@
+---
+title: Architecture
+description: How taskito works under the hood — Rust core, scheduler, storage, worker pool.
+---
+
+import { Cards, Card } from "fumadocs-ui/components/card";
+import {
+  Compass,
+  GitBranch,
+  Layers,
+  CalendarClock,
+  Database,
+  Boxes,
+  ShieldAlert,
+  FileCode2,
+} from "lucide-react";
+
+The internals, explained from the outside in. Start with **Overview** for the
+high-level model, then drill into the layer that interests you.
+
+<Cards>
+  <Card
+    icon={<Compass />}
+    title="Overview"
+    href="/docs/architecture/overview"
+    description="The big picture — Python ↔ PyO3 ↔ Rust core, end to end."
+  />
+  <Card
+    icon={<GitBranch />}
+    title="Job lifecycle"
+    href="/docs/architecture/job-lifecycle"
+    description="Every state a job moves through, from enqueue to result or dead letter."
+  />
+  <Card
+    icon={<Layers />}
+    title="Worker pool"
+    href="/docs/architecture/worker-pool"
+    description="OS-thread pool, prefork children, async executor — how each model dispatches work."
+  />
+  <Card
+    icon={<CalendarClock />}
+    title="Scheduler"
+    href="/docs/architecture/scheduler"
+    description="The Tokio polling loop — how jobs are picked, claimed, and routed to workers."
+  />
+  <Card
+    icon={<Database />}
+    title="Storage"
+    href="/docs/architecture/storage"
+    description="The Storage trait, Diesel for SQLite/Postgres, Redis backend, table schemas."
+  />
+  <Card
+    icon={<Boxes />}
+    title="Resources"
+    href="/docs/architecture/resources"
+    description="The 3-layer DI pipeline — argument interception, worker injection, proxy reconstruction."
+  />
+  <Card
+    icon={<ShieldAlert />}
+    title="Failure model"
+    href="/docs/architecture/failure-model"
+    description="Retries, dead letters, circuit breakers, cancellation — what happens when things go wrong."
+  />
+  <Card
+    icon={<FileCode2 />}
+    title="Serialization"
+    href="/docs/architecture/serialization"
+    description="Cloudpickle, JSON, MsgPack — how arguments and results cross the worker boundary."
+  />
+</Cards>

--- a/docs/content/docs/architecture/scheduler.mdx
+++ b/docs/content/docs/architecture/scheduler.mdx
@@ -5,7 +5,7 @@ description: "The Tokio-based poll loop that dequeues, dispatches, retries, and 
 
 The scheduler runs in a dedicated Tokio single-threaded async runtime:
 
-```
+```text
 loop {
     sleep(50ms) or shutdown signal
 
@@ -23,6 +23,28 @@ loop {
 }
 ```
 
+> **Why those numbers?** 50 ms is fast enough that dequeue latency is imperceptible
+> but slow enough to leave the CPU 99% idle when the queue is empty. The periodic
+> intervals (~60, ~100, ~1200) are deliberately coprime so the four maintenance
+> tasks rarely fire on the same tick — keeping each individual iteration cheap.
+
+## Polling cycle
+
+<Mermaid
+  chart={`flowchart LR
+    Tick(["loop tick"]) --> Sleep["sleep 50ms"]
+    Sleep --> Dispatch["try_dispatch()"]
+    Dispatch --> Periodic{"iteration<br/>multiple?"}
+    Periodic -->|"every ~60"| CP["check_periodic()"]
+    Periodic -->|"every ~100"| RS["reap_stale()"]
+    Periodic -->|"every ~1200"| AC["auto_cleanup()"]
+    Periodic -->|"otherwise"| Next["next tick"]
+    CP --> Next
+    RS --> Next
+    AC --> Next
+    Next --> Tick`}
+/>
+
 ## Dispatch flow
 
 1. `dequeue_from()` — atomically `SELECT` + `UPDATE` (pending → running) within a transaction.
@@ -30,3 +52,27 @@ loop {
 3. Send job to worker pool via `tokio::sync::mpsc` channel.
 4. Worker executes task, sends result back.
 5. `handle_result()` — mark complete, schedule retry, or move to DLQ.
+
+<Mermaid
+  chart={`sequenceDiagram
+    autonumber
+    participant S as Scheduler
+    participant DB as Storage
+    participant RL as RateLimiter
+    participant WP as WorkerPool
+    participant W as Worker
+
+    S->>DB: dequeue_from()
+    DB-->>S: pending job
+    S->>RL: check(task)
+    alt over limit
+        RL-->>S: limited
+        S->>DB: reschedule +1s
+    else under limit
+        RL-->>S: ok
+        S->>WP: mpsc.send(job)
+        WP->>W: execute()
+        W-->>S: result
+        S->>DB: handle_result()
+    end`}
+/>

--- a/docs/content/docs/architecture/storage.mdx
+++ b/docs/content/docs/architecture/storage.mdx
@@ -14,86 +14,122 @@ description: "SQLite pragmas, schema, indexes, connection pooling, and Postgres 
 
 ## Database schema
 
-<Mermaid
-  chart={`erDiagram
-    jobs {
-        TEXT id PK
-        TEXT queue
-        TEXT task_name
-        BLOB payload
-        INTEGER status
-        INTEGER priority
-        INTEGER created_at
-        INTEGER scheduled_at
-        INTEGER started_at
-        INTEGER completed_at
-        INTEGER retry_count
-        INTEGER max_retries
-        BLOB result
-        TEXT error
-        INTEGER timeout_ms
-        TEXT unique_key
-        INTEGER progress
-        TEXT metadata
-        BOOLEAN cancel_requested
-        INTEGER expires_at
-        INTEGER result_ttl_ms
-    }
+Six tables in the SQLite backend. Use the arrows or click a dot to flip between tables; the last slide shows their relationships.
 
-    dead_letter {
-        TEXT id PK
-        TEXT original_job_id
-        TEXT queue
-        TEXT task_name
-        BLOB payload
-        TEXT error
-        INTEGER retry_count
-        INTEGER failed_at
-        TEXT metadata
-        INTEGER priority
-        INTEGER max_retries
-        INTEGER timeout_ms
-        INTEGER result_ttl_ms
-    }
+<DiagramCarousel title="SQLite schema">
+  <DiagramSlide title="jobs">
+    <Mermaid
+      chart={`erDiagram
+        jobs {
+            TEXT id PK
+            TEXT queue
+            TEXT task_name
+            BLOB payload
+            INTEGER status
+            INTEGER priority
+            INTEGER created_at
+            INTEGER scheduled_at
+            INTEGER started_at
+            INTEGER completed_at
+            INTEGER retry_count
+            INTEGER max_retries
+            BLOB result
+            TEXT error
+            INTEGER timeout_ms
+            TEXT unique_key
+            INTEGER progress
+            TEXT metadata
+            BOOLEAN cancel_requested
+            INTEGER expires_at
+            INTEGER result_ttl_ms
+        }`}
+    />
+  </DiagramSlide>
 
-    job_errors {
-        TEXT id PK
-        TEXT job_id FK
-        INTEGER attempt
-        TEXT error
-        INTEGER failed_at
-    }
+  <DiagramSlide title="dead_letter">
+    <Mermaid
+      chart={`erDiagram
+        dead_letter {
+            TEXT id PK
+            TEXT original_job_id
+            TEXT queue
+            TEXT task_name
+            BLOB payload
+            TEXT error
+            INTEGER retry_count
+            INTEGER failed_at
+            TEXT metadata
+            INTEGER priority
+            INTEGER max_retries
+            INTEGER timeout_ms
+            INTEGER result_ttl_ms
+        }`}
+    />
+  </DiagramSlide>
 
-    rate_limits {
-        TEXT key PK
-        REAL tokens
-        REAL max_tokens
-        REAL refill_rate
-        INTEGER last_refill
-    }
+  <DiagramSlide title="job_errors">
+    <Mermaid
+      chart={`erDiagram
+        job_errors {
+            TEXT id PK
+            TEXT job_id FK
+            INTEGER attempt
+            TEXT error
+            INTEGER failed_at
+        }`}
+    />
+  </DiagramSlide>
 
-    periodic_tasks {
-        TEXT name PK
-        TEXT task_name
-        TEXT cron_expr
-        BLOB args
-        BLOB kwargs
-        TEXT queue
-        BOOLEAN enabled
-        INTEGER last_run
-        INTEGER next_run
-    }
+  <DiagramSlide title="rate_limits">
+    <Mermaid
+      chart={`erDiagram
+        rate_limits {
+            TEXT key PK
+            REAL tokens
+            REAL max_tokens
+            REAL refill_rate
+            INTEGER last_refill
+        }`}
+    />
+  </DiagramSlide>
 
-    workers {
-        TEXT worker_id PK
-        INTEGER last_heartbeat
-        TEXT queues
-        TEXT status
-    }
+  <DiagramSlide title="periodic_tasks">
+    <Mermaid
+      chart={`erDiagram
+        periodic_tasks {
+            TEXT name PK
+            TEXT task_name
+            TEXT cron_expr
+            BLOB args
+            BLOB kwargs
+            TEXT queue
+            BOOLEAN enabled
+            INTEGER last_run
+            INTEGER next_run
+        }`}
+    />
+  </DiagramSlide>
 
-    jobs ||--o{ job_errors : "error history"
-    jobs ||--o| dead_letter : "DLQ on exhaustion"`}
-/>
+  <DiagramSlide title="workers">
+    <Mermaid
+      chart={`erDiagram
+        workers {
+            TEXT worker_id PK
+            INTEGER last_heartbeat
+            TEXT queues
+            TEXT status
+        }`}
+    />
+  </DiagramSlide>
+
+  <DiagramSlide title="relationships">
+    <Mermaid
+      chart={`erDiagram
+        jobs ||--o{ job_errors : "error history"
+        jobs ||--o| dead_letter : "DLQ on exhaustion"`}
+    />
+  </DiagramSlide>
+</DiagramCarousel>
 
 ## Key indexes
 

--- a/docs/content/docs/guides/index.mdx
+++ b/docs/content/docs/guides/index.mdx
@@ -3,16 +3,75 @@ title: Guides
 description: Topical guides covering taskito's surface area.
 ---
 
-import { Cards, Card } from 'fumadocs-ui/components/card';
+import { Cards, Card } from "fumadocs-ui/components/card";
+import {
+  Boxes,
+  ShieldCheck,
+  Cpu,
+  Wrench,
+  Activity,
+  Layers,
+  Workflow,
+  Plug,
+  Puzzle,
+} from "lucide-react";
+
+Pick the topic you're working through. Each guide is self-contained, with code
+samples, gotchas, and links to the relevant API reference.
 
 <Cards>
-  <Card title="Core" href="/docs/guides/core" />
-  <Card title="Reliability" href="/docs/guides/reliability" />
-  <Card title="Advanced execution" href="/docs/guides/advanced-execution" />
-  <Card title="Operations" href="/docs/guides/operations" />
-  <Card title="Observability" href="/docs/guides/observability" />
-  <Card title="Resources" href="/docs/guides/resources" />
-  <Card title="Workflows" href="/docs/guides/workflows" />
-  <Card title="Integrations" href="/docs/guides/integrations" />
-  <Card title="Extensibility" href="/docs/guides/extensibility" />
+  <Card
+    icon={<Boxes />}
+    title="Core"
+    href="/docs/guides/core"
+    description="Define tasks, route to queues, run workers, schedule periodics."
+  />
+  <Card
+    icon={<ShieldCheck />}
+    title="Reliability"
+    href="/docs/guides/reliability"
+    description="Retries, dead letters, circuit breakers, idempotency, error handling."
+  />
+  <Card
+    icon={<Cpu />}
+    title="Advanced execution"
+    href="/docs/guides/advanced-execution"
+    description="Prefork pools, native async, streaming, cancellation, soft timeouts."
+  />
+  <Card
+    icon={<Wrench />}
+    title="Operations"
+    href="/docs/guides/operations"
+    description="Deployment, scaling, namespaces, migration from Celery."
+  />
+  <Card
+    icon={<Activity />}
+    title="Observability"
+    href="/docs/guides/observability"
+    description="Metrics, logs, dashboard, OpenTelemetry, Sentry, Prometheus."
+  />
+  <Card
+    icon={<Layers />}
+    title="Resources"
+    href="/docs/guides/resources"
+    description="Inject DB clients, HTTP sessions, and cloud SDKs by name with hot reload."
+  />
+  <Card
+    icon={<Workflow />}
+    title="Workflows"
+    href="/docs/guides/workflows"
+    description="DAGs, fan-out, fan-in, conditions, gates, sub-workflows, incremental re-runs."
+  />
+  <Card
+    icon={<Plug />}
+    title="Integrations"
+    href="/docs/guides/integrations"
+    description="Django, FastAPI, Flask — admin views, REST routers, management commands."
+  />
+  <Card
+    icon={<Puzzle />}
+    title="Extensibility"
+    href="/docs/guides/extensibility"
+    description="Custom serializers, middleware, events, webhooks, proxies."
+  />
 </Cards>

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -4,6 +4,7 @@ description: Rust-powered task queue for Python. No broker required.
 ---
 
 import { Cards, Card } from "fumadocs-ui/components/card";
+import { Rocket, BookOpen, Boxes, Code2 } from "lucide-react";
 
 A brokerless, Rust-powered task queue for Python. Replace Celery without Redis.
 
@@ -26,23 +27,27 @@ Python only runs during actual task execution.
 
 <Cards>
   <Card
+    icon={<Rocket />}
     title="Getting Started"
     href="/docs/getting-started/installation"
     description="Install and run your first task in 5 minutes."
   />
   <Card
+    icon={<BookOpen />}
     title="Guides"
     href="/docs/guides"
-    description="Core, reliability, advanced execution, operations, observability."
+    description="Topical walkthroughs grouped by intent — core, reliability, advanced execution, operations, more."
   />
   <Card
+    icon={<Boxes />}
     title="Architecture"
-    href="/docs/architecture/overview"
-    description="How taskito is built — Rust core, PyO3 boundary, storage layer."
+    href="/docs/architecture"
+    description="How the Rust core, scheduler, storage, and worker pool fit together."
   />
   <Card
+    icon={<Code2 />}
     title="API Reference"
-    href="/docs/api-reference/overview"
-    description="Complete API surface for the Queue, tasks, results, locks, and workflows."
+    href="/docs/api-reference"
+    description="Every public class, method, and CLI command with signatures and examples."
   />
 </Cards>

--- a/docs/src/app/(home)/_sections/how-it-works.tsx
+++ b/docs/src/app/(home)/_sections/how-it-works.tsx
@@ -1,0 +1,117 @@
+const STATIONS = [
+  { label: "enqueue", cx: 30 },
+  { label: "queue", cx: 110 },
+  { label: "worker", cx: 190 },
+  { label: "result", cx: 270 },
+] as const;
+
+const VIEW_WIDTH = 300;
+const TRACK_Y = 22;
+const STATION_RADIUS = 6;
+
+export function HowItWorks() {
+  return (
+    <section className="px-4 pb-16 max-w-3xl mx-auto w-full">
+      <div className="text-center mb-6">
+        <h2 className="text-xs uppercase tracking-[0.18em] text-fd-muted-foreground font-medium">
+          How it works
+        </h2>
+      </div>
+      <div className="flex justify-center">
+        <svg
+          role="img"
+          aria-label="Job lifecycle: a job travels from your code to the queue, to a worker, then back as a result"
+          viewBox={`0 0 ${VIEW_WIDTH} 56`}
+          className="w-full max-w-lg"
+        >
+          <line
+            x1={STATIONS[0].cx}
+            y1={TRACK_Y}
+            x2={STATIONS[STATIONS.length - 1].cx}
+            y2={TRACK_Y}
+            stroke="var(--color-fd-border)"
+            strokeWidth="1.5"
+            strokeDasharray="3 4"
+          />
+          {STATIONS.map((station) => (
+            <g key={station.label}>
+              <circle
+                cx={station.cx}
+                cy={TRACK_Y}
+                r={STATION_RADIUS}
+                fill="var(--color-fd-card)"
+                stroke="var(--color-fd-border)"
+                strokeWidth="1.5"
+              />
+              <text
+                x={station.cx}
+                y={TRACK_Y + 24}
+                textAnchor="middle"
+                fill="var(--color-fd-muted-foreground)"
+                fontSize="10"
+                fontWeight="500"
+                fontFamily="ui-sans-serif, system-ui, sans-serif"
+              >
+                {station.label}
+              </text>
+            </g>
+          ))}
+          <circle
+            className="taskito-job-pulse"
+            cx={STATIONS[0].cx}
+            cy={TRACK_Y}
+            r={STATION_RADIUS + 2}
+            fill="none"
+            stroke="var(--color-fd-primary)"
+            strokeWidth="1.25"
+            opacity="0"
+          />
+          <circle
+            className="taskito-job-dot"
+            cx={STATIONS[0].cx}
+            cy={TRACK_Y}
+            r="3.5"
+            fill="var(--color-fd-primary)"
+          />
+        </svg>
+      </div>
+      <style>{`
+        @keyframes taskito-job-travel {
+          0%   { cx: 30px; opacity: 0; }
+          5%   { cx: 30px; opacity: 1; }
+          22%  { cx: 110px; opacity: 1; }
+          32%  { cx: 110px; opacity: 1; }
+          47%  { cx: 190px; opacity: 1; }
+          57%  { cx: 190px; opacity: 1; }
+          74%  { cx: 270px; opacity: 1; }
+          88%  { cx: 270px; opacity: 1; }
+          94%  { cx: 270px; opacity: 0; }
+          100% { cx: 30px; opacity: 0; }
+        }
+        @keyframes taskito-station-pulse {
+          0%, 18%   { cx: 30px;  r: 8px;  opacity: 0; }
+          22%       { cx: 30px;  r: 12px; opacity: 0.6; }
+          26%       { cx: 30px;  r: 14px; opacity: 0; }
+          27%, 28%  { cx: 110px; r: 8px;  opacity: 0; }
+          32%       { cx: 110px; r: 12px; opacity: 0.6; }
+          36%       { cx: 110px; r: 14px; opacity: 0; }
+          37%, 53%  { cx: 190px; r: 8px;  opacity: 0; }
+          57%       { cx: 190px; r: 12px; opacity: 0.6; }
+          61%       { cx: 190px; r: 14px; opacity: 0; }
+          62%, 70%  { cx: 270px; r: 8px;  opacity: 0; }
+          74%       { cx: 270px; r: 12px; opacity: 0.6; }
+          78%       { cx: 270px; r: 14px; opacity: 0; }
+          100%      { cx: 270px; r: 8px;  opacity: 0; }
+        }
+        @media (prefers-reduced-motion: no-preference) {
+          .taskito-job-dot {
+            animation: taskito-job-travel 4.5s ease-in-out infinite;
+          }
+          .taskito-job-pulse {
+            animation: taskito-station-pulse 4.5s ease-in-out infinite;
+          }
+        }
+      `}</style>
+    </section>
+  );
+}

--- a/docs/src/app/(home)/_sections/how-it-works.tsx
+++ b/docs/src/app/(home)/_sections/how-it-works.tsx
@@ -72,11 +72,11 @@ export function HowItWorks() {
             <filter id="taskito-flow-sketch">
               <feTurbulence
                 type="fractalNoise"
-                baseFrequency="0.04"
+                baseFrequency="0.025"
                 numOctaves="2"
                 seed="3"
               />
-              <feDisplacementMap in="SourceGraphic" scale="1.4" />
+              <feDisplacementMap in="SourceGraphic" scale="0.7" />
             </filter>
             <marker
               id="taskito-flow-arrow"
@@ -90,8 +90,8 @@ export function HowItWorks() {
               <path
                 d="M 1 1 L 10 6 L 1 11"
                 fill="none"
-                stroke="var(--color-fd-sketch-strong)"
-                strokeWidth="1.6"
+                stroke="var(--color-fd-sketch-accent)"
+                strokeWidth="1.8"
                 strokeLinecap="round"
                 strokeLinejoin="round"
               />
@@ -107,8 +107,8 @@ export function HowItWorks() {
                 y1={TRACK_Y}
                 x2={next.cx - STATION_W / 2 - 8}
                 y2={TRACK_Y}
-                stroke="var(--color-fd-sketch)"
-                strokeWidth="1.5"
+                stroke="var(--color-fd-sketch-accent)"
+                strokeWidth="1.75"
                 strokeLinecap="round"
                 strokeDasharray="2 5"
                 markerEnd="url(#taskito-flow-arrow)"
@@ -154,7 +154,7 @@ function StationNode({ station }: { station: Station }) {
         rx="6"
         fill="var(--color-fd-card)"
         stroke="var(--color-fd-sketch-strong)"
-        strokeWidth="1.75"
+        strokeWidth="2.25"
         filter="url(#taskito-flow-sketch)"
       />
       <g

--- a/docs/src/app/(home)/_sections/how-it-works.tsx
+++ b/docs/src/app/(home)/_sections/how-it-works.tsx
@@ -1,117 +1,371 @@
-const STATIONS = [
-  { label: "enqueue", cx: 30 },
-  { label: "queue", cx: 110 },
-  { label: "worker", cx: 190 },
-  { label: "result", cx: 270 },
-] as const;
+import type { ReactNode } from "react";
 
-const VIEW_WIDTH = 300;
-const TRACK_Y = 22;
-const STATION_RADIUS = 6;
+type Station = {
+  id: string;
+  label: string;
+  hint: string;
+  cx: number;
+  glyph: ReactNode;
+};
+
+const VIEW_WIDTH = 380;
+const TRACK_Y = 36;
+const STATION_RADIUS = 14;
+
+const STATIONS: Station[] = [
+  {
+    id: "enqueue",
+    label: "enqueue",
+    hint: ".delay()",
+    cx: 40,
+    glyph: <CodeGlyph />,
+  },
+  {
+    id: "queue",
+    label: "queue",
+    hint: "SQLite · Postgres",
+    cx: 145,
+    glyph: <DatabaseGlyph />,
+  },
+  {
+    id: "worker",
+    label: "worker",
+    hint: "Rust pool",
+    cx: 250,
+    glyph: <WorkerGlyph />,
+  },
+  {
+    id: "result",
+    label: "result",
+    hint: ".result()",
+    cx: 340,
+    glyph: <CheckGlyph />,
+  },
+];
+
+const JOB_DELAYS = ["0s", "-1.6s", "-3.2s"] as const;
 
 export function HowItWorks() {
   return (
-    <section className="px-4 pb-16 max-w-3xl mx-auto w-full">
-      <div className="text-center mb-6">
-        <h2 className="text-xs uppercase tracking-[0.18em] text-fd-muted-foreground font-medium">
+    <section className="px-4 pb-20 max-w-3xl mx-auto w-full">
+      <div className="text-center mb-8">
+        <h2 className="text-xs uppercase tracking-[0.2em] text-fd-muted-foreground font-semibold mb-1">
           How it works
         </h2>
+        <p className="text-sm text-fd-muted-foreground/70">
+          Your code calls{" "}
+          <code className="font-mono text-fd-primary/80">.delay()</code> · the
+          job durably queues · a Rust scheduler routes it · a worker returns the
+          result.
+        </p>
       </div>
       <div className="flex justify-center">
         <svg
           role="img"
-          aria-label="Job lifecycle: a job travels from your code to the queue, to a worker, then back as a result"
-          viewBox={`0 0 ${VIEW_WIDTH} 56`}
-          className="w-full max-w-lg"
+          aria-label="Job lifecycle: enqueue from your code, durable queue, Rust worker pool, result returned"
+          viewBox={`0 0 ${VIEW_WIDTH} 88`}
+          className="w-full max-w-2xl taskito-flow"
         >
+          <defs>
+            <linearGradient
+              id="taskito-track-gradient"
+              x1="0"
+              y1="0"
+              x2={VIEW_WIDTH}
+              y2="0"
+              gradientUnits="userSpaceOnUse"
+            >
+              <stop offset="0" stopColor="var(--color-fd-border)" />
+              <stop
+                offset="0.5"
+                stopColor="var(--color-fd-primary)"
+                stopOpacity="0.4"
+              />
+              <stop offset="1" stopColor="var(--color-fd-border)" />
+            </linearGradient>
+            <radialGradient id="taskito-job-aura" cx="0.5" cy="0.5" r="0.5">
+              <stop
+                offset="0"
+                stopColor="var(--color-fd-primary)"
+                stopOpacity="0.7"
+              />
+              <stop
+                offset="1"
+                stopColor="var(--color-fd-primary)"
+                stopOpacity="0"
+              />
+            </radialGradient>
+          </defs>
+
+          <BackgroundGrid />
+
           <line
             x1={STATIONS[0].cx}
             y1={TRACK_Y}
             x2={STATIONS[STATIONS.length - 1].cx}
             y2={TRACK_Y}
-            stroke="var(--color-fd-border)"
+            stroke="url(#taskito-track-gradient)"
             strokeWidth="1.5"
-            strokeDasharray="3 4"
+            strokeDasharray="3 5"
+            className="taskito-track"
           />
+
           {STATIONS.map((station) => (
-            <g key={station.label}>
+            <StationNode key={station.id} station={station} />
+          ))}
+
+          {JOB_DELAYS.map((delay, index) => (
+            <g
+              // biome-ignore lint/suspicious/noArrayIndexKey: stable phased delays
+              key={index}
+              style={{ animationDelay: delay }}
+              className="taskito-job"
+            >
               <circle
-                cx={station.cx}
+                cx={STATIONS[0].cx}
                 cy={TRACK_Y}
-                r={STATION_RADIUS}
-                fill="var(--color-fd-card)"
-                stroke="var(--color-fd-border)"
-                strokeWidth="1.5"
+                r="9"
+                fill="url(#taskito-job-aura)"
+                className="taskito-job-aura"
               />
-              <text
-                x={station.cx}
-                y={TRACK_Y + 24}
-                textAnchor="middle"
-                fill="var(--color-fd-muted-foreground)"
-                fontSize="10"
-                fontWeight="500"
-                fontFamily="ui-sans-serif, system-ui, sans-serif"
-              >
-                {station.label}
-              </text>
+              <circle
+                cx={STATIONS[0].cx}
+                cy={TRACK_Y}
+                r="3.5"
+                fill="var(--color-fd-primary)"
+                className="taskito-job-dot"
+              />
             </g>
           ))}
-          <circle
-            className="taskito-job-pulse"
-            cx={STATIONS[0].cx}
-            cy={TRACK_Y}
-            r={STATION_RADIUS + 2}
-            fill="none"
-            stroke="var(--color-fd-primary)"
-            strokeWidth="1.25"
-            opacity="0"
-          />
-          <circle
-            className="taskito-job-dot"
-            cx={STATIONS[0].cx}
-            cy={TRACK_Y}
-            r="3.5"
-            fill="var(--color-fd-primary)"
-          />
         </svg>
       </div>
-      <style>{`
-        @keyframes taskito-job-travel {
-          0%   { cx: 30px; opacity: 0; }
-          5%   { cx: 30px; opacity: 1; }
-          22%  { cx: 110px; opacity: 1; }
-          32%  { cx: 110px; opacity: 1; }
-          47%  { cx: 190px; opacity: 1; }
-          57%  { cx: 190px; opacity: 1; }
-          74%  { cx: 270px; opacity: 1; }
-          88%  { cx: 270px; opacity: 1; }
-          94%  { cx: 270px; opacity: 0; }
-          100% { cx: 30px; opacity: 0; }
-        }
-        @keyframes taskito-station-pulse {
-          0%, 18%   { cx: 30px;  r: 8px;  opacity: 0; }
-          22%       { cx: 30px;  r: 12px; opacity: 0.6; }
-          26%       { cx: 30px;  r: 14px; opacity: 0; }
-          27%, 28%  { cx: 110px; r: 8px;  opacity: 0; }
-          32%       { cx: 110px; r: 12px; opacity: 0.6; }
-          36%       { cx: 110px; r: 14px; opacity: 0; }
-          37%, 53%  { cx: 190px; r: 8px;  opacity: 0; }
-          57%       { cx: 190px; r: 12px; opacity: 0.6; }
-          61%       { cx: 190px; r: 14px; opacity: 0; }
-          62%, 70%  { cx: 270px; r: 8px;  opacity: 0; }
-          74%       { cx: 270px; r: 12px; opacity: 0.6; }
-          78%       { cx: 270px; r: 14px; opacity: 0; }
-          100%      { cx: 270px; r: 8px;  opacity: 0; }
-        }
-        @media (prefers-reduced-motion: no-preference) {
-          .taskito-job-dot {
-            animation: taskito-job-travel 4.5s ease-in-out infinite;
-          }
-          .taskito-job-pulse {
-            animation: taskito-station-pulse 4.5s ease-in-out infinite;
-          }
-        }
-      `}</style>
+      <FlowStyles />
     </section>
+  );
+}
+
+function StationNode({ station }: { station: Station }) {
+  const isWorker = station.id === "worker";
+  const isResult = station.id === "result";
+  return (
+    <g className="taskito-station">
+      <circle
+        cx={station.cx}
+        cy={TRACK_Y}
+        r={STATION_RADIUS}
+        fill="var(--color-fd-card)"
+        stroke="var(--color-fd-border)"
+        strokeWidth="1.5"
+      />
+      {isWorker ? (
+        <circle
+          cx={station.cx}
+          cy={TRACK_Y}
+          r={STATION_RADIUS + 3}
+          fill="none"
+          stroke="var(--color-fd-primary)"
+          strokeWidth="1.5"
+          strokeDasharray="4 6"
+          className="taskito-worker-spinner"
+          style={{ transformOrigin: `${station.cx}px ${TRACK_Y}px` }}
+        />
+      ) : null}
+      {isResult ? (
+        <circle
+          cx={station.cx}
+          cy={TRACK_Y}
+          r={STATION_RADIUS + 4}
+          fill="none"
+          stroke="var(--color-fd-primary)"
+          strokeWidth="1"
+          opacity="0"
+          className="taskito-result-pulse"
+        />
+      ) : null}
+      <g
+        transform={`translate(${station.cx - 7}, ${TRACK_Y - 7})`}
+        className="taskito-station-glyph"
+      >
+        {station.glyph}
+      </g>
+      <text
+        x={station.cx}
+        y={TRACK_Y + 26}
+        textAnchor="middle"
+        fill="var(--color-fd-foreground)"
+        fontSize="10"
+        fontWeight="600"
+        fontFamily="ui-sans-serif, system-ui, sans-serif"
+        className="taskito-station-label"
+      >
+        {station.label}
+      </text>
+      <text
+        x={station.cx}
+        y={TRACK_Y + 39}
+        textAnchor="middle"
+        fill="var(--color-fd-muted-foreground)"
+        fontSize="8"
+        fontFamily="ui-monospace, SFMono-Regular, monospace"
+        opacity="0.7"
+      >
+        {station.hint}
+      </text>
+    </g>
+  );
+}
+
+function BackgroundGrid() {
+  const dots = [];
+  const step = 14;
+  for (let x = 8; x < VIEW_WIDTH; x += step) {
+    for (let y = 4; y < 84; y += step) {
+      dots.push(
+        <circle
+          key={`${x}-${y}`}
+          cx={x}
+          cy={y}
+          r="0.7"
+          fill="var(--color-fd-muted-foreground)"
+          opacity="0.08"
+        />,
+      );
+    }
+  }
+  return <g aria-hidden>{dots}</g>;
+}
+
+function CodeGlyph() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="var(--color-fd-foreground)"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      role="img"
+    >
+      <title>code</title>
+      <polyline points="16 18 22 12 16 6" />
+      <polyline points="8 6 2 12 8 18" />
+    </svg>
+  );
+}
+
+function DatabaseGlyph() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="var(--color-fd-foreground)"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      role="img"
+    >
+      <title>database</title>
+      <ellipse cx="12" cy="5" rx="9" ry="3" />
+      <path d="M3 5v14a9 3 0 0 0 18 0V5" />
+      <path d="M3 12a9 3 0 0 0 18 0" />
+    </svg>
+  );
+}
+
+function WorkerGlyph() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="var(--color-fd-foreground)"
+      role="img"
+    >
+      <title>worker pool</title>
+      <circle cx="6" cy="12" r="2.4" />
+      <circle cx="12" cy="12" r="2.4" />
+      <circle cx="18" cy="12" r="2.4" />
+    </svg>
+  );
+}
+
+function CheckGlyph() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="var(--color-fd-primary)"
+      strokeWidth="2.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      role="img"
+    >
+      <title>check</title>
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+}
+
+function FlowStyles() {
+  return (
+    <style>{`
+      .taskito-flow .taskito-station {
+        transition: transform 200ms ease;
+      }
+      .taskito-flow .taskito-station:hover {
+        transform: translateY(-1px);
+      }
+      .taskito-flow .taskito-station:hover .taskito-station-label {
+        fill: var(--color-fd-primary);
+      }
+      @keyframes taskito-job-travel {
+        0%   { cx: 40px;  opacity: 0; }
+        4%   { opacity: 1; }
+        25%  { cx: 145px; opacity: 1; }
+        33%  { cx: 145px; opacity: 1; }
+        50%  { cx: 250px; opacity: 1; }
+        58%  { cx: 250px; opacity: 1; }
+        80%  { cx: 340px; opacity: 1; }
+        92%  { opacity: 0; }
+        100% { cx: 40px;  opacity: 0; }
+      }
+      @keyframes taskito-worker-spin {
+        from { transform: rotate(0deg); }
+        to   { transform: rotate(360deg); }
+      }
+      @keyframes taskito-result-pulse {
+        0%, 70% { r: 18px; opacity: 0; }
+        80%     { r: 18px; opacity: 0.6; }
+        100%    { r: 26px; opacity: 0; }
+      }
+      @keyframes taskito-track-shimmer {
+        0%   { stroke-dashoffset: 0; }
+        100% { stroke-dashoffset: -16; }
+      }
+      @media (prefers-reduced-motion: no-preference) {
+        .taskito-flow .taskito-job-dot {
+          animation: taskito-job-travel 4.8s cubic-bezier(0.45, 0.05, 0.55, 0.95) infinite;
+          filter: drop-shadow(0 0 3px var(--color-fd-primary));
+        }
+        .taskito-flow .taskito-job-aura {
+          animation: taskito-job-travel 4.8s cubic-bezier(0.45, 0.05, 0.55, 0.95) infinite;
+        }
+        .taskito-flow .taskito-worker-spinner {
+          animation: taskito-worker-spin 6s linear infinite;
+        }
+        .taskito-flow .taskito-result-pulse {
+          animation: taskito-result-pulse 4.8s ease-out infinite;
+        }
+        .taskito-flow .taskito-track {
+          animation: taskito-track-shimmer 1.6s linear infinite;
+        }
+      }
+    `}</style>
   );
 }

--- a/docs/src/app/(home)/_sections/how-it-works.tsx
+++ b/docs/src/app/(home)/_sections/how-it-works.tsx
@@ -184,7 +184,7 @@ function StationNode({ station }: { station: Station }) {
         fill="var(--color-fd-foreground)"
         fontSize="16"
         fontWeight="600"
-        fontFamily="var(--font-handwritten), Caveat, cursive"
+        fontFamily="var(--font-handwritten), 'Shantell Sans', cursive"
       >
         {station.label}
       </text>

--- a/docs/src/app/(home)/_sections/how-it-works.tsx
+++ b/docs/src/app/(home)/_sections/how-it-works.tsx
@@ -8,53 +8,55 @@ type Station = {
   glyph: ReactNode;
 };
 
-const VIEW_WIDTH = 380;
-const TRACK_Y = 36;
-const STATION_RADIUS = 14;
+const VIEW_W = 460;
+const VIEW_H = 130;
+const TRACK_Y = 50;
+const STATION_W = 56;
+const STATION_H = 44;
 
 const STATIONS: Station[] = [
   {
     id: "enqueue",
     label: "enqueue",
     hint: ".delay()",
-    cx: 40,
+    cx: 56,
     glyph: <CodeGlyph />,
   },
   {
     id: "queue",
     label: "queue",
     hint: "SQLite · Postgres",
-    cx: 145,
+    cx: 184,
     glyph: <DatabaseGlyph />,
   },
   {
     id: "worker",
     label: "worker",
     hint: "Rust pool",
-    cx: 250,
+    cx: 304,
     glyph: <WorkerGlyph />,
   },
   {
     id: "result",
     label: "result",
     hint: ".result()",
-    cx: 340,
+    cx: 412,
     glyph: <CheckGlyph />,
   },
 ];
 
-const JOB_DELAYS = ["0s", "-1.6s", "-3.2s"] as const;
+const JOB_DELAYS = ["0s", "-1.7s", "-3.4s"] as const;
 
 export function HowItWorks() {
   return (
     <section className="px-4 pb-20 max-w-3xl mx-auto w-full">
-      <div className="text-center mb-8">
-        <h2 className="text-xs uppercase tracking-[0.2em] text-fd-muted-foreground font-semibold mb-1">
-          How it works
+      <div className="text-center mb-10">
+        <h2 className="font-handwritten text-3xl sm:text-4xl text-fd-foreground mb-2">
+          how it works
         </h2>
-        <p className="text-sm text-fd-muted-foreground/70">
+        <p className="text-sm text-fd-muted-foreground">
           Your code calls{" "}
-          <code className="font-mono text-fd-primary/80">.delay()</code> · the
+          <code className="font-mono text-fd-primary/90">.delay()</code> · the
           job durably queues · a Rust scheduler routes it · a worker returns the
           result.
         </p>
@@ -63,79 +65,73 @@ export function HowItWorks() {
         <svg
           role="img"
           aria-label="Job lifecycle: enqueue from your code, durable queue, Rust worker pool, result returned"
-          viewBox={`0 0 ${VIEW_WIDTH} 88`}
+          viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
           className="w-full max-w-2xl taskito-flow"
         >
           <defs>
-            <linearGradient
-              id="taskito-track-gradient"
-              x1="0"
-              y1="0"
-              x2={VIEW_WIDTH}
-              y2="0"
-              gradientUnits="userSpaceOnUse"
+            <filter id="taskito-flow-sketch">
+              <feTurbulence
+                type="fractalNoise"
+                baseFrequency="0.04"
+                numOctaves="2"
+                seed="3"
+              />
+              <feDisplacementMap in="SourceGraphic" scale="1.4" />
+            </filter>
+            <marker
+              id="taskito-flow-arrow"
+              viewBox="0 0 12 12"
+              refX="9"
+              refY="6"
+              markerWidth="6"
+              markerHeight="6"
+              orient="auto"
             >
-              <stop offset="0" stopColor="var(--color-fd-border)" />
-              <stop
-                offset="0.5"
-                stopColor="var(--color-fd-primary)"
-                stopOpacity="0.4"
+              <path
+                d="M 1 1 L 10 6 L 1 11"
+                fill="none"
+                stroke="var(--color-fd-sketch-strong)"
+                strokeWidth="1.6"
+                strokeLinecap="round"
+                strokeLinejoin="round"
               />
-              <stop offset="1" stopColor="var(--color-fd-border)" />
-            </linearGradient>
-            <radialGradient id="taskito-job-aura" cx="0.5" cy="0.5" r="0.5">
-              <stop
-                offset="0"
-                stopColor="var(--color-fd-primary)"
-                stopOpacity="0.7"
-              />
-              <stop
-                offset="1"
-                stopColor="var(--color-fd-primary)"
-                stopOpacity="0"
-              />
-            </radialGradient>
+            </marker>
           </defs>
 
-          <BackgroundGrid />
-
-          <line
-            x1={STATIONS[0].cx}
-            y1={TRACK_Y}
-            x2={STATIONS[STATIONS.length - 1].cx}
-            y2={TRACK_Y}
-            stroke="url(#taskito-track-gradient)"
-            strokeWidth="1.5"
-            strokeDasharray="3 5"
-            className="taskito-track"
-          />
+          {STATIONS.slice(0, -1).map((station, i) => {
+            const next = STATIONS[i + 1];
+            return (
+              <line
+                key={station.id}
+                x1={station.cx + STATION_W / 2 + 4}
+                y1={TRACK_Y}
+                x2={next.cx - STATION_W / 2 - 8}
+                y2={TRACK_Y}
+                stroke="var(--color-fd-sketch)"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeDasharray="2 5"
+                markerEnd="url(#taskito-flow-arrow)"
+                filter="url(#taskito-flow-sketch)"
+              />
+            );
+          })}
 
           {STATIONS.map((station) => (
             <StationNode key={station.id} station={station} />
           ))}
 
           {JOB_DELAYS.map((delay, index) => (
-            <g
-              // biome-ignore lint/suspicious/noArrayIndexKey: stable phased delays
+            <circle
+              // biome-ignore lint/suspicious/noArrayIndexKey: stable list
               key={index}
+              cx={STATIONS[0].cx}
+              cy={TRACK_Y}
+              r="4"
+              fill="var(--color-fd-primary)"
+              className="taskito-flow-job"
               style={{ animationDelay: delay }}
-              className="taskito-job"
-            >
-              <circle
-                cx={STATIONS[0].cx}
-                cy={TRACK_Y}
-                r="9"
-                fill="url(#taskito-job-aura)"
-                className="taskito-job-aura"
-              />
-              <circle
-                cx={STATIONS[0].cx}
-                cy={TRACK_Y}
-                r="3.5"
-                fill="var(--color-fd-primary)"
-                className="taskito-job-dot"
-              />
-            </g>
+            />
           ))}
         </svg>
       </div>
@@ -146,66 +142,58 @@ export function HowItWorks() {
 
 function StationNode({ station }: { station: Station }) {
   const isWorker = station.id === "worker";
-  const isResult = station.id === "result";
+  const x = station.cx - STATION_W / 2;
+  const y = TRACK_Y - STATION_H / 2;
   return (
-    <g className="taskito-station">
-      <circle
-        cx={station.cx}
-        cy={TRACK_Y}
-        r={STATION_RADIUS}
+    <g className="taskito-flow-station">
+      <rect
+        x={x}
+        y={y}
+        width={STATION_W}
+        height={STATION_H}
+        rx="6"
         fill="var(--color-fd-card)"
-        stroke="var(--color-fd-border)"
-        strokeWidth="1.5"
+        stroke="var(--color-fd-sketch-strong)"
+        strokeWidth="1.75"
+        filter="url(#taskito-flow-sketch)"
       />
+      <g
+        transform={`translate(${station.cx - 8}, ${TRACK_Y - 8})`}
+        className="taskito-flow-station-glyph"
+      >
+        {station.glyph}
+      </g>
       {isWorker ? (
         <circle
           cx={station.cx}
           cy={TRACK_Y}
-          r={STATION_RADIUS + 3}
+          r={STATION_W / 2 + 4}
           fill="none"
           stroke="var(--color-fd-primary)"
-          strokeWidth="1.5"
-          strokeDasharray="4 6"
-          className="taskito-worker-spinner"
+          strokeWidth="1.4"
+          strokeDasharray="3 6"
+          opacity="0.7"
+          className="taskito-flow-worker-spinner"
           style={{ transformOrigin: `${station.cx}px ${TRACK_Y}px` }}
         />
       ) : null}
-      {isResult ? (
-        <circle
-          cx={station.cx}
-          cy={TRACK_Y}
-          r={STATION_RADIUS + 4}
-          fill="none"
-          stroke="var(--color-fd-primary)"
-          strokeWidth="1"
-          opacity="0"
-          className="taskito-result-pulse"
-        />
-      ) : null}
-      <g
-        transform={`translate(${station.cx - 7}, ${TRACK_Y - 7})`}
-        className="taskito-station-glyph"
-      >
-        {station.glyph}
-      </g>
       <text
         x={station.cx}
-        y={TRACK_Y + 26}
+        y={TRACK_Y + STATION_H / 2 + 18}
         textAnchor="middle"
         fill="var(--color-fd-foreground)"
-        fontSize="10"
+        fontSize="16"
         fontWeight="600"
-        fontFamily="ui-sans-serif, system-ui, sans-serif"
-        className="taskito-station-label"
+        fontFamily="var(--font-handwritten), Caveat, cursive"
       >
         {station.label}
       </text>
       <text
         x={station.cx}
-        y={TRACK_Y + 39}
+        y={TRACK_Y + STATION_H / 2 + 32}
         textAnchor="middle"
         fill="var(--color-fd-muted-foreground)"
-        fontSize="8"
+        fontSize="9"
         fontFamily="ui-monospace, SFMono-Regular, monospace"
         opacity="0.7"
       >
@@ -215,31 +203,11 @@ function StationNode({ station }: { station: Station }) {
   );
 }
 
-function BackgroundGrid() {
-  const dots = [];
-  const step = 14;
-  for (let x = 8; x < VIEW_WIDTH; x += step) {
-    for (let y = 4; y < 84; y += step) {
-      dots.push(
-        <circle
-          key={`${x}-${y}`}
-          cx={x}
-          cy={y}
-          r="0.7"
-          fill="var(--color-fd-muted-foreground)"
-          opacity="0.08"
-        />,
-      );
-    }
-  }
-  return <g aria-hidden>{dots}</g>;
-}
-
 function CodeGlyph() {
   return (
     <svg
-      width="14"
-      height="14"
+      width="16"
+      height="16"
       viewBox="0 0 24 24"
       fill="none"
       stroke="var(--color-fd-foreground)"
@@ -258,8 +226,8 @@ function CodeGlyph() {
 function DatabaseGlyph() {
   return (
     <svg
-      width="14"
-      height="14"
+      width="16"
+      height="16"
       viewBox="0 0 24 24"
       fill="none"
       stroke="var(--color-fd-foreground)"
@@ -279,8 +247,8 @@ function DatabaseGlyph() {
 function WorkerGlyph() {
   return (
     <svg
-      width="14"
-      height="14"
+      width="16"
+      height="16"
       viewBox="0 0 24 24"
       fill="var(--color-fd-foreground)"
       role="img"
@@ -296,8 +264,8 @@ function WorkerGlyph() {
 function CheckGlyph() {
   return (
     <svg
-      width="14"
-      height="14"
+      width="16"
+      height="16"
       viewBox="0 0 24 24"
       fill="none"
       stroke="var(--color-fd-primary)"
@@ -315,55 +283,34 @@ function CheckGlyph() {
 function FlowStyles() {
   return (
     <style>{`
-      .taskito-flow .taskito-station {
+      .taskito-flow .taskito-flow-station {
         transition: transform 200ms ease;
       }
-      .taskito-flow .taskito-station:hover {
-        transform: translateY(-1px);
+      .taskito-flow .taskito-flow-station:hover {
+        transform: translateY(-1.5px);
       }
-      .taskito-flow .taskito-station:hover .taskito-station-label {
-        fill: var(--color-fd-primary);
-      }
-      @keyframes taskito-job-travel {
-        0%   { cx: 40px;  opacity: 0; }
+      @keyframes taskito-flow-job-travel {
+        0%   { cx: 56px;  opacity: 0; }
         4%   { opacity: 1; }
-        25%  { cx: 145px; opacity: 1; }
-        33%  { cx: 145px; opacity: 1; }
-        50%  { cx: 250px; opacity: 1; }
-        58%  { cx: 250px; opacity: 1; }
-        80%  { cx: 340px; opacity: 1; }
+        24%  { cx: 184px; opacity: 1; }
+        32%  { cx: 184px; opacity: 1; }
+        50%  { cx: 304px; opacity: 1; }
+        58%  { cx: 304px; opacity: 1; }
+        80%  { cx: 412px; opacity: 1; }
         92%  { opacity: 0; }
-        100% { cx: 40px;  opacity: 0; }
+        100% { cx: 56px;  opacity: 0; }
       }
-      @keyframes taskito-worker-spin {
+      @keyframes taskito-flow-worker-spin {
         from { transform: rotate(0deg); }
         to   { transform: rotate(360deg); }
       }
-      @keyframes taskito-result-pulse {
-        0%, 70% { r: 18px; opacity: 0; }
-        80%     { r: 18px; opacity: 0.6; }
-        100%    { r: 26px; opacity: 0; }
-      }
-      @keyframes taskito-track-shimmer {
-        0%   { stroke-dashoffset: 0; }
-        100% { stroke-dashoffset: -16; }
-      }
       @media (prefers-reduced-motion: no-preference) {
-        .taskito-flow .taskito-job-dot {
-          animation: taskito-job-travel 4.8s cubic-bezier(0.45, 0.05, 0.55, 0.95) infinite;
-          filter: drop-shadow(0 0 3px var(--color-fd-primary));
+        .taskito-flow .taskito-flow-job {
+          animation: taskito-flow-job-travel 5.1s cubic-bezier(0.45, 0.05, 0.55, 0.95) infinite;
+          filter: drop-shadow(0 0 4px var(--color-fd-primary));
         }
-        .taskito-flow .taskito-job-aura {
-          animation: taskito-job-travel 4.8s cubic-bezier(0.45, 0.05, 0.55, 0.95) infinite;
-        }
-        .taskito-flow .taskito-worker-spinner {
-          animation: taskito-worker-spin 6s linear infinite;
-        }
-        .taskito-flow .taskito-result-pulse {
-          animation: taskito-result-pulse 4.8s ease-out infinite;
-        }
-        .taskito-flow .taskito-track {
-          animation: taskito-track-shimmer 1.6s linear infinite;
+        .taskito-flow .taskito-flow-worker-spinner {
+          animation: taskito-flow-worker-spin 7s linear infinite;
         }
       }
     `}</style>

--- a/docs/src/app/(home)/_sections/how-it-works.tsx
+++ b/docs/src/app/(home)/_sections/how-it-works.tsx
@@ -66,7 +66,7 @@ export function HowItWorks() {
           role="img"
           aria-label="Job lifecycle: enqueue from your code, durable queue, Rust worker pool, result returned"
           viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
-          className="w-full max-w-2xl taskito-flow"
+          className="w-full max-w-2xl font-handwritten taskito-flow"
         >
           <defs>
             <filter id="taskito-flow-sketch">
@@ -184,7 +184,6 @@ function StationNode({ station }: { station: Station }) {
         fill="var(--color-fd-foreground)"
         fontSize="16"
         fontWeight="600"
-        fontFamily="var(--font-handwritten), 'Shantell Sans', cursive"
       >
         {station.label}
       </text>

--- a/docs/src/app/(home)/_sections/index.ts
+++ b/docs/src/app/(home)/_sections/index.ts
@@ -2,3 +2,4 @@ export { ComparisonSection } from "./comparison-section";
 export { CTA } from "./cta";
 export { Features } from "./features";
 export { Hero } from "./hero";
+export { HowItWorks } from "./how-it-works";

--- a/docs/src/app/(home)/_sections/index.ts
+++ b/docs/src/app/(home)/_sections/index.ts
@@ -3,3 +3,6 @@ export { CTA } from "./cta";
 export { Features } from "./features";
 export { Hero } from "./hero";
 export { HowItWorks } from "./how-it-works";
+export { Integrations } from "./integrations";
+export { UseCases } from "./use-cases";
+export { WorkerPool } from "./worker-pool";

--- a/docs/src/app/(home)/_sections/integrations.tsx
+++ b/docs/src/app/(home)/_sections/integrations.tsx
@@ -1,0 +1,39 @@
+import { SectionHeader } from "@/components/ui";
+import {
+  INTEGRATIONS,
+  INTEGRATIONS_DESCRIPTION,
+  INTEGRATIONS_TITLE,
+} from "@/lib/landing-content";
+
+export function Integrations() {
+  return (
+    <section className="px-4 py-16 max-w-5xl mx-auto w-full">
+      <SectionHeader
+        title={INTEGRATIONS_TITLE}
+        description={INTEGRATIONS_DESCRIPTION}
+      />
+      <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-4">
+        {INTEGRATIONS.map((group) => (
+          <div
+            key={group.group}
+            className="rounded-lg border border-fd-border bg-fd-card/50 p-5"
+          >
+            <div className="text-xs uppercase tracking-[0.18em] text-fd-muted-foreground font-semibold mb-3">
+              {group.group}
+            </div>
+            <div className="flex flex-wrap gap-1.5">
+              {group.items.map((item) => (
+                <span
+                  key={item}
+                  className="inline-flex items-center rounded-md border border-fd-border/60 bg-fd-card px-2 py-1 text-xs font-medium text-fd-foreground/80 hover:border-fd-primary/40 hover:text-fd-primary transition-colors"
+                >
+                  {item}
+                </span>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/docs/src/app/(home)/_sections/use-cases.tsx
+++ b/docs/src/app/(home)/_sections/use-cases.tsx
@@ -1,0 +1,52 @@
+import { ArrowUpRight } from "lucide-react";
+import Link from "next/link";
+import { SectionHeader } from "@/components/ui";
+import {
+  USE_CASES,
+  USE_CASES_DESCRIPTION,
+  USE_CASES_TITLE,
+  type UseCase,
+} from "@/lib/landing-content";
+
+export function UseCases() {
+  return (
+    <section className="px-4 py-20 max-w-6xl mx-auto w-full">
+      <SectionHeader
+        title={USE_CASES_TITLE}
+        description={USE_CASES_DESCRIPTION}
+      />
+      <div className="grid sm:grid-cols-2 gap-5">
+        {USE_CASES.map((useCase) => (
+          <UseCaseCard key={useCase.title} useCase={useCase} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function UseCaseCard({ useCase }: { useCase: UseCase }) {
+  const { icon: Icon, title, body, href } = useCase;
+  return (
+    <Link
+      href={href}
+      className="group relative rounded-lg border border-fd-border bg-fd-card p-6 hover:border-fd-primary/40 hover:bg-fd-accent/40 transition-all overflow-hidden"
+    >
+      <div
+        aria-hidden
+        className="absolute -top-12 -right-12 size-32 rounded-full bg-fd-primary/5 group-hover:bg-fd-primary/10 transition-colors"
+      />
+      <div className="relative">
+        <div className="flex items-center justify-between mb-4">
+          <div className="size-10 rounded-md bg-fd-primary/10 flex items-center justify-center">
+            <Icon className="size-5 text-fd-primary" />
+          </div>
+          <ArrowUpRight className="size-4 text-fd-muted-foreground/50 group-hover:text-fd-primary group-hover:-translate-y-0.5 group-hover:translate-x-0.5 transition-all" />
+        </div>
+        <h3 className="text-lg font-semibold mb-2">{title}</h3>
+        <p className="text-sm text-fd-muted-foreground leading-relaxed">
+          {body}
+        </p>
+      </div>
+    </Link>
+  );
+}

--- a/docs/src/app/(home)/_sections/worker-pool.tsx
+++ b/docs/src/app/(home)/_sections/worker-pool.tsx
@@ -22,15 +22,19 @@ const RESULTS = [
   { delay: "-1.5s" },
 ] as const;
 
-const POOL_LEFT = 180;
-const POOL_TOP = 30;
-const WORKER_SIZE = 32;
+const VIEW_W = 560;
+const VIEW_H = 150;
+const POOL_LEFT = 200;
+const POOL_TOP = 38;
+const WORKER_SIZE = 34;
 const WORKER_GAP = 10;
 const POOL_WIDTH = 3 * WORKER_SIZE + 2 * WORKER_GAP;
 const POOL_HEIGHT = 2 * WORKER_SIZE + 1 * WORKER_GAP;
-const VIEW_W = 560;
-const VIEW_H = 130;
 const POOL_RIGHT = POOL_LEFT + POOL_WIDTH;
+const TRACK_Y = POOL_TOP + POOL_HEIGHT / 2;
+const INCOMING_LEFT = 30;
+const RESULT_LEFT = POOL_RIGHT + 30;
+const RESULT_END = VIEW_W - 30;
 
 export function WorkerPool() {
   return (
@@ -46,149 +50,47 @@ export function WorkerPool() {
           viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
           className="w-full max-w-2xl taskito-pool"
         >
-          <defs>
-            <linearGradient
-              id="taskito-pool-incoming"
-              x1="0"
-              y1="0"
-              x2="1"
-              y2="0"
-            >
-              <stop
-                offset="0"
-                stopColor="var(--color-fd-primary)"
-                stopOpacity="0"
-              />
-              <stop
-                offset="1"
-                stopColor="var(--color-fd-primary)"
-                stopOpacity="0.85"
-              />
-            </linearGradient>
-            <linearGradient
-              id="taskito-pool-outgoing"
-              x1="0"
-              y1="0"
-              x2="1"
-              y2="0"
-            >
-              <stop
-                offset="0"
-                stopColor="var(--color-fd-primary)"
-                stopOpacity="0.85"
-              />
-              <stop
-                offset="1"
-                stopColor="var(--color-fd-primary)"
-                stopOpacity="0"
-              />
-            </linearGradient>
-          </defs>
-
-          <text
-            x="14"
-            y="20"
-            fill="var(--color-fd-muted-foreground)"
-            fontSize="9"
-            fontFamily="ui-monospace, SFMono-Regular, monospace"
-            letterSpacing="0.1em"
-          >
-            INCOMING
-          </text>
-          <text
-            x={POOL_LEFT}
-            y="20"
-            fill="var(--color-fd-muted-foreground)"
-            fontSize="9"
-            fontFamily="ui-monospace, SFMono-Regular, monospace"
-            letterSpacing="0.1em"
-          >
-            WORKERS
-          </text>
-          <text
-            x={POOL_RIGHT + 20}
-            y="20"
-            fill="var(--color-fd-muted-foreground)"
-            fontSize="9"
-            fontFamily="ui-monospace, SFMono-Regular, monospace"
-            letterSpacing="0.1em"
-          >
-            RESULTS
-          </text>
+          <LaneLabels />
+          <Lanes />
 
           {INCOMING_JOBS.map((job, i) => (
             <circle
               // biome-ignore lint/suspicious/noArrayIndexKey: stable list
               key={`incoming-${i}`}
-              cy={POOL_TOP + POOL_HEIGHT / 2}
-              r="4"
-              fill="url(#taskito-pool-incoming)"
-              className="taskito-pool-incoming"
+              cx={INCOMING_LEFT}
+              cy={TRACK_Y}
+              r="3.5"
+              fill="var(--color-fd-primary)"
+              className="taskito-incoming-dot"
               style={{ animationDelay: job.delay }}
             />
           ))}
 
-          {WORKERS.map((worker) => {
-            const x = POOL_LEFT + worker.x * (WORKER_SIZE + WORKER_GAP);
-            const y = POOL_TOP + worker.y * (WORKER_SIZE + WORKER_GAP);
-            return (
-              <g
-                key={worker.id}
-                style={
-                  {
-                    "--worker-delay": worker.delay,
-                    "--worker-duration": worker.duration,
-                  } as React.CSSProperties
-                }
-                className="taskito-worker"
-              >
-                <rect
-                  x={x}
-                  y={y}
-                  width={WORKER_SIZE}
-                  height={WORKER_SIZE}
-                  rx="6"
-                  fill="var(--color-fd-card)"
-                  stroke="var(--color-fd-border)"
-                  strokeWidth="1.5"
-                  className="taskito-worker-base"
-                />
-                <rect
-                  x={x + 4}
-                  y={y + 4}
-                  width={WORKER_SIZE - 8}
-                  height={WORKER_SIZE - 8}
-                  rx="3"
-                  fill="var(--color-fd-primary)"
-                  className="taskito-worker-active"
-                />
-              </g>
-            );
-          })}
+          {WORKERS.map((worker) => (
+            <Worker key={worker.id} worker={worker} />
+          ))}
 
           {RESULTS.map((result, i) => (
             <g
               // biome-ignore lint/suspicious/noArrayIndexKey: stable list
               key={`result-${i}`}
-              className="taskito-pool-result"
+              transform={`translate(${RESULT_LEFT} ${TRACK_Y})`}
+              className="taskito-result"
               style={{ animationDelay: result.delay }}
             >
               <circle
-                cy={POOL_TOP + POOL_HEIGHT / 2}
-                r="6"
+                r="7"
                 fill="var(--color-fd-card)"
                 stroke="var(--color-fd-primary)"
                 strokeWidth="1.5"
               />
               <path
-                d="m -3 0 l 2 2 l 4 -4"
+                d="m -3.5 0.5 l 2.5 2.5 l 4.5 -4.5"
                 stroke="var(--color-fd-primary)"
                 strokeWidth="1.5"
                 strokeLinecap="round"
                 strokeLinejoin="round"
                 fill="none"
-                transform={`translate(0, ${POOL_TOP + POOL_HEIGHT / 2})`}
-                className="taskito-pool-result-check"
               />
             </g>
           ))}
@@ -211,58 +113,176 @@ export function WorkerPool() {
   );
 }
 
+function LaneLabels() {
+  return (
+    <>
+      <text
+        x={INCOMING_LEFT}
+        y="20"
+        fill="var(--color-fd-muted-foreground)"
+        fontSize="9"
+        fontFamily="ui-monospace, SFMono-Regular, monospace"
+        letterSpacing="0.15em"
+        opacity="0.7"
+      >
+        INCOMING
+      </text>
+      <text
+        x={POOL_LEFT}
+        y="20"
+        fill="var(--color-fd-muted-foreground)"
+        fontSize="9"
+        fontFamily="ui-monospace, SFMono-Regular, monospace"
+        letterSpacing="0.15em"
+        opacity="0.7"
+      >
+        WORKERS
+      </text>
+      <text
+        x={RESULT_LEFT}
+        y="20"
+        fill="var(--color-fd-muted-foreground)"
+        fontSize="9"
+        fontFamily="ui-monospace, SFMono-Regular, monospace"
+        letterSpacing="0.15em"
+        opacity="0.7"
+      >
+        RESULTS
+      </text>
+    </>
+  );
+}
+
+function Lanes() {
+  return (
+    <>
+      <line
+        x1={INCOMING_LEFT}
+        y1={TRACK_Y}
+        x2={POOL_LEFT - 8}
+        y2={TRACK_Y}
+        stroke="var(--color-fd-border)"
+        strokeWidth="1"
+        strokeDasharray="2 4"
+      />
+      <line
+        x1={POOL_RIGHT + 8}
+        y1={TRACK_Y}
+        x2={RESULT_END}
+        y2={TRACK_Y}
+        stroke="var(--color-fd-border)"
+        strokeWidth="1"
+        strokeDasharray="2 4"
+      />
+    </>
+  );
+}
+
+function Worker({ worker }: { worker: (typeof WORKERS)[number] }) {
+  const x = POOL_LEFT + worker.x * (WORKER_SIZE + WORKER_GAP);
+  const y = POOL_TOP + worker.y * (WORKER_SIZE + WORKER_GAP);
+  const cx = x + WORKER_SIZE / 2;
+  const cy = y + WORKER_SIZE / 2;
+  return (
+    <g
+      style={
+        {
+          "--worker-delay": worker.delay,
+          "--worker-duration": worker.duration,
+        } as React.CSSProperties
+      }
+      className="taskito-worker"
+    >
+      <rect
+        x={x}
+        y={y}
+        width={WORKER_SIZE}
+        height={WORKER_SIZE}
+        rx="6"
+        fill="var(--color-fd-card)"
+        stroke="var(--color-fd-border)"
+        strokeWidth="1.5"
+      />
+      <circle
+        cx={cx}
+        cy={cy}
+        r="6"
+        fill="none"
+        stroke="var(--color-fd-primary)"
+        strokeWidth="1.25"
+        className="taskito-worker-ring"
+        style={{ transformOrigin: `${cx}px ${cy}px` }}
+      />
+      <circle
+        cx={cx}
+        cy={cy}
+        r="2.75"
+        fill="var(--color-fd-muted-foreground)"
+        opacity="0.35"
+        className="taskito-worker-dot-idle"
+      />
+      <circle
+        cx={cx}
+        cy={cy}
+        r="2.75"
+        fill="var(--color-fd-primary)"
+        className="taskito-worker-dot-active"
+      />
+    </g>
+  );
+}
+
 function PoolStyles() {
   return (
     <style>{`
-      @keyframes taskito-pool-incoming-flow {
-        0%   { cx: 18px;  opacity: 0; }
+      @keyframes taskito-incoming-flow {
+        0%   { cx: ${INCOMING_LEFT}px; opacity: 0; }
         10%  { opacity: 1; }
-        80%  { cx: ${POOL_LEFT - 8}px; opacity: 1; }
-        100% { cx: ${POOL_LEFT - 8}px; opacity: 0; }
+        88%  { cx: ${POOL_LEFT - 6}px; opacity: 1; }
+        100% { cx: ${POOL_LEFT - 6}px; opacity: 0; }
       }
-      @keyframes taskito-pool-result-flow {
-        0%   { cx: ${POOL_RIGHT + 8}px; opacity: 0; }
+      @keyframes taskito-result-flow {
+        0%   { transform: translate(${RESULT_LEFT}px, ${TRACK_Y}px); opacity: 0; }
         10%  { opacity: 1; }
-        90%  { cx: ${VIEW_W - 16}px; opacity: 1; }
-        100% { cx: ${VIEW_W - 16}px; opacity: 0; }
+        90%  { transform: translate(${RESULT_END}px, ${TRACK_Y}px); opacity: 1; }
+        100% { transform: translate(${RESULT_END}px, ${TRACK_Y}px); opacity: 0; }
       }
-      @keyframes taskito-worker-pulse {
-        0%, 35% {
-          opacity: 0;
-          transform: scale(0.6);
-        }
-        45%     {
-          opacity: 1;
-          transform: scale(1);
-        }
-        80%     {
-          opacity: 1;
-          transform: scale(1);
-        }
-        100%    {
-          opacity: 0;
-          transform: scale(0.6);
-        }
+      @keyframes taskito-worker-active-pulse {
+        0%, 35%   { opacity: 0; transform: scale(0.7); }
+        50%       { opacity: 1; transform: scale(1); }
+        85%       { opacity: 1; transform: scale(1); }
+        100%      { opacity: 0; transform: scale(0.7); }
       }
-      @media (prefers-reduced-motion: no-preference) {
-        .taskito-pool .taskito-pool-incoming {
-          animation: taskito-pool-incoming-flow 2s linear infinite;
-          filter: drop-shadow(0 0 3px var(--color-fd-primary));
-        }
-        .taskito-pool .taskito-pool-result {
-          animation: taskito-pool-result-flow 2s linear infinite;
-        }
-        .taskito-pool .taskito-worker-active {
-          transform-box: fill-box;
-          transform-origin: center;
-          animation: taskito-worker-pulse var(--worker-duration) ease-in-out infinite;
-          animation-delay: var(--worker-delay);
-        }
+      @keyframes taskito-worker-ring-pulse {
+        0%, 35%   { opacity: 0; transform: scale(0.6); }
+        55%       { opacity: 0.5; transform: scale(1.4); }
+        100%      { opacity: 0; transform: scale(2); }
       }
-      .taskito-pool .taskito-worker-active {
+      .taskito-pool .taskito-worker-dot-active {
         opacity: 0;
         transform-box: fill-box;
         transform-origin: center;
+      }
+      .taskito-pool .taskito-worker-ring {
+        opacity: 0;
+        transform-box: fill-box;
+      }
+      @media (prefers-reduced-motion: no-preference) {
+        .taskito-pool .taskito-incoming-dot {
+          animation: taskito-incoming-flow 2.2s linear infinite;
+          filter: drop-shadow(0 0 2px var(--color-fd-primary));
+        }
+        .taskito-pool .taskito-result {
+          animation: taskito-result-flow 2.2s linear infinite;
+        }
+        .taskito-pool .taskito-worker-dot-active {
+          animation: taskito-worker-active-pulse var(--worker-duration) ease-in-out infinite;
+          animation-delay: var(--worker-delay);
+        }
+        .taskito-pool .taskito-worker-ring {
+          animation: taskito-worker-ring-pulse var(--worker-duration) ease-out infinite;
+          animation-delay: var(--worker-delay);
+        }
       }
     `}</style>
   );

--- a/docs/src/app/(home)/_sections/worker-pool.tsx
+++ b/docs/src/app/(home)/_sections/worker-pool.tsx
@@ -135,7 +135,7 @@ export function WorkerPool() {
             textAnchor="middle"
             fill="var(--color-fd-muted-foreground)"
             fontSize="14"
-            fontFamily="var(--font-handwritten), Caveat, cursive"
+            fontFamily="var(--font-handwritten), 'Shantell Sans', cursive"
             fontWeight="500"
           >
             6 workers · 0 brokers
@@ -162,7 +162,7 @@ function LaneLabels() {
           y="28"
           fill="var(--color-fd-foreground)"
           fontSize="17"
-          fontFamily="var(--font-handwritten), Caveat, cursive"
+          fontFamily="var(--font-handwritten), 'Shantell Sans', cursive"
           fontWeight="600"
         >
           {label.text}

--- a/docs/src/app/(home)/_sections/worker-pool.tsx
+++ b/docs/src/app/(home)/_sections/worker-pool.tsx
@@ -51,7 +51,7 @@ export function WorkerPool() {
           role="img"
           aria-label="Six-worker pool with jobs streaming in from the left and results streaming out to the right"
           viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
-          className="w-full max-w-2xl taskito-pool"
+          className="w-full max-w-2xl font-handwritten taskito-pool"
         >
           <defs>
             <filter id="taskito-pool-sketch">
@@ -135,7 +135,6 @@ export function WorkerPool() {
             textAnchor="middle"
             fill="var(--color-fd-muted-foreground)"
             fontSize="14"
-            fontFamily="var(--font-handwritten), 'Shantell Sans', cursive"
             fontWeight="500"
           >
             6 workers · 0 brokers
@@ -162,7 +161,6 @@ function LaneLabels() {
           y="28"
           fill="var(--color-fd-foreground)"
           fontSize="17"
-          fontFamily="var(--font-handwritten), 'Shantell Sans', cursive"
           fontWeight="600"
         >
           {label.text}

--- a/docs/src/app/(home)/_sections/worker-pool.tsx
+++ b/docs/src/app/(home)/_sections/worker-pool.tsx
@@ -1,0 +1,269 @@
+import { SectionHeader } from "@/components/ui";
+
+const WORKERS = [
+  { id: 0, x: 0, y: 0, delay: "0s", duration: "2.4s" },
+  { id: 1, x: 1, y: 0, delay: "-0.4s", duration: "2.8s" },
+  { id: 2, x: 2, y: 0, delay: "-1.1s", duration: "2.6s" },
+  { id: 3, x: 0, y: 1, delay: "-0.7s", duration: "3.1s" },
+  { id: 4, x: 1, y: 1, delay: "-1.6s", duration: "2.5s" },
+  { id: 5, x: 2, y: 1, delay: "-0.2s", duration: "2.9s" },
+] as const;
+
+const INCOMING_JOBS = [
+  { delay: "0s" },
+  { delay: "-0.6s" },
+  { delay: "-1.2s" },
+  { delay: "-1.8s" },
+] as const;
+
+const RESULTS = [
+  { delay: "-0.3s" },
+  { delay: "-0.9s" },
+  { delay: "-1.5s" },
+] as const;
+
+const POOL_LEFT = 180;
+const POOL_TOP = 30;
+const WORKER_SIZE = 32;
+const WORKER_GAP = 10;
+const POOL_WIDTH = 3 * WORKER_SIZE + 2 * WORKER_GAP;
+const POOL_HEIGHT = 2 * WORKER_SIZE + 1 * WORKER_GAP;
+const VIEW_W = 560;
+const VIEW_H = 130;
+const POOL_RIGHT = POOL_LEFT + POOL_WIDTH;
+
+export function WorkerPool() {
+  return (
+    <section className="px-4 pb-24 max-w-3xl mx-auto w-full">
+      <SectionHeader
+        title="Six workers. Constant flow."
+        description="Jobs stream in, workers pick them up, results stream out. No broker between them."
+      />
+      <div className="flex justify-center">
+        <svg
+          role="img"
+          aria-label="Six-worker pool with jobs streaming in from the left and results streaming out to the right"
+          viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
+          className="w-full max-w-2xl taskito-pool"
+        >
+          <defs>
+            <linearGradient
+              id="taskito-pool-incoming"
+              x1="0"
+              y1="0"
+              x2="1"
+              y2="0"
+            >
+              <stop
+                offset="0"
+                stopColor="var(--color-fd-primary)"
+                stopOpacity="0"
+              />
+              <stop
+                offset="1"
+                stopColor="var(--color-fd-primary)"
+                stopOpacity="0.85"
+              />
+            </linearGradient>
+            <linearGradient
+              id="taskito-pool-outgoing"
+              x1="0"
+              y1="0"
+              x2="1"
+              y2="0"
+            >
+              <stop
+                offset="0"
+                stopColor="var(--color-fd-primary)"
+                stopOpacity="0.85"
+              />
+              <stop
+                offset="1"
+                stopColor="var(--color-fd-primary)"
+                stopOpacity="0"
+              />
+            </linearGradient>
+          </defs>
+
+          <text
+            x="14"
+            y="20"
+            fill="var(--color-fd-muted-foreground)"
+            fontSize="9"
+            fontFamily="ui-monospace, SFMono-Regular, monospace"
+            letterSpacing="0.1em"
+          >
+            INCOMING
+          </text>
+          <text
+            x={POOL_LEFT}
+            y="20"
+            fill="var(--color-fd-muted-foreground)"
+            fontSize="9"
+            fontFamily="ui-monospace, SFMono-Regular, monospace"
+            letterSpacing="0.1em"
+          >
+            WORKERS
+          </text>
+          <text
+            x={POOL_RIGHT + 20}
+            y="20"
+            fill="var(--color-fd-muted-foreground)"
+            fontSize="9"
+            fontFamily="ui-monospace, SFMono-Regular, monospace"
+            letterSpacing="0.1em"
+          >
+            RESULTS
+          </text>
+
+          {INCOMING_JOBS.map((job, i) => (
+            <circle
+              // biome-ignore lint/suspicious/noArrayIndexKey: stable list
+              key={`incoming-${i}`}
+              cy={POOL_TOP + POOL_HEIGHT / 2}
+              r="4"
+              fill="url(#taskito-pool-incoming)"
+              className="taskito-pool-incoming"
+              style={{ animationDelay: job.delay }}
+            />
+          ))}
+
+          {WORKERS.map((worker) => {
+            const x = POOL_LEFT + worker.x * (WORKER_SIZE + WORKER_GAP);
+            const y = POOL_TOP + worker.y * (WORKER_SIZE + WORKER_GAP);
+            return (
+              <g
+                key={worker.id}
+                style={
+                  {
+                    "--worker-delay": worker.delay,
+                    "--worker-duration": worker.duration,
+                  } as React.CSSProperties
+                }
+                className="taskito-worker"
+              >
+                <rect
+                  x={x}
+                  y={y}
+                  width={WORKER_SIZE}
+                  height={WORKER_SIZE}
+                  rx="6"
+                  fill="var(--color-fd-card)"
+                  stroke="var(--color-fd-border)"
+                  strokeWidth="1.5"
+                  className="taskito-worker-base"
+                />
+                <rect
+                  x={x + 4}
+                  y={y + 4}
+                  width={WORKER_SIZE - 8}
+                  height={WORKER_SIZE - 8}
+                  rx="3"
+                  fill="var(--color-fd-primary)"
+                  className="taskito-worker-active"
+                />
+              </g>
+            );
+          })}
+
+          {RESULTS.map((result, i) => (
+            <g
+              // biome-ignore lint/suspicious/noArrayIndexKey: stable list
+              key={`result-${i}`}
+              className="taskito-pool-result"
+              style={{ animationDelay: result.delay }}
+            >
+              <circle
+                cy={POOL_TOP + POOL_HEIGHT / 2}
+                r="6"
+                fill="var(--color-fd-card)"
+                stroke="var(--color-fd-primary)"
+                strokeWidth="1.5"
+              />
+              <path
+                d="m -3 0 l 2 2 l 4 -4"
+                stroke="var(--color-fd-primary)"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                fill="none"
+                transform={`translate(0, ${POOL_TOP + POOL_HEIGHT / 2})`}
+                className="taskito-pool-result-check"
+              />
+            </g>
+          ))}
+
+          <text
+            x={POOL_LEFT + POOL_WIDTH / 2}
+            y={POOL_TOP + POOL_HEIGHT + 22}
+            textAnchor="middle"
+            fill="var(--color-fd-muted-foreground)"
+            fontSize="9"
+            fontFamily="ui-monospace, SFMono-Regular, monospace"
+            opacity="0.7"
+          >
+            6 workers · 0 brokers
+          </text>
+        </svg>
+      </div>
+      <PoolStyles />
+    </section>
+  );
+}
+
+function PoolStyles() {
+  return (
+    <style>{`
+      @keyframes taskito-pool-incoming-flow {
+        0%   { cx: 18px;  opacity: 0; }
+        10%  { opacity: 1; }
+        80%  { cx: ${POOL_LEFT - 8}px; opacity: 1; }
+        100% { cx: ${POOL_LEFT - 8}px; opacity: 0; }
+      }
+      @keyframes taskito-pool-result-flow {
+        0%   { cx: ${POOL_RIGHT + 8}px; opacity: 0; }
+        10%  { opacity: 1; }
+        90%  { cx: ${VIEW_W - 16}px; opacity: 1; }
+        100% { cx: ${VIEW_W - 16}px; opacity: 0; }
+      }
+      @keyframes taskito-worker-pulse {
+        0%, 35% {
+          opacity: 0;
+          transform: scale(0.6);
+        }
+        45%     {
+          opacity: 1;
+          transform: scale(1);
+        }
+        80%     {
+          opacity: 1;
+          transform: scale(1);
+        }
+        100%    {
+          opacity: 0;
+          transform: scale(0.6);
+        }
+      }
+      @media (prefers-reduced-motion: no-preference) {
+        .taskito-pool .taskito-pool-incoming {
+          animation: taskito-pool-incoming-flow 2s linear infinite;
+          filter: drop-shadow(0 0 3px var(--color-fd-primary));
+        }
+        .taskito-pool .taskito-pool-result {
+          animation: taskito-pool-result-flow 2s linear infinite;
+        }
+        .taskito-pool .taskito-worker-active {
+          transform-box: fill-box;
+          transform-origin: center;
+          animation: taskito-worker-pulse var(--worker-duration) ease-in-out infinite;
+          animation-delay: var(--worker-delay);
+        }
+      }
+      .taskito-pool .taskito-worker-active {
+        opacity: 0;
+        transform-box: fill-box;
+        transform-origin: center;
+      }
+    `}</style>
+  );
+}

--- a/docs/src/app/(home)/_sections/worker-pool.tsx
+++ b/docs/src/app/(home)/_sections/worker-pool.tsx
@@ -57,11 +57,11 @@ export function WorkerPool() {
             <filter id="taskito-pool-sketch">
               <feTurbulence
                 type="fractalNoise"
-                baseFrequency="0.04"
+                baseFrequency="0.025"
                 numOctaves="2"
                 seed="7"
               />
-              <feDisplacementMap in="SourceGraphic" scale="1.2" />
+              <feDisplacementMap in="SourceGraphic" scale="0.7" />
             </filter>
             <marker
               id="taskito-pool-arrow"
@@ -75,8 +75,8 @@ export function WorkerPool() {
               <path
                 d="M 1 1 L 10 6 L 1 11"
                 fill="none"
-                stroke="var(--color-fd-sketch-strong)"
-                strokeWidth="1.6"
+                stroke="var(--color-fd-sketch-accent)"
+                strokeWidth="1.8"
                 strokeLinecap="round"
                 strokeLinejoin="round"
               />
@@ -115,7 +115,7 @@ export function WorkerPool() {
                 r="8"
                 fill="var(--color-fd-card)"
                 stroke="var(--color-fd-primary)"
-                strokeWidth="1.75"
+                strokeWidth="2"
                 filter="url(#taskito-pool-sketch)"
               />
               <path
@@ -180,8 +180,8 @@ function Lanes() {
         y1={TRACK_Y}
         x2={POOL_LEFT - 10}
         y2={TRACK_Y}
-        stroke="var(--color-fd-sketch)"
-        strokeWidth="1.5"
+        stroke="var(--color-fd-sketch-accent)"
+        strokeWidth="1.75"
         strokeDasharray="2 6"
         strokeLinecap="round"
         markerEnd="url(#taskito-pool-arrow)"
@@ -192,8 +192,8 @@ function Lanes() {
         y1={TRACK_Y}
         x2={RESULT_END - 4}
         y2={TRACK_Y}
-        stroke="var(--color-fd-sketch)"
-        strokeWidth="1.5"
+        stroke="var(--color-fd-sketch-accent)"
+        strokeWidth="1.75"
         strokeDasharray="2 6"
         strokeLinecap="round"
         markerEnd="url(#taskito-pool-arrow)"
@@ -226,7 +226,7 @@ function Worker({ worker }: { worker: (typeof WORKERS)[number] }) {
         rx="7"
         fill="var(--color-fd-card)"
         stroke="var(--color-fd-sketch-strong)"
-        strokeWidth="1.75"
+        strokeWidth="2.25"
         filter="url(#taskito-pool-sketch)"
       />
       <circle
@@ -244,7 +244,7 @@ function Worker({ worker }: { worker: (typeof WORKERS)[number] }) {
         cy={cy}
         r="3"
         fill="var(--color-fd-muted-foreground)"
-        opacity="0.4"
+        opacity="0.65"
       />
       <circle
         cx={cx}

--- a/docs/src/app/(home)/_sections/worker-pool.tsx
+++ b/docs/src/app/(home)/_sections/worker-pool.tsx
@@ -1,5 +1,3 @@
-import { SectionHeader } from "@/components/ui";
-
 const WORKERS = [
   { id: 0, x: 0, y: 0, delay: "0s", duration: "2.4s" },
   { id: 1, x: 1, y: 0, delay: "-0.4s", duration: "2.8s" },
@@ -22,12 +20,12 @@ const RESULTS = [
   { delay: "-1.5s" },
 ] as const;
 
-const VIEW_W = 560;
-const VIEW_H = 150;
-const POOL_LEFT = 200;
-const POOL_TOP = 38;
-const WORKER_SIZE = 34;
-const WORKER_GAP = 10;
+const VIEW_W = 580;
+const VIEW_H = 170;
+const POOL_LEFT = 210;
+const POOL_TOP = 50;
+const WORKER_SIZE = 38;
+const WORKER_GAP = 12;
 const POOL_WIDTH = 3 * WORKER_SIZE + 2 * WORKER_GAP;
 const POOL_HEIGHT = 2 * WORKER_SIZE + 1 * WORKER_GAP;
 const POOL_RIGHT = POOL_LEFT + POOL_WIDTH;
@@ -39,10 +37,15 @@ const RESULT_END = VIEW_W - 30;
 export function WorkerPool() {
   return (
     <section className="px-4 pb-24 max-w-3xl mx-auto w-full">
-      <SectionHeader
-        title="Six workers. Constant flow."
-        description="Jobs stream in, workers pick them up, results stream out. No broker between them."
-      />
+      <div className="text-center mb-10">
+        <h2 className="font-handwritten text-3xl sm:text-4xl text-fd-foreground mb-2">
+          six workers, constant flow
+        </h2>
+        <p className="text-sm text-fd-muted-foreground">
+          Jobs stream in, workers pick them up, results stream out. No broker
+          between them.
+        </p>
+      </div>
       <div className="flex justify-center">
         <svg
           role="img"
@@ -50,6 +53,36 @@ export function WorkerPool() {
           viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
           className="w-full max-w-2xl taskito-pool"
         >
+          <defs>
+            <filter id="taskito-pool-sketch">
+              <feTurbulence
+                type="fractalNoise"
+                baseFrequency="0.04"
+                numOctaves="2"
+                seed="7"
+              />
+              <feDisplacementMap in="SourceGraphic" scale="1.2" />
+            </filter>
+            <marker
+              id="taskito-pool-arrow"
+              viewBox="0 0 12 12"
+              refX="9"
+              refY="6"
+              markerWidth="6"
+              markerHeight="6"
+              orient="auto"
+            >
+              <path
+                d="M 1 1 L 10 6 L 1 11"
+                fill="none"
+                stroke="var(--color-fd-sketch-strong)"
+                strokeWidth="1.6"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </marker>
+          </defs>
+
           <LaneLabels />
           <Lanes />
 
@@ -59,7 +92,7 @@ export function WorkerPool() {
               key={`incoming-${i}`}
               cx={INCOMING_LEFT}
               cy={TRACK_Y}
-              r="3.5"
+              r="4"
               fill="var(--color-fd-primary)"
               className="taskito-incoming-dot"
               style={{ animationDelay: job.delay }}
@@ -79,15 +112,16 @@ export function WorkerPool() {
               style={{ animationDelay: result.delay }}
             >
               <circle
-                r="7"
+                r="8"
                 fill="var(--color-fd-card)"
                 stroke="var(--color-fd-primary)"
-                strokeWidth="1.5"
+                strokeWidth="1.75"
+                filter="url(#taskito-pool-sketch)"
               />
               <path
                 d="m -3.5 0.5 l 2.5 2.5 l 4.5 -4.5"
                 stroke="var(--color-fd-primary)"
-                strokeWidth="1.5"
+                strokeWidth="1.75"
                 strokeLinecap="round"
                 strokeLinejoin="round"
                 fill="none"
@@ -97,12 +131,12 @@ export function WorkerPool() {
 
           <text
             x={POOL_LEFT + POOL_WIDTH / 2}
-            y={POOL_TOP + POOL_HEIGHT + 22}
+            y={POOL_TOP + POOL_HEIGHT + 28}
             textAnchor="middle"
             fill="var(--color-fd-muted-foreground)"
-            fontSize="9"
-            fontFamily="ui-monospace, SFMono-Regular, monospace"
-            opacity="0.7"
+            fontSize="14"
+            fontFamily="var(--font-handwritten), Caveat, cursive"
+            fontWeight="500"
           >
             6 workers · 0 brokers
           </text>
@@ -114,41 +148,26 @@ export function WorkerPool() {
 }
 
 function LaneLabels() {
+  const labels = [
+    { x: INCOMING_LEFT, text: "incoming" },
+    { x: POOL_LEFT, text: "workers" },
+    { x: RESULT_LEFT, text: "results" },
+  ];
   return (
     <>
-      <text
-        x={INCOMING_LEFT}
-        y="20"
-        fill="var(--color-fd-muted-foreground)"
-        fontSize="9"
-        fontFamily="ui-monospace, SFMono-Regular, monospace"
-        letterSpacing="0.15em"
-        opacity="0.7"
-      >
-        INCOMING
-      </text>
-      <text
-        x={POOL_LEFT}
-        y="20"
-        fill="var(--color-fd-muted-foreground)"
-        fontSize="9"
-        fontFamily="ui-monospace, SFMono-Regular, monospace"
-        letterSpacing="0.15em"
-        opacity="0.7"
-      >
-        WORKERS
-      </text>
-      <text
-        x={RESULT_LEFT}
-        y="20"
-        fill="var(--color-fd-muted-foreground)"
-        fontSize="9"
-        fontFamily="ui-monospace, SFMono-Regular, monospace"
-        letterSpacing="0.15em"
-        opacity="0.7"
-      >
-        RESULTS
-      </text>
+      {labels.map((label) => (
+        <text
+          key={label.text}
+          x={label.x}
+          y="28"
+          fill="var(--color-fd-foreground)"
+          fontSize="17"
+          fontFamily="var(--font-handwritten), Caveat, cursive"
+          fontWeight="600"
+        >
+          {label.text}
+        </text>
+      ))}
     </>
   );
 }
@@ -159,20 +178,26 @@ function Lanes() {
       <line
         x1={INCOMING_LEFT}
         y1={TRACK_Y}
-        x2={POOL_LEFT - 8}
+        x2={POOL_LEFT - 10}
         y2={TRACK_Y}
-        stroke="var(--color-fd-border)"
-        strokeWidth="1"
-        strokeDasharray="2 4"
+        stroke="var(--color-fd-sketch)"
+        strokeWidth="1.5"
+        strokeDasharray="2 6"
+        strokeLinecap="round"
+        markerEnd="url(#taskito-pool-arrow)"
+        filter="url(#taskito-pool-sketch)"
       />
       <line
-        x1={POOL_RIGHT + 8}
+        x1={POOL_RIGHT + 10}
         y1={TRACK_Y}
-        x2={RESULT_END}
+        x2={RESULT_END - 4}
         y2={TRACK_Y}
-        stroke="var(--color-fd-border)"
-        strokeWidth="1"
-        strokeDasharray="2 4"
+        stroke="var(--color-fd-sketch)"
+        strokeWidth="1.5"
+        strokeDasharray="2 6"
+        strokeLinecap="round"
+        markerEnd="url(#taskito-pool-arrow)"
+        filter="url(#taskito-pool-sketch)"
       />
     </>
   );
@@ -198,33 +223,33 @@ function Worker({ worker }: { worker: (typeof WORKERS)[number] }) {
         y={y}
         width={WORKER_SIZE}
         height={WORKER_SIZE}
-        rx="6"
+        rx="7"
         fill="var(--color-fd-card)"
-        stroke="var(--color-fd-border)"
-        strokeWidth="1.5"
+        stroke="var(--color-fd-sketch-strong)"
+        strokeWidth="1.75"
+        filter="url(#taskito-pool-sketch)"
       />
       <circle
         cx={cx}
         cy={cy}
-        r="6"
+        r="7"
         fill="none"
         stroke="var(--color-fd-primary)"
-        strokeWidth="1.25"
+        strokeWidth="1.4"
         className="taskito-worker-ring"
         style={{ transformOrigin: `${cx}px ${cy}px` }}
       />
       <circle
         cx={cx}
         cy={cy}
-        r="2.75"
+        r="3"
         fill="var(--color-fd-muted-foreground)"
-        opacity="0.35"
-        className="taskito-worker-dot-idle"
+        opacity="0.4"
       />
       <circle
         cx={cx}
         cy={cy}
-        r="2.75"
+        r="3"
         fill="var(--color-fd-primary)"
         className="taskito-worker-dot-active"
       />
@@ -238,25 +263,25 @@ function PoolStyles() {
       @keyframes taskito-incoming-flow {
         0%   { cx: ${INCOMING_LEFT}px; opacity: 0; }
         10%  { opacity: 1; }
-        88%  { cx: ${POOL_LEFT - 6}px; opacity: 1; }
-        100% { cx: ${POOL_LEFT - 6}px; opacity: 0; }
+        88%  { cx: ${POOL_LEFT - 8}px; opacity: 1; }
+        100% { cx: ${POOL_LEFT - 8}px; opacity: 0; }
       }
       @keyframes taskito-result-flow {
         0%   { transform: translate(${RESULT_LEFT}px, ${TRACK_Y}px); opacity: 0; }
         10%  { opacity: 1; }
-        90%  { transform: translate(${RESULT_END}px, ${TRACK_Y}px); opacity: 1; }
-        100% { transform: translate(${RESULT_END}px, ${TRACK_Y}px); opacity: 0; }
+        90%  { transform: translate(${RESULT_END - 4}px, ${TRACK_Y}px); opacity: 1; }
+        100% { transform: translate(${RESULT_END - 4}px, ${TRACK_Y}px); opacity: 0; }
       }
       @keyframes taskito-worker-active-pulse {
-        0%, 35%   { opacity: 0; transform: scale(0.7); }
+        0%, 35%   { opacity: 0; transform: scale(0.6); }
         50%       { opacity: 1; transform: scale(1); }
         85%       { opacity: 1; transform: scale(1); }
-        100%      { opacity: 0; transform: scale(0.7); }
+        100%      { opacity: 0; transform: scale(0.6); }
       }
       @keyframes taskito-worker-ring-pulse {
-        0%, 35%   { opacity: 0; transform: scale(0.6); }
-        55%       { opacity: 0.5; transform: scale(1.4); }
-        100%      { opacity: 0; transform: scale(2); }
+        0%, 35%   { opacity: 0; transform: scale(0.55); }
+        55%       { opacity: 0.55; transform: scale(1.5); }
+        100%      { opacity: 0; transform: scale(2.1); }
       }
       .taskito-pool .taskito-worker-dot-active {
         opacity: 0;
@@ -269,11 +294,11 @@ function PoolStyles() {
       }
       @media (prefers-reduced-motion: no-preference) {
         .taskito-pool .taskito-incoming-dot {
-          animation: taskito-incoming-flow 2.2s linear infinite;
-          filter: drop-shadow(0 0 2px var(--color-fd-primary));
+          animation: taskito-incoming-flow 2.4s linear infinite;
+          filter: drop-shadow(0 0 3px var(--color-fd-primary));
         }
         .taskito-pool .taskito-result {
-          animation: taskito-result-flow 2.2s linear infinite;
+          animation: taskito-result-flow 2.4s linear infinite;
         }
         .taskito-pool .taskito-worker-dot-active {
           animation: taskito-worker-active-pulse var(--worker-duration) ease-in-out infinite;

--- a/docs/src/app/(home)/page.tsx
+++ b/docs/src/app/(home)/page.tsx
@@ -1,9 +1,16 @@
-import { ComparisonSection, CTA, Features, Hero } from "./_sections";
+import {
+  ComparisonSection,
+  CTA,
+  Features,
+  Hero,
+  HowItWorks,
+} from "./_sections";
 
 export default function HomePage() {
   return (
     <main className="flex flex-col flex-1">
       <Hero />
+      <HowItWorks />
       <Features />
       <ComparisonSection />
       <CTA />

--- a/docs/src/app/(home)/page.tsx
+++ b/docs/src/app/(home)/page.tsx
@@ -4,6 +4,9 @@ import {
   Features,
   Hero,
   HowItWorks,
+  Integrations,
+  UseCases,
+  WorkerPool,
 } from "./_sections";
 
 export default function HomePage() {
@@ -11,7 +14,10 @@ export default function HomePage() {
     <main className="flex flex-col flex-1">
       <Hero />
       <HowItWorks />
+      <WorkerPool />
       <Features />
+      <UseCases />
+      <Integrations />
       <ComparisonSection />
       <CTA />
     </main>

--- a/docs/src/app/global.css
+++ b/docs/src/app/global.css
@@ -2,6 +2,19 @@
 @import "fumadocs-ui/css/neutral.css";
 @import "fumadocs-ui/css/preset.css";
 
+@theme {
+  --font-sans:
+    var(--font-sans), "IBM Plex Sans", ui-sans-serif, system-ui, sans-serif;
+  --font-mono:
+    var(--font-mono), "IBM Plex Mono", ui-monospace, SFMono-Regular,
+    "Cascadia Mono", monospace;
+  --font-handwritten: var(--font-handwritten), "Caveat", cursive;
+  --color-fd-sketch:
+    color-mix(in oklch, var(--color-fd-foreground) 55%, transparent);
+  --color-fd-sketch-strong:
+    color-mix(in oklch, var(--color-fd-foreground) 75%, transparent);
+}
+
 html {
   scrollbar-gutter: stable;
 }

--- a/docs/src/app/global.css
+++ b/docs/src/app/global.css
@@ -8,7 +8,7 @@
   --font-mono:
     var(--font-mono), "IBM Plex Mono", ui-monospace, SFMono-Regular,
     "Cascadia Mono", monospace;
-  --font-handwritten: var(--font-handwritten), "Caveat", cursive;
+  --font-handwritten: var(--font-handwritten), "Shantell Sans", "Caveat", cursive;
   --color-fd-sketch:
     color-mix(in oklch, var(--color-fd-foreground) 55%, transparent);
   --color-fd-sketch-strong:

--- a/docs/src/app/global.css
+++ b/docs/src/app/global.css
@@ -10,9 +10,11 @@
     "Cascadia Mono", monospace;
   --font-handwritten: var(--font-handwritten), "Shantell Sans", "Caveat", cursive;
   --color-fd-sketch:
-    color-mix(in oklch, var(--color-fd-foreground) 55%, transparent);
-  --color-fd-sketch-strong:
     color-mix(in oklch, var(--color-fd-foreground) 75%, transparent);
+  --color-fd-sketch-strong:
+    color-mix(in oklch, var(--color-fd-foreground) 92%, transparent);
+  --color-fd-sketch-accent:
+    color-mix(in oklch, var(--color-fd-primary) 80%, transparent);
 }
 
 html {

--- a/docs/src/app/layout.tsx
+++ b/docs/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Caveat, IBM_Plex_Mono, IBM_Plex_Sans } from "next/font/google";
+import { IBM_Plex_Mono, IBM_Plex_Sans, Shantell_Sans } from "next/font/google";
 import { Provider } from "@/components/provider";
 import "./global.css";
 
@@ -15,9 +15,8 @@ const ibmPlexMono = IBM_Plex_Mono({
   variable: "--font-mono",
 });
 
-const caveat = Caveat({
+const shantellSans = Shantell_Sans({
   subsets: ["latin"],
-  weight: ["500", "600", "700"],
   variable: "--font-handwritten",
 });
 
@@ -34,7 +33,7 @@ export default function Layout({ children }: LayoutProps<"/">) {
   return (
     <html
       lang="en"
-      className={`${ibmPlexSans.variable} ${ibmPlexMono.variable} ${caveat.variable} font-sans`}
+      className={`${ibmPlexSans.variable} ${ibmPlexMono.variable} ${shantellSans.variable} font-sans`}
       suppressHydrationWarning
     >
       <body className="flex flex-col min-h-screen">

--- a/docs/src/app/layout.tsx
+++ b/docs/src/app/layout.tsx
@@ -1,10 +1,24 @@
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
+import { Caveat, IBM_Plex_Mono, IBM_Plex_Sans } from "next/font/google";
 import { Provider } from "@/components/provider";
 import "./global.css";
 
-const inter = Inter({
+const ibmPlexSans = IBM_Plex_Sans({
   subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+  variable: "--font-sans",
+});
+
+const ibmPlexMono = IBM_Plex_Mono({
+  subsets: ["latin"],
+  weight: ["400", "500", "600"],
+  variable: "--font-mono",
+});
+
+const caveat = Caveat({
+  subsets: ["latin"],
+  weight: ["500", "600", "700"],
+  variable: "--font-handwritten",
 });
 
 export const metadata: Metadata = {
@@ -18,7 +32,11 @@ export const metadata: Metadata = {
 
 export default function Layout({ children }: LayoutProps<"/">) {
   return (
-    <html lang="en" className={inter.className} suppressHydrationWarning>
+    <html
+      lang="en"
+      className={`${ibmPlexSans.variable} ${ibmPlexMono.variable} ${caveat.variable} font-sans`}
+      suppressHydrationWarning
+    >
       <body className="flex flex-col min-h-screen">
         <Provider>{children}</Provider>
       </body>

--- a/docs/src/components/diagram-carousel.tsx
+++ b/docs/src/components/diagram-carousel.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import {
+  Children,
+  isValidElement,
+  type ReactElement,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { cn } from "@/lib/cn";
+
+type DiagramSlideProps = {
+  title?: string;
+  children: ReactNode;
+};
+
+export function DiagramSlide({ children }: DiagramSlideProps) {
+  return <>{children}</>;
+}
+
+type SlideElement = ReactElement<DiagramSlideProps>;
+
+export function DiagramCarousel({
+  children,
+  title,
+}: {
+  children: ReactNode;
+  title?: string;
+}) {
+  const slides = Children.toArray(children).filter(
+    (child): child is SlideElement => isValidElement(child),
+  );
+  const total = slides.length;
+  const containerRef = useRef<HTMLElement | null>(null);
+  const [index, setIndex] = useState(0);
+
+  const prev = useCallback(
+    () => setIndex((i) => (i - 1 + total) % total),
+    [total],
+  );
+  const next = useCallback(() => setIndex((i) => (i + 1) % total), [total]);
+
+  useEffect(() => {
+    const node = containerRef.current;
+    if (!node) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "ArrowLeft") {
+        e.preventDefault();
+        prev();
+      } else if (e.key === "ArrowRight") {
+        e.preventDefault();
+        next();
+      }
+    }
+    node.addEventListener("keydown", onKey);
+    return () => node.removeEventListener("keydown", onKey);
+  }, [prev, next]);
+
+  if (total === 0) return null;
+
+  const activeTitle = slides[index]?.props.title;
+
+  return (
+    <section
+      ref={containerRef as React.RefObject<HTMLElement>}
+      className="taskito-carousel my-6 rounded-lg border border-fd-border bg-fd-card overflow-hidden focus:outline-none focus:ring-2 focus:ring-fd-primary/40"
+      // biome-ignore lint/a11y/noNoninteractiveTabindex: container hosts arrow-key navigation per WAI-ARIA carousel pattern
+      tabIndex={0}
+      aria-roledescription="carousel"
+      aria-label={title ?? "Diagram carousel"}
+    >
+      <div className="flex items-center justify-between gap-4 px-4 py-3 border-b border-fd-border bg-fd-muted">
+        <div className="flex items-baseline gap-2 min-w-0">
+          {title && (
+            <span className="text-sm font-semibold text-fd-foreground shrink-0">
+              {title}
+            </span>
+          )}
+          {activeTitle && (
+            <span className="text-sm text-fd-muted-foreground truncate font-mono">
+              {title ? "·" : ""} {activeTitle}
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-3 shrink-0">
+          <span className="text-xs text-fd-muted-foreground tabular-nums">
+            {index + 1} / {total}
+          </span>
+          <div className="flex gap-1">
+            <button
+              type="button"
+              onClick={prev}
+              aria-label="Previous diagram"
+              className="size-7 rounded-md border border-fd-border hover:bg-fd-accent hover:border-fd-primary/40 flex items-center justify-center transition-colors"
+            >
+              <ChevronLeft className="size-4" />
+            </button>
+            <button
+              type="button"
+              onClick={next}
+              aria-label="Next diagram"
+              className="size-7 rounded-md border border-fd-border hover:bg-fd-accent hover:border-fd-primary/40 flex items-center justify-center transition-colors"
+            >
+              <ChevronRight className="size-4" />
+            </button>
+          </div>
+        </div>
+      </div>
+      <div className="relative">
+        {slides.map((slide, i) => (
+          <div
+            // biome-ignore lint/suspicious/noArrayIndexKey: stable list of slides
+            key={i}
+            style={{ display: i === index ? "block" : "none" }}
+            className="px-4 pb-2"
+            aria-hidden={i !== index}
+          >
+            {slide}
+          </div>
+        ))}
+      </div>
+      <div className="flex items-center justify-center gap-2 py-3 border-t border-fd-border bg-fd-muted/40">
+        {slides.map((slide, i) => {
+          const slideTitle = slide.props.title;
+          return (
+            <button
+              // biome-ignore lint/suspicious/noArrayIndexKey: stable list of slides
+              key={i}
+              type="button"
+              onClick={() => setIndex(i)}
+              aria-label={`Go to ${slideTitle ?? `diagram ${i + 1}`}`}
+              aria-current={i === index}
+              className={cn(
+                "h-1.5 rounded-full transition-all",
+                i === index
+                  ? "w-7 bg-fd-primary"
+                  : "w-1.5 bg-fd-muted-foreground/30 hover:bg-fd-muted-foreground/60",
+              )}
+            />
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/docs/src/components/mdx.tsx
+++ b/docs/src/components/mdx.tsx
@@ -1,11 +1,14 @@
 import defaultMdxComponents from "fumadocs-ui/mdx";
 import type { MDXComponents } from "mdx/types";
+import { DiagramCarousel, DiagramSlide } from "./diagram-carousel";
 import { Mermaid } from "./mermaid";
 
 export function getMDXComponents(components?: MDXComponents) {
   return {
     ...defaultMdxComponents,
     Mermaid,
+    DiagramCarousel,
+    DiagramSlide,
     ...components,
   } satisfies MDXComponents;
 }

--- a/docs/src/components/mermaid.tsx
+++ b/docs/src/components/mermaid.tsx
@@ -25,6 +25,25 @@ const DARK_THEME_VARIABLES = {
   noteBorderColor: "#7a7d85",
   errorBkgColor: "#4a1d1d",
   errorTextColor: "#fca5a5",
+  // erDiagram-specific (entity attribute rows)
+  attributeBackgroundColorOdd: "#1f2024",
+  attributeBackgroundColorEven: "#272a30",
+  // stateDiagram-specific
+  altBackground: "#26282d",
+  // flowchart label colors
+  labelBackground: "#2a2c31",
+  // sequenceDiagram
+  actorBkg: "#1f2024",
+  actorBorder: "#7a7d85",
+  actorTextColor: "#f5f5f7",
+  actorLineColor: "#9b9ea6",
+  signalColor: "#f5f5f7",
+  signalTextColor: "#f5f5f7",
+  labelBoxBkgColor: "#2a2c31",
+  labelBoxBorderColor: "#7a7d85",
+  loopTextColor: "#f5f5f7",
+  activationBkgColor: "#3a3c41",
+  activationBorderColor: "#9b9ea6",
 } as const;
 
 const LIGHT_THEME_VARIABLES = {
@@ -47,6 +66,25 @@ const LIGHT_THEME_VARIABLES = {
   noteBkgColor: "#fef9c3",
   noteTextColor: "#1a1a1a",
   noteBorderColor: "#a1a1aa",
+  // erDiagram-specific (entity attribute rows)
+  attributeBackgroundColorOdd: "#ffffff",
+  attributeBackgroundColorEven: "#f4f4f5",
+  // stateDiagram-specific
+  altBackground: "#f4f4f5",
+  // flowchart label colors
+  labelBackground: "#ffffff",
+  // sequenceDiagram
+  actorBkg: "#ffffff",
+  actorBorder: "#3a3a3a",
+  actorTextColor: "#1a1a1a",
+  actorLineColor: "#4a4a4a",
+  signalColor: "#1a1a1a",
+  signalTextColor: "#1a1a1a",
+  labelBoxBkgColor: "#ffffff",
+  labelBoxBorderColor: "#3a3a3a",
+  loopTextColor: "#1a1a1a",
+  activationBkgColor: "#f4f4f5",
+  activationBorderColor: "#4a4a4a",
 } as const;
 
 export function Mermaid({ chart }: { chart: string }) {

--- a/docs/src/components/mermaid.tsx
+++ b/docs/src/components/mermaid.tsx
@@ -39,7 +39,7 @@ export function Mermaid({ chart }: { chart: string }) {
   return (
     <div
       ref={containerRef}
-      className="my-4 flex justify-center [&_svg]:max-w-full"
+      className="my-4 flex justify-center font-handwritten [&_svg]:max-w-full"
       // biome-ignore lint/security/noDangerouslySetInnerHtml: mermaid produces trusted SVG from author content
       dangerouslySetInnerHTML={{ __html: svg }}
     />

--- a/docs/src/components/mermaid.tsx
+++ b/docs/src/components/mermaid.tsx
@@ -3,6 +3,52 @@
 import { useTheme } from "next-themes";
 import { useEffect, useId, useRef, useState } from "react";
 
+const DARK_THEME_VARIABLES = {
+  background: "transparent",
+  primaryColor: "#1f2024",
+  primaryTextColor: "#f5f5f7",
+  primaryBorderColor: "#7a7d85",
+  lineColor: "#9b9ea6",
+  secondaryColor: "#2a2c31",
+  tertiaryColor: "#26282d",
+  mainBkg: "#1f2024",
+  nodeBkg: "#1f2024",
+  nodeBorder: "#7a7d85",
+  clusterBkg: "#1a1b1e",
+  clusterBorder: "#5a5d65",
+  edgeLabelBackground: "#2a2c31",
+  titleColor: "#f5f5f7",
+  labelTextColor: "#f5f5f7",
+  textColor: "#f5f5f7",
+  noteBkgColor: "#3a3c41",
+  noteTextColor: "#f5f5f7",
+  noteBorderColor: "#7a7d85",
+  errorBkgColor: "#4a1d1d",
+  errorTextColor: "#fca5a5",
+} as const;
+
+const LIGHT_THEME_VARIABLES = {
+  background: "transparent",
+  primaryColor: "#ffffff",
+  primaryTextColor: "#1a1a1a",
+  primaryBorderColor: "#3a3a3a",
+  lineColor: "#4a4a4a",
+  secondaryColor: "#f4f4f5",
+  tertiaryColor: "#fafafa",
+  mainBkg: "#ffffff",
+  nodeBkg: "#ffffff",
+  nodeBorder: "#3a3a3a",
+  clusterBkg: "#f4f4f5",
+  clusterBorder: "#a1a1aa",
+  edgeLabelBackground: "#ffffff",
+  titleColor: "#1a1a1a",
+  labelTextColor: "#1a1a1a",
+  textColor: "#1a1a1a",
+  noteBkgColor: "#fef9c3",
+  noteTextColor: "#1a1a1a",
+  noteBorderColor: "#a1a1aa",
+} as const;
+
 export function Mermaid({ chart }: { chart: string }) {
   const id = useId();
   const containerRef = useRef<HTMLDivElement>(null);
@@ -13,11 +59,22 @@ export function Mermaid({ chart }: { chart: string }) {
     let cancelled = false;
     void (async () => {
       const mermaid = (await import("mermaid")).default;
+      if (typeof document !== "undefined" && document.fonts?.ready) {
+        await document.fonts.ready;
+      }
+      const isDark = resolvedTheme === "dark";
       mermaid.initialize({
         startOnLoad: false,
-        theme: resolvedTheme === "dark" ? "dark" : "default",
+        theme: "base",
+        themeVariables: isDark ? DARK_THEME_VARIABLES : LIGHT_THEME_VARIABLES,
         securityLevel: "loose",
-        fontFamily: "inherit",
+        fontFamily: '"IBM Plex Sans", "Inter", system-ui, sans-serif',
+        flowchart: { padding: 18, htmlLabels: true, useMaxWidth: true },
+        sequence: {
+          actorFontFamily: '"IBM Plex Sans", sans-serif',
+          noteFontFamily: '"IBM Plex Sans", sans-serif',
+          messageFontFamily: '"IBM Plex Sans", sans-serif',
+        },
       });
       try {
         const renderId = `m${id.replace(/[^a-zA-Z0-9]/g, "")}`;
@@ -39,7 +96,7 @@ export function Mermaid({ chart }: { chart: string }) {
   return (
     <div
       ref={containerRef}
-      className="my-4 flex justify-center font-handwritten [&_svg]:max-w-full"
+      className="my-6 flex justify-center [&_svg]:max-w-full"
       // biome-ignore lint/security/noDangerouslySetInnerHtml: mermaid produces trusted SVG from author content
       dangerouslySetInnerHTML={{ __html: svg }}
     />

--- a/docs/src/lib/landing-content.tsx
+++ b/docs/src/lib/landing-content.tsx
@@ -1,8 +1,11 @@
 import {
   Activity,
+  Clock,
   Cpu,
+  Database,
   Layers,
   type LucideIcon,
+  Mail,
   Shield,
   Workflow,
   Zap,
@@ -198,6 +201,72 @@ send_email.delay("alice@example.com", "Hi", "Body")
     },
   ],
 };
+
+export type UseCase = {
+  icon: LucideIcon;
+  title: string;
+  body: string;
+  href: string;
+};
+
+export const USE_CASES_TITLE = "Built for the jobs you actually have";
+export const USE_CASES_DESCRIPTION =
+  "Pick the workload — taskito ships the primitives.";
+
+export const USE_CASES: UseCase[] = [
+  {
+    icon: Database,
+    title: "ETL pipelines",
+    body: "Chain extract → transform → load as a DAG. Fan out across workers, fan in to aggregate, restart from any node on failure.",
+    href: "/docs/guides/workflows",
+  },
+  {
+    icon: Mail,
+    title: "Email & notifications",
+    body: "Bursty SMTP, push, or webhook delivery. Per-task rate limits keep providers happy; retries with backoff handle transient failures.",
+    href: "/docs/guides/reliability/retries",
+  },
+  {
+    icon: Cpu,
+    title: "ML inference & batch",
+    body: "Long-running model jobs with progress tracking, soft timeouts, and prefork pools for true CPU parallelism without GIL contention.",
+    href: "/docs/guides/advanced-execution/prefork",
+  },
+  {
+    icon: Clock,
+    title: "Scheduled jobs",
+    body: "Six-field cron syntax down to the second. Periodic tasks live in the scheduler — no separate beat daemon to babysit.",
+    href: "/docs/guides/core/scheduling",
+  },
+];
+
+export const INTEGRATIONS_TITLE = "Slots into your stack";
+export const INTEGRATIONS_DESCRIPTION =
+  "First-class support for the tools you already run.";
+
+export type IntegrationGroup = {
+  group: string;
+  items: string[];
+};
+
+export const INTEGRATIONS: IntegrationGroup[] = [
+  {
+    group: "Frameworks",
+    items: ["Django", "FastAPI", "Flask"],
+  },
+  {
+    group: "Storage",
+    items: ["Postgres", "SQLite", "Redis"],
+  },
+  {
+    group: "Observability",
+    items: ["OpenTelemetry", "Sentry", "Prometheus"],
+  },
+  {
+    group: "Serialization",
+    items: ["JSON", "MsgPack", "Cloudpickle"],
+  },
+];
 
 export const CTA: LandingCta = {
   title: "Five minutes from `pip install` to your first job.",


### PR DESCRIPTION
A small interactive landing-page section that earns its keep by demonstrating the product instead of decorating it.

## What

Drops a 300×56 SVG strip between **Hero** and **Features** showing a job traveling **enqueue → queue → worker → result** on a 4.5-second loop. Pure SVG + CSS keyframes — no Framer Motion, no client component, no extra deps.

- The job (small filled circle in the brand accent color) moves between four station markers, holding briefly at each.
- A pulse ring expands at each station the moment the job arrives — subtle "the worker just picked it up" cue.
- Connecting line is dashed, suggesting "data in motion" without being too literal.
- Station labels live below each marker (\`enqueue\`, \`queue\`, \`worker\`, \`result\`).

## Why this and not other animation options

The animations I deliberately skipped, and why:
- **Card-tilt / spotlight on Features grid** — generic AI aesthetic, doesn't say anything taskito-specific.
- **Counting-up "7 vs 22 lines"** above the Comparison — the side-by-side panels already do that work; a ticker reads as marketing.
- **Scroll-triggered fade-ins** — fights screen readers, gets disabled by reduced-motion anyway, adds perceived latency.
- **Animated gradient backgrounds** — pure decoration. The static radial gradient in the Hero is enough.
- **Typed-out hero code snippet** — cliché. The Shiki-highlighted static snippet is more honest.

The job-flow strip is the only one that *teaches the model* — it visualizes what taskito actually does, in a way the comparison panels (which show *code*, not *behavior*) can't.

## Implementation notes

- **Server component**, async-free. Pure rendered SVG — animations run via CSS that the browser handles.
- **`prefers-reduced-motion: reduce`** disables the keyframes entirely. The strip falls back to a static end-state showing all four stations, no motion. Fully WCAG-compliant.
- **No new dependencies.** Uses the same `--color-fd-*` tokens as the rest of the landing page.
- **CSS is colocated** in an inline \`<style>\` tag inside the component (React supports this in server components). Class names are prefixed \`taskito-job-*\` to avoid collisions.
- **Compatible with \`output: 'export'\`** — everything pre-renders at build time; the only "runtime" thing is the browser playing CSS keyframes.

## Test plan

- [x] \`pnpm --dir docs types:check\` — clean
- [x] \`pnpm --dir docs lint\` — clean (2 known scaffold-CSS warnings unchanged)
- [x] \`pnpm --dir docs build\` — clean static export, same route count
- [ ] CI: \`Deploy Docs\` job
- [ ] Visual smoke on the deploy preview:
  - Strip sits below Hero, above Features, with proper vertical rhythm
  - Job circle moves smoothly between stations, no jitter on Chromium / Firefox / Safari
  - Pulse ring fires at each station as the job arrives
  - Dark mode: line is faint dashed (\`--color-fd-border\`), job is amber (\`--color-fd-primary\`), labels are muted
- [ ] **Accessibility check**: System Settings → Accessibility → "Reduce motion" enabled → strip should render static (no animation), still readable
- [ ] Mobile (375px viewport) — strip scales via \`max-w-lg\`, labels stay legible

## Non-goals

- No interactivity (clicking, hovering). The strip is illustrative, not a control surface.
- No real-time data binding to actual queue stats. The flow is a generic illustration of *the model*, not a live dashboard.
- No expansion to other sections of the site. This is landing-page only.