### PR TITLE
fix(docs): force ER attribute text color via themeCSS in dark mode

### DIFF
--- a/docs/src/components/mermaid.tsx
+++ b/docs/src/components/mermaid.tsx
@@ -4,6 +4,7 @@ import { useTheme } from "next-themes";
 import { useEffect, useId, useRef, useState } from "react";
 
 const DARK_THEME_VARIABLES = {
+  darkMode: true,
   background: "transparent",
   primaryColor: "#1f2024",
   primaryTextColor: "#f5f5f7",
@@ -25,9 +26,9 @@ const DARK_THEME_VARIABLES = {
   noteBorderColor: "#7a7d85",
   errorBkgColor: "#4a1d1d",
   errorTextColor: "#fca5a5",
-  // erDiagram-specific (entity attribute rows)
+  // erDiagram-specific (entity attribute rows) — same color, no zebra stripe
   attributeBackgroundColorOdd: "#1f2024",
-  attributeBackgroundColorEven: "#272a30",
+  attributeBackgroundColorEven: "#1f2024",
   // stateDiagram-specific
   altBackground: "#26282d",
   // flowchart label colors
@@ -46,7 +47,37 @@ const DARK_THEME_VARIABLES = {
   activationBorderColor: "#9b9ea6",
 } as const;
 
+const DARK_THEME_CSS = `
+  .er.entityBox { fill: #1f2024 !important; stroke: #7a7d85 !important; }
+  .er.entityLabel { fill: #f5f5f7 !important; }
+  .er.attributeBoxOdd { fill: #1f2024 !important; }
+  .er.attributeBoxEven { fill: #1f2024 !important; }
+  .er .er.attribute-text,
+  .er .attribute-text,
+  .er text {
+    fill: #f5f5f7 !important;
+  }
+  .er.relationshipLabel,
+  .er.relationshipLabelBox {
+    fill: #f5f5f7 !important;
+  }
+  .er.relationshipLabelBox + text { fill: #1a1a1a !important; }
+`;
+
+const LIGHT_THEME_CSS = `
+  .er.entityBox { fill: #ffffff !important; stroke: #3a3a3a !important; }
+  .er.entityLabel { fill: #1a1a1a !important; }
+  .er.attributeBoxOdd { fill: #ffffff !important; }
+  .er.attributeBoxEven { fill: #f4f4f5 !important; }
+  .er .er.attribute-text,
+  .er .attribute-text,
+  .er text {
+    fill: #1a1a1a !important;
+  }
+`;
+
 const LIGHT_THEME_VARIABLES = {
+  darkMode: false,
   background: "transparent",
   primaryColor: "#ffffff",
   primaryTextColor: "#1a1a1a",
@@ -105,6 +136,7 @@ export function Mermaid({ chart }: { chart: string }) {
         startOnLoad: false,
         theme: "base",
         themeVariables: isDark ? DARK_THEME_VARIABLES : LIGHT_THEME_VARIABLES,
+        themeCSS: isDark ? DARK_THEME_CSS : LIGHT_THEME_CSS,
         securityLevel: "loose",
         fontFamily: '"IBM Plex Sans", "Inter", system-ui, sans-serif',
         flowchart: { padding: 18, htmlLabels: true, useMaxWidth: true },


### PR DESCRIPTION
Follow-up to #131. The 7-slide schema carousel showed alternating dim text in dark mode — odd rows ended up with washed-out characters that were nearly unreadable.

## Root cause

Two compounding issues:

1. **Mermaid's auto-contrast for ER rows.** With odd-vs-even row backgrounds set to two slightly different shades (`#1f2024` / `#272a30`), Mermaid's internal heuristics chose different text colors for each — and in dark mode the choice for one of them landed on a low-contrast grey instead of the configured `textColor`.

2. **`themeVariables.textColor` doesn't propagate to ER `.attribute-text` reliably.** The ER renderer uses its own internal class hierarchy (`.er.attributeBoxOdd`, `.er.attributeBoxEven`, `.er .attribute-text`) and doesn't always read from `textColor`. Some Mermaid versions ship hardcoded fills.

## Fix

Three layers of defense in `docs/src/components/mermaid.tsx`:

1. **Drop the zebra stripe** — set both `attributeBackgroundColorOdd` and `attributeBackgroundColorEven` to the same value (`#1f2024` dark / `#ffffff` light). Removes the auto-contrast asymmetry entirely.
2. **`darkMode: true` flag** in dark theme variables. Tells Mermaid which way internal heuristics should lean for any color it auto-picks.
3. **`themeCSS` override with `!important`** — explicit CSS injected into every Mermaid SVG forcing `.er.entityBox`, `.er.entityLabel`, `.er.attributeBoxOdd/Even`, `.er .attribute-text`, and `.er text` to the right fill colors. Belt-and-suspenders against any Mermaid-version-specific hardcoded values.

Light theme keeps a subtle alternation (`#ffffff` / `#f4f4f5`) since the contrast is fine on a light bg.

## Test plan

- [x] `pnpm --dir docs types:check` clean
- [x] `pnpm --dir docs lint` clean
- [x] `pnpm --dir docs build` clean
- [ ] CI: `Deploy Docs` job
- [ ] Visual: open `/docs/architecture/storage` in dark mode, flip through all 7 carousel slides — every column (TYPE / NAME / KEY) should be uniformly readable on every row.
- [ ] Light mode same page — subtle row striping, all text readable.
- [ ] Other Mermaid diagrams still render correctly (`/docs/architecture/job-lifecycle`, `/docs/architecture/scheduler`).