### PR TITLE
fix(docs): drop tabMode="top" that hid article body

### DIFF
--- a/docs/src/app/docs/layout.tsx
+++ b/docs/src/app/docs/layout.tsx
@@ -4,7 +4,7 @@ import { source } from "@/lib/source";
 
 export default function Layout({ children }: LayoutProps<"/docs">) {
   return (
-    <DocsLayout tabMode="top" tree={source.getPageTree()} {...baseOptions()}>
+    <DocsLayout tree={source.getPageTree()} {...baseOptions()}>
       {children}
     </DocsLayout>
   );


### PR DESCRIPTION
## Summary

Commit `1b2bb18` added `tabMode="top"` to `docs/src/app/docs/layout.tsx`. In Fumadocs UI 16.8.5 this renders the auto-generated tab strip into `[grid-area:main]` — the **same** CSS grid cell as the article — with `z-10` and an opaque `bg-fd-background`. The strip stretches across the full main cell and completely covers `<DocsTitle>` plus the MDX body. The sidebar tree and right-side TOC still render, which is exactly what the bug report shows: a fully-blank center column on every docs page.

This was reproducible both locally (`pnpm dev`) and on `docs.byteveda.org/taskito/...`. Confirmed via `grep '\[grid-area:main\]' out/docs/getting-started/installation.html` returning **2** elements before, **1** after.

The fix drops the prop so Fumadocs falls back to the default `tabMode="auto"`, which renders the same auto-generated section list as a `SidebarTabsDropdown` inside the sidebar header — which is exactly what `1b2bb18`'s message described ("promote top sections to **sidebar** tabs").

- One-line change in `docs/src/app/docs/layout.tsx`.
- `root: true` flags on the section meta.json files are still consumed by `tabMode="auto"`, so the section dropdown is populated unchanged.

## Test plan

- [x] `cd docs && pnpm types:check` — clean
- [x] `cd docs && pnpm lint` — clean
- [x] `cd docs && pnpm build` — succeeded
- [x] Built HTML for `getting-started/installation`, `architecture/overview`, `guides/core/tasks`, `architecture`, `api-reference` each contains exactly one `[grid-area:main]` element (the `<article id="nd-page">`)
- [x] Article body, h1 "Installation", description, callout, code blocks all present in built HTML
- [x] Sidebar header now contains the auto-generated section dropdown button ("Getting Started" with up/down chevron)
- [ ] After merge, verify on `docs.byteveda.org/taskito/docs/getting-started/installation` that the article renders with title, description, and content visible