### PR TITLE
docs: nav structure, dark-mode diagrams, basePath

### DIFF
--- a/docs/content/docs/api-reference/meta.json
+++ b/docs/content/docs/api-reference/meta.json
@@ -1,6 +1,8 @@
 {
   "title": "API Reference",
+  "root": true,
   "pages": [
+    "index",
     "overview",
     "queue",
     "task",

--- a/docs/content/docs/api-reference/queue/meta.json
+++ b/docs/content/docs/api-reference/queue/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Queue",
-  "pages": ["index", "jobs", "queues", "workers", "resources", "events"]
+  "pages": ["jobs", "queues", "workers", "resources", "events"]
 }

--- a/docs/content/docs/architecture/meta.json
+++ b/docs/content/docs/architecture/meta.json
@@ -1,6 +1,8 @@
 {
   "title": "Architecture",
+  "root": true,
   "pages": [
+    "index",
     "overview",
     "job-lifecycle",
     "worker-pool",

--- a/docs/content/docs/getting-started/meta.json
+++ b/docs/content/docs/getting-started/meta.json
@@ -1,4 +1,5 @@
 {
   "title": "Getting Started",
+  "root": true,
   "pages": ["installation", "quickstart", "concepts"]
 }

--- a/docs/content/docs/guides/advanced-execution/meta.json
+++ b/docs/content/docs/guides/advanced-execution/meta.json
@@ -1,7 +1,6 @@
 {
   "title": "Advanced execution",
   "pages": [
-    "index",
     "prefork",
     "async-tasks",
     "streaming",

--- a/docs/content/docs/guides/core/meta.json
+++ b/docs/content/docs/guides/core/meta.json
@@ -1,7 +1,6 @@
 {
   "title": "Core",
   "pages": [
-    "index",
     "tasks",
     "queues",
     "workers",

--- a/docs/content/docs/guides/extensibility/meta.json
+++ b/docs/content/docs/guides/extensibility/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Extensibility",
-  "pages": ["index", "middleware", "serializers", "events-webhooks"]
+  "pages": ["middleware", "serializers", "events-webhooks"]
 }

--- a/docs/content/docs/guides/integrations/meta.json
+++ b/docs/content/docs/guides/integrations/meta.json
@@ -1,12 +1,4 @@
 {
   "title": "Integrations",
-  "pages": [
-    "index",
-    "flask",
-    "fastapi",
-    "django",
-    "otel",
-    "prometheus",
-    "sentry"
-  ]
+  "pages": ["flask", "fastapi", "django", "otel", "prometheus", "sentry"]
 }

--- a/docs/content/docs/guides/meta.json
+++ b/docs/content/docs/guides/meta.json
@@ -1,5 +1,6 @@
 {
   "title": "Guides",
+  "root": true,
   "pages": [
     "index",
     "core",

--- a/docs/content/docs/guides/observability/meta.json
+++ b/docs/content/docs/guides/observability/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Observability",
-  "pages": ["index", "monitoring", "logging", "dashboard", "dashboard-api"]
+  "pages": ["monitoring", "logging", "dashboard", "dashboard-api"]
 }

--- a/docs/content/docs/guides/operations/meta.json
+++ b/docs/content/docs/guides/operations/meta.json
@@ -1,7 +1,6 @@
 {
   "title": "Operations",
   "pages": [
-    "index",
     "testing",
     "job-management",
     "troubleshooting",

--- a/docs/content/docs/guides/reliability/meta.json
+++ b/docs/content/docs/guides/reliability/meta.json
@@ -1,7 +1,6 @@
 {
   "title": "Reliability",
   "pages": [
-    "index",
     "retries",
     "error-handling",
     "guarantees",

--- a/docs/content/docs/guides/resources/meta.json
+++ b/docs/content/docs/guides/resources/meta.json
@@ -1,7 +1,6 @@
 {
   "title": "Resources",
   "pages": [
-    "index",
     "interception",
     "dependency-injection",
     "proxies",

--- a/docs/content/docs/guides/workflows/building.mdx
+++ b/docs/content/docs/guides/workflows/building.mdx
@@ -113,20 +113,18 @@ This creates a `WorkflowRun` handle. Under the hood:
 Each step transitions through these states:
 
 <Mermaid
-  chart={`stateDiagram-v2
-    [*] --> Pending
-    Pending --> Running : job picked up
-    Running --> Completed : success
-    Running --> Failed : error (retries exhausted)
-    Pending --> Skipped : cascade / condition
-    Pending --> WaitingApproval : gate reached
-    WaitingApproval --> Completed : approved
-    WaitingApproval --> Failed : rejected
-    Pending --> CacheHit : incremental reuse
-    Completed --> [*]
-    Failed --> [*]
-    Skipped --> [*]
-    CacheHit --> [*]`}
+  chart={`flowchart TD
+    Start(( )) --> Pending([Pending])
+    Pending -- job picked up --> Running([Running])
+    Pending -- gate reached --> WaitingApproval([WaitingApproval])
+    Pending -- cascade / condition --> Skipped([Skipped])
+    Pending -- incremental reuse --> CacheHit([CacheHit])
+    Running -- success --> Completed([Completed])
+    Running -- retries exhausted --> Failed([Failed])
+    WaitingApproval -- approved --> Completed
+    WaitingApproval -- rejected --> Failed
+    classDef terminal stroke-dasharray: 4 3
+    class Completed,Failed,Skipped,CacheHit terminal`}
 />
 
 | Status | Terminal | Meaning |

--- a/docs/content/docs/guides/workflows/caching.mdx
+++ b/docs/content/docs/guides/workflows/caching.mdx
@@ -29,20 +29,17 @@ nodes are also dirty — even if they had cached results:
 
 <Mermaid
   chart={`graph LR
-    A["a — dirty (missing)"] --> B["b — dirty (propagated)"]
-    B --> C["c — dirty (propagated)"]
-    style A fill:#FFB6C1
-    style B fill:#FFB6C1
-    style C fill:#FFB6C1`}
+    A["a — dirty (missing)"]:::failed --> B["b — dirty (propagated)"]:::failed
+    B --> C["c — dirty (propagated)"]:::failed
+    classDef failed fill:#fecaca,color:#7f1d1d,stroke:#dc2626`}
 />
 
 <Mermaid
   chart={`graph LR
-    A["a — CACHE_HIT ✓"] --> B["b — dirty (failed in base)"]
-    B --> C["c — dirty (propagated)"]
-    style A fill:#90EE90
-    style B fill:#FFB6C1
-    style C fill:#FFB6C1`}
+    A["a — CACHE_HIT ✓"]:::success --> B["b — dirty (failed in base)"]:::failed
+    B --> C["c — dirty (propagated)"]:::failed
+    classDef success fill:#bbf7d0,color:#14532d,stroke:#16a34a
+    classDef failed fill:#fecaca,color:#7f1d1d,stroke:#dc2626`}
 />
 
 ## Cache TTL

--- a/docs/content/docs/guides/workflows/conditions.mdx
+++ b/docs/content/docs/guides/workflows/conditions.mdx
@@ -61,12 +61,11 @@ One failure skips **all** pending steps. The workflow transitions to `FAILED`.
 
 <Mermaid
   chart={`graph LR
-    A["a ✓"] --> B["b ✗"]
-    B --> C["c ━ SKIPPED"]
-    B --> D["d ━ SKIPPED"]
-    style B fill:#FFB6C1
-    style C fill:#F5F5F5
-    style D fill:#F5F5F5`}
+    A["a ✓"] --> B["b ✗"]:::failed
+    B --> C["c ━ SKIPPED"]:::skipped
+    B --> D["d ━ SKIPPED"]:::skipped
+    classDef failed fill:#fecaca,color:#7f1d1d,stroke:#dc2626
+    classDef skipped fill:#e5e7eb,color:#374151,stroke:#9ca3af`}
 />
 
   </Tab>
@@ -81,13 +80,13 @@ branches keep running**.
 
 <Mermaid
   chart={`graph TD
-    root["root ✓"] --> fail_branch["fail ✗"]
+    root["root ✓"] --> fail_branch["fail ✗"]:::failed
     root --> ok_branch["ok ✓"]
-    fail_branch --> after_fail["after_fail ━ SKIPPED"]
-    ok_branch --> after_ok["after_ok ✓"]
-    style fail_branch fill:#FFB6C1
-    style after_fail fill:#F5F5F5
-    style after_ok fill:#90EE90`}
+    fail_branch --> after_fail["after_fail ━ SKIPPED"]:::skipped
+    ok_branch --> after_ok["after_ok ✓"]:::success
+    classDef failed fill:#fecaca,color:#7f1d1d,stroke:#dc2626
+    classDef skipped fill:#e5e7eb,color:#374151,stroke:#9ca3af
+    classDef success fill:#bbf7d0,color:#14532d,stroke:#16a34a`}
 />
 
   </Tab>
@@ -110,11 +109,11 @@ wf.step("cleanup", cleanup, after="b", condition="always")  # runs even if b is 
 
 <Mermaid
   chart={`graph LR
-    A["a ✗ FAILED"] --> B["b ━ SKIPPED"]
-    B --> C["cleanup ✓ ALWAYS"]
-    style A fill:#FFB6C1
-    style B fill:#F5F5F5
-    style C fill:#90EE90`}
+    A["a ✗ FAILED"]:::failed --> B["b ━ SKIPPED"]:::skipped
+    B --> C["cleanup ✓ ALWAYS"]:::success
+    classDef failed fill:#fecaca,color:#7f1d1d,stroke:#dc2626
+    classDef skipped fill:#e5e7eb,color:#374151,stroke:#9ca3af
+    classDef success fill:#bbf7d0,color:#14532d,stroke:#16a34a`}
 />
 
 ## Combining conditions with fan-out

--- a/docs/content/docs/guides/workflows/fan-out.mdx
+++ b/docs/content/docs/guides/workflows/fan-out.mdx
@@ -8,15 +8,15 @@ into a downstream step.
 
 <Mermaid
   chart={`graph LR
-    fetch --> process_0["process[0]"]
+    fetch:::source --> process_0["process[0]"]
     fetch --> process_1["process[1]"]
     fetch --> process_2["process[2]"]
-    process_0 --> aggregate
+    process_0 --> aggregate:::sink
     process_1 --> aggregate
     process_2 --> aggregate
 
-    style fetch fill:#90EE90
-    style aggregate fill:#87CEEB`}
+    classDef source fill:#bbf7d0,color:#14532d,stroke:#16a34a
+    classDef sink fill:#bfdbfe,color:#1e3a8a,stroke:#3b82f6`}
 />
 
 ## Fan-out with `"each"`

--- a/docs/content/docs/guides/workflows/gates.mdx
+++ b/docs/content/docs/guides/workflows/gates.mdx
@@ -9,10 +9,11 @@ status until explicitly approved or rejected — or until a timeout fires.
 <Mermaid
   chart={`graph LR
     train["train ✓"] --> eval["evaluate ✓"]
-    eval --> gate["approve ⏸"]
+    eval --> gate["approve ⏸"]:::gate
     gate -->|approved| deploy["deploy"]
-    gate -->|rejected| skip["deploy ━ SKIPPED"]
-    style gate fill:#FFFACD`}
+    gate -->|rejected| skip["deploy ━ SKIPPED"]:::skipped
+    classDef gate fill:#fef3c7,color:#78350f,stroke:#d97706
+    classDef skipped fill:#e5e7eb,color:#374151,stroke:#9ca3af`}
 />
 
 ## Adding a gate

--- a/docs/content/docs/guides/workflows/meta.json
+++ b/docs/content/docs/guides/workflows/meta.json
@@ -1,7 +1,6 @@
 {
   "title": "Workflows",
   "pages": [
-    "index",
     "building",
     "fan-out",
     "conditions",

--- a/docs/content/docs/more/examples/meta.json
+++ b/docs/content/docs/more/examples/meta.json
@@ -1,7 +1,6 @@
 {
   "title": "Examples",
   "pages": [
-    "index",
     "fastapi-service",
     "notifications",
     "web-scraper",

--- a/docs/content/docs/more/meta.json
+++ b/docs/content/docs/more/meta.json
@@ -1,4 +1,5 @@
 {
   "title": "More",
+  "root": true,
   "pages": ["examples", "comparison", "faq", "changelog"]
 }

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -2,16 +2,15 @@ import { createMDX } from "fumadocs-mdx/next";
 
 const withMDX = createMDX();
 
-// `basePath` is only needed for the deployed GH Pages URL
-// (docs.byteveda.org/taskito). In dev (`pnpm dev`) it makes `localhost:3000`
-// 404 because the app moves to `localhost:3000/taskito`. Scope it to
-// production so dev hits the root.
-const isProd = process.env.NODE_ENV === "production";
+// Set `DOCS_BASE_PATH=/taskito` in CI to deploy under github.io/taskito.
+// Local `pnpm build && pnpm start` leaves it unset, so the static export
+// serves cleanly from the root and `serve out` just works.
+const basePath = process.env.DOCS_BASE_PATH ?? "";
 
 /** @type {import('next').NextConfig} */
 const config = {
   output: "export",
-  basePath: isProd ? "/taskito" : "",
+  basePath,
   reactStrictMode: true,
   images: {
     unoptimized: true,

--- a/docs/src/app/(home)/_sections/hero.tsx
+++ b/docs/src/app/(home)/_sections/hero.tsx
@@ -1,8 +1,9 @@
 import { ArrowRight } from "lucide-react";
+import Link from "next/link";
 import { Fragment } from "react";
 import { Button, CodePanel } from "@/components/ui";
 import { highlight } from "@/lib/highlight";
-import { HERO } from "@/lib/landing-content";
+import { DOC_SECTIONS, type DocSectionCard, HERO } from "@/lib/landing-content";
 import { WindowDots } from "./_window-dots";
 
 export async function Hero() {
@@ -51,7 +52,46 @@ export async function Hero() {
           {highlightedPreview}
         </CodePanel>
       </div>
+      <DocSectionCards />
     </section>
+  );
+}
+
+function DocSectionCards() {
+  return (
+    <nav
+      aria-label="Documentation sections"
+      className="max-w-5xl mx-auto mt-16 sm:mt-20 grid gap-4 sm:grid-cols-2 lg:grid-cols-4"
+    >
+      {DOC_SECTIONS.map((section) => (
+        <DocSectionCardLink key={section.href} section={section} />
+      ))}
+    </nav>
+  );
+}
+
+function DocSectionCardLink({ section }: { section: DocSectionCard }) {
+  const Icon = section.icon;
+  return (
+    <Link
+      href={section.href}
+      className="group relative flex h-full flex-col gap-3 rounded-xl border border-fd-border bg-fd-card p-5 transition-colors hover:border-fd-primary/40 hover:bg-fd-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fd-ring"
+    >
+      <div className="flex items-center justify-between">
+        <span className="inline-flex size-9 items-center justify-center rounded-lg border border-fd-border bg-fd-background text-fd-primary transition-colors group-hover:border-fd-primary/40 group-hover:bg-fd-primary/10">
+          <Icon className="size-4" />
+        </span>
+        <ArrowRight className="size-4 text-fd-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-fd-foreground" />
+      </div>
+      <div>
+        <h3 className="text-sm font-semibold text-fd-foreground">
+          {section.title}
+        </h3>
+        <p className="mt-1 text-xs leading-relaxed text-fd-muted-foreground">
+          {section.description}
+        </p>
+      </div>
+    </Link>
   );
 }
 

--- a/docs/src/app/(home)/layout.tsx
+++ b/docs/src/app/(home)/layout.tsx
@@ -1,6 +1,6 @@
 import { HomeLayout } from "fumadocs-ui/layouts/home";
-import { baseOptions } from "@/lib/layout.shared";
+import { homeOptions } from "@/lib/layout.shared";
 
 export default function Layout({ children }: LayoutProps<"/">) {
-  return <HomeLayout {...baseOptions()}>{children}</HomeLayout>;
+  return <HomeLayout {...homeOptions()}>{children}</HomeLayout>;
 }

--- a/docs/src/app/docs/layout.tsx
+++ b/docs/src/app/docs/layout.tsx
@@ -4,7 +4,7 @@ import { source } from "@/lib/source";
 
 export default function Layout({ children }: LayoutProps<"/docs">) {
   return (
-    <DocsLayout tree={source.getPageTree()} {...baseOptions()}>
+    <DocsLayout tabMode="top" tree={source.getPageTree()} {...baseOptions()}>
       {children}
     </DocsLayout>
   );

--- a/docs/src/lib/landing-content.tsx
+++ b/docs/src/lib/landing-content.tsx
@@ -1,12 +1,15 @@
 import {
   Activity,
+  BookOpen,
   Clock,
+  Code2,
   Cpu,
   Database,
   Layers,
   type LucideIcon,
   Mail,
   Shield,
+  Sparkles,
   Workflow,
   Zap,
 } from "lucide-react";
@@ -34,6 +37,44 @@ export type LandingFeature = {
   title: string;
   body: string;
 };
+
+export type DocSectionCard = {
+  icon: LucideIcon;
+  title: string;
+  description: string;
+  href: string;
+};
+
+export const DOC_SECTIONS: DocSectionCard[] = [
+  {
+    icon: BookOpen,
+    title: "Guides",
+    description:
+      "Recipes for tasks, queues, workers, retries, workflows, observability, and integrations.",
+    href: "/docs/guides",
+  },
+  {
+    icon: Layers,
+    title: "Architecture",
+    description:
+      "How the Rust core, scheduler, worker pool, storage, and resource graph fit together.",
+    href: "/docs/architecture/overview",
+  },
+  {
+    icon: Code2,
+    title: "API Reference",
+    description:
+      "Queues, tasks, results, contexts, the canvas, workflows, testing helpers, and the CLI.",
+    href: "/docs/api-reference/overview",
+  },
+  {
+    icon: Sparkles,
+    title: "More",
+    description:
+      "Worked examples, the Celery comparison, FAQ, and the per-release changelog.",
+    href: "/docs/more/examples",
+  },
+];
 
 export type ComparisonRow = {
   label: string;

--- a/docs/src/lib/layout.shared.tsx
+++ b/docs/src/lib/layout.shared.tsx
@@ -1,33 +1,41 @@
 import type { BaseLayoutProps } from "fumadocs-ui/layouts/shared";
 import { appName, gitConfig } from "./shared";
 
+const PRIMARY_NAV_LINKS = [
+  {
+    text: "Getting Started",
+    url: "/docs/getting-started/installation",
+  },
+  {
+    text: "Guides",
+    url: "/docs/guides",
+  },
+  {
+    text: "Architecture",
+    url: "/docs/architecture/overview",
+  },
+  {
+    text: "API",
+    url: "/docs/api-reference/overview",
+  },
+  {
+    text: "Changelog",
+    url: "/docs/more/changelog",
+  },
+];
+
 export function baseOptions(): BaseLayoutProps {
   return {
     nav: {
       title: appName,
     },
     githubUrl: `https://github.com/${gitConfig.user}/${gitConfig.repo}`,
-    links: [
-      {
-        text: "Getting Started",
-        url: "/docs/getting-started/installation",
-      },
-      {
-        text: "Guides",
-        url: "/docs/guides",
-      },
-      {
-        text: "Architecture",
-        url: "/docs/architecture/overview",
-      },
-      {
-        text: "API",
-        url: "/docs/api-reference/overview",
-      },
-      {
-        text: "Changelog",
-        url: "/docs/more/changelog",
-      },
-    ],
+  };
+}
+
+export function homeOptions(): BaseLayoutProps {
+  return {
+    ...baseOptions(),
+    links: PRIMARY_NAV_LINKS,
   };
 }


### PR DESCRIPTION
## Summary

- Promote top sections (Getting Started · Guides · Architecture · API Reference · More) to persistent sidebar tabs via `root: true` + `tabMode="top"`. Each tab lands on the section's `index.mdx`.
- Split shared layout options into `baseOptions` (docs) and `homeOptions` (home + primary nav links), removing the duplicate nav strip in the docs sidebar.
- Add a four-card "Documentation sections" grid to the home hero so the primary doc surfaces are reachable in one click from `/`.
- Fix workflow diagrams that were unreadable in dark mode (low-contrast fills with no `color`) — replaced ad-hoc `style X fill:#hex` lines with semantic `classDef`s pinning fill, text colour, and stroke.
- Convert the node-statuses diagram from `stateDiagram-v2` to `flowchart TD` so dense edge labels stop overlapping.
- Drop duplicate `"index"` entries from sub-folder `meta.json`s — they were rendering as a redundant child link beneath each folder header.
- Make the GH Pages basePath an explicit `DOCS_BASE_PATH` env var (replacing the `NODE_ENV === "production"` heuristic), so `pnpm build && pnpm start` previews work locally without 404 storms.

## Test plan

- [ ] `pnpm --dir docs types:check` passes
- [ ] `pnpm --dir docs lint` passes
- [ ] `pnpm --dir docs build` succeeds (full static export)
- [ ] `pnpm --dir docs start` serves at `http://localhost:3000/`; home, every section landing page, and a representative deep page render with no asset 404s
- [ ] On `/docs/...` pages, the top-tab strip lists all five sections with the active section underlined; sidebar shows only the active section's pages
- [ ] Workflow diagrams (caching, conditions, gates, fan-out, building) are readable in both light and dark themes