### PR TITLE
docs: rewrite Celery migration table notes for specificity

### DIFF
--- a/docs/content/docs/guides/operations/migration.mdx
+++ b/docs/content/docs/guides/operations/migration.mdx
@@ -14,17 +14,17 @@ with less infrastructure and simpler configuration.
 
 | Celery | taskito | Notes |
 |---|---|---|
-| `Celery()` app | `Queue()` | No broker URL needed |
-| `@app.task` | `@queue.task()` | Same decorator pattern |
-| `.apply_async()` | `.apply_async()` | Same name, similar API |
-| `.delay()` | `.delay()` | Identical |
-| `AsyncResult` | `JobResult` | `.result()` instead of `.get()` |
-| Canvas (`chain`, `group`, `chord`) | `chain`, `group`, `chord` | Same names, same concepts |
-| `celery beat` | `@queue.periodic()` | Built-in, no separate process |
-| Result backend (Redis/DB) | Built-in (SQLite) | No configuration needed |
-| Broker (Redis/RabbitMQ) | Not needed | SQLite handles everything |
-| `celery worker` | `taskito worker` | Similar CLI |
-| `celery inspect` | `taskito info` | Similar CLI |
+| `Celery()` app | `Queue()` | `Queue(db_path=...)` replaces `Celery(broker=..., backend=...)` — no broker URL, no result-backend URL, no `app.conf` setup. |
+| `@app.task` | `@queue.task()` | Same decorator shape; `max_retries`, `rate_limit`, `bind=True`, `name=` carry over with identical names. |
+| `.apply_async()` | `.apply_async()` | Same kwargs (`countdown`, `eta`, `priority`, `queue`); taskito adds `delay`, `unique_key`, `expires`, `depends_on`. |
+| `.delay()` | `.delay()` | Drop-in. Returns `JobResult` instead of `AsyncResult`. |
+| `AsyncResult` | `JobResult` | `.result(timeout=...)` replaces `.get(timeout=...)`; async variant `await job.aresult()`. |
+| Canvas (`chain`, `group`, `chord`) | `chain`, `group`, `chord` | API-compatible. taskito adds a DAG `Workflow` builder with conditions, gates, and fan-in. |
+| `celery beat` | `@queue.periodic()` | No separate beat daemon. Cron expressions support seconds (6 fields) and live in the worker process. |
+| Result backend (Redis/DB) | Built-in (SQLite) | Results store in the same SQLite file as jobs. Per-job `result_ttl_ms` controls retention. |
+| Broker (Redis/RabbitMQ) | Not needed | A single SQLite (or Postgres) connection replaces the broker. WAL mode allows concurrent reads. |
+| `celery worker` | `taskito worker` | `--concurrency`, `--queues`, `--loglevel` carry over. taskito adds `--pool prefork` for CPU parallelism. |
+| `celery inspect` | `taskito info` | Covers `inspect active/scheduled/registered`. `taskito dashboard` is the live UI version. |
 
 ## Side-by-side examples
 


### PR DESCRIPTION
The "Notes" column on the Celery → taskito concept-mapping table was too thin to actually help someone migrating. It mostly restated the obvious ("Same name, similar API", "Same decorator pattern", "Similar CLI") without telling the reader what specifically changes when they switch.

This PR rewrites every Notes cell to surface the practical delta — what kwargs carry over, what the return type becomes, what flags are new in taskito.

## Before vs after

| Celery | taskito | Before | After |
|---|---|---|---|
| \`Celery()\` app | \`Queue()\` | No broker URL needed | \`Queue(db_path=...)\` replaces \`Celery(broker=..., backend=...)\` — no broker URL, no result-backend URL, no \`app.conf\` setup. |
| \`@app.task\` | \`@queue.task()\` | Same decorator pattern | Same decorator shape; \`max_retries\`, \`rate_limit\`, \`bind=True\`, \`name=\` carry over with identical names. |
| \`.apply_async()\` | \`.apply_async()\` | Same name, similar API | Same kwargs (\`countdown\`, \`eta\`, \`priority\`, \`queue\`); taskito adds \`delay\`, \`unique_key\`, \`expires\`, \`depends_on\`. |
| \`.delay()\` | \`.delay()\` | Identical | Drop-in. Returns \`JobResult\` instead of \`AsyncResult\`. |
| \`AsyncResult\` | \`JobResult\` | \`.result()\` instead of \`.get()\` | \`.result(timeout=...)\` replaces \`.get(timeout=...)\`; async variant \`await job.aresult()\`. |
| Canvas | \`chain\`, \`group\`, \`chord\` | Same names, same concepts | API-compatible. taskito adds a DAG \`Workflow\` builder with conditions, gates, and fan-in. |
| \`celery beat\` | \`@queue.periodic()\` | Built-in, no separate process | No separate beat daemon. Cron expressions support seconds (6 fields) and live in the worker process. |
| Result backend | Built-in (SQLite) | No configuration needed | Results store in the same SQLite file as jobs. Per-job \`result_ttl_ms\` controls retention. |
| Broker | Not needed | SQLite handles everything | A single SQLite (or Postgres) connection replaces the broker. WAL mode allows concurrent reads. |
| \`celery worker\` | \`taskito worker\` | Similar CLI | \`--concurrency\`, \`--queues\`, \`--loglevel\` carry over. taskito adds \`--pool prefork\` for CPU parallelism. |
| \`celery inspect\` | \`taskito info\` | Similar CLI | Covers \`inspect active/scheduled/registered\`. \`taskito dashboard\` is the live UI version. |

## Conventions used

- Lead with the concrete API delta where applicable (\`X replaces Y\` / \`Drop-in. Returns Z\`).
- Mention taskito-only additions only when proximate (e.g. \`--pool prefork\` on \`worker\`, \`unique_key\` on \`apply_async\`) — keeps each row scannable.
- Backtick everything that is code.
- Tone stays casual; no row grows past two sentences.

## Test plan

- [x] \`pnpm --dir docs build\` — clean build
- [ ] CI: \`Deploy Docs\` job
- [ ] Visual smoke: open \`/docs/guides/operations/migration\` and confirm the table reflows correctly with the wider note cells in dark + light mode.