### PR TITLE
fix(ci): set DOCS_BASE_PATH for GH Pages deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,6 +50,8 @@ jobs:
         run: pnpm lint
 
       - name: Build
+        env:
+          DOCS_BASE_PATH: /taskito
         run: pnpm build
 
       - name: Upload Pages artifact


### PR DESCRIPTION
## Summary

PR #136 made `DOCS_BASE_PATH` an explicit env var (replacing the `NODE_ENV === "production"` heuristic) so local `pnpm build && pnpm start` serves cleanly at `/`. The deploy workflow was never updated, so the GH Pages build went out without `/taskito` as the basePath — every CSS/JS asset under `docs.byteveda.org/taskito/` 404s and the live site renders raw unstyled HTML.

This passes `DOCS_BASE_PATH=/taskito` into the workflow's build step. CI builds get the deploy basePath; local builds keep their root-mounted preview.

## Test plan

- [ ] Workflow re-runs on merge to `master`
- [ ] `docs.byteveda.org/taskito/` renders with full styling
- [ ] Asset URLs in the deployed HTML start with `/taskito/_next/...`
- [ ] Internal navigation (Getting Started, Guides, Architecture, …) works