### PR TITLE
docs: replace architecture Mermaid charts with animated SVG diagrams

### DIFF
--- a/docs/content/docs/architecture/failure-model.mdx
+++ b/docs/content/docs/architecture/failure-model.mdx
@@ -39,25 +39,7 @@ potentially executing the same task twice. Design tasks to be
 
 ## Recovery timeline
 
-<Mermaid
-  chart={`sequenceDiagram
-    participant C as Client
-    participant DB as Database
-    participant S as Scheduler
-    participant W as Worker
-
-    C->>DB: enqueue(job)
-    S->>DB: dequeue + claim_execution
-    S->>W: dispatch job
-    W->>W: execute task...
-    Note over W: Worker crashes at T=5s
-    Note over S: Scheduler continues polling...
-    Note over S: T=300s: reap_stale_jobs() detects<br/>job.started_at + timeout_ms < now
-    S->>DB: mark failed, schedule retry
-    S->>DB: dequeue (same job, retry_count=1)
-    S->>W: dispatch to different worker
-    W->>DB: complete + clear claim`}
-/>
+<CrashRecoveryTimeline />
 
 ## Partial writes
 

--- a/docs/content/docs/architecture/job-lifecycle.mdx
+++ b/docs/content/docs/architecture/job-lifecycle.mdx
@@ -5,20 +5,7 @@ description: "Every job moves through a state machine from creation to completio
 
 Every job moves through a state machine from creation to completion (or death).
 
-<Mermaid
-  chart={`stateDiagram-v2
-    [*] --> Pending: enqueue() / delay()
-    Pending --> Running: dequeued by scheduler
-    Pending --> Cancelled: cancel_job()
-    Running --> Complete: task returns successfully
-    Running --> Failed: task raises exception
-    Failed --> Pending: retry (count < max_retries)\nwith exponential backoff
-    Failed --> Dead: retries exhausted\nmoved to DLQ
-    Dead --> Pending: retry_dead()
-    Complete --> [*]
-    Cancelled --> [*]
-    Dead --> [*]: purge_dead()`}
-/>
+<JobStateMachine />
 
 ## Status codes
 

--- a/docs/content/docs/architecture/overview.mdx
+++ b/docs/content/docs/architecture/overview.mdx
@@ -7,31 +7,7 @@ taskito is a hybrid Python/Rust system. Python provides the user-facing API. Rus
 handles all the heavy lifting: storage, scheduling, dispatch, rate limiting, and
 worker management.
 
-<Mermaid
-  chart={`flowchart TD
-    subgraph py ["Python Layer"]
-        direction LR
-        Q["Queue"] --> IC["ArgumentInterceptor"]
-        TW["@queue.task()"] ~~~ RR["ResourceRuntime"]
-    end
-
-    subgraph rust ["Rust Core — PyO3"]
-        direction LR
-        PQ["PyQueue"] --> SCH["Scheduler"]
-        SCH --> WP["Worker Pool"]
-        SCH --> RL["Rate Limiter"]
-    end
-
-    subgraph storage ["Storage"]
-        direction LR
-        SQ[("SQLite")] ~~~ PG[("PostgreSQL")]
-    end
-
-    IC --> PQ
-    WP -->|"acquire GIL"| TW
-    SCH -->|"poll / update"| SQ
-    PQ -->|"INSERT"| SQ`}
-/>
+<ArchitectureStack />
 
 ## Section overview
 

--- a/docs/content/docs/architecture/resources.mdx
+++ b/docs/content/docs/architecture/resources.mdx
@@ -5,26 +5,7 @@ description: "The three-layer Python pipeline that intercepts arguments, injects
 
 The resource system is a three-layer Python pipeline that runs entirely outside Rust:
 
-<Mermaid
-  chart={`flowchart TD
-    subgraph enqueue ["enqueue()"]
-        ARGS["Task arguments"] --> IC["ArgumentInterceptor"]
-        IC -->|PASS / CONVERT / REDIRECT| SER["Serializer"]
-        IC -->|PROXY| PX["ProxyHandler.deconstruct()"]
-        PX --> SER
-    end
-
-    SER -->|"serialized payload"| QUEUE[("Queue")]
-
-    subgraph worker ["Worker dispatch"]
-        DE["Deserialize"] --> RC["reconstruct_args()"]
-        RC --> FN["Task function"]
-        RT["ResourceRuntime"] -->|"inject"| FN
-        PX2["ProxyHandler.reconstruct()"] --> FN
-    end
-
-    QUEUE --> DE`}
-/>
+<ResourcePipeline />
 
 **Layer 1 — Argument Interception**: the `ArgumentInterceptor` walks every argument
 before serialization, applying the strategy registered for its type. CONVERT types

--- a/docs/content/docs/architecture/scheduler.mdx
+++ b/docs/content/docs/architecture/scheduler.mdx
@@ -30,20 +30,7 @@ loop {
 
 ## Polling cycle
 
-<Mermaid
-  chart={`flowchart LR
-    Tick(["loop tick"]) --> Sleep["sleep 50ms"]
-    Sleep --> Dispatch["try_dispatch()"]
-    Dispatch --> Periodic{"iteration<br/>multiple?"}
-    Periodic -->|"every ~60"| CP["check_periodic()"]
-    Periodic -->|"every ~100"| RS["reap_stale()"]
-    Periodic -->|"every ~1200"| AC["auto_cleanup()"]
-    Periodic -->|"otherwise"| Next["next tick"]
-    CP --> Next
-    RS --> Next
-    AC --> Next
-    Next --> Tick`}
-/>
+<SchedulerPollLoop />
 
 ## Dispatch flow
 
@@ -53,26 +40,4 @@ loop {
 4. Worker executes task, sends result back.
 5. `handle_result()` — mark complete, schedule retry, or move to DLQ.
 
-<Mermaid
-  chart={`sequenceDiagram
-    autonumber
-    participant S as Scheduler
-    participant DB as Storage
-    participant RL as RateLimiter
-    participant WP as WorkerPool
-    participant W as Worker
-
-    S->>DB: dequeue_from()
-    DB-->>S: pending job
-    S->>RL: check(task)
-    alt over limit
-        RL-->>S: limited
-        S->>DB: reschedule +1s
-    else under limit
-        RL-->>S: ok
-        S->>WP: mpsc.send(job)
-        WP->>W: execute()
-        W-->>S: result
-        S->>DB: handle_result()
-    end`}
-/>
+<DispatchSequence />

--- a/docs/content/docs/architecture/storage.mdx
+++ b/docs/content/docs/architecture/storage.mdx
@@ -18,115 +18,126 @@ Six tables in the SQLite backend. Use the arrows or click a dot to flip between 
 
 <DiagramCarousel title="SQLite schema">
   <DiagramSlide title="jobs">
-    <Mermaid
-      chart={`erDiagram
-        jobs {
-            TEXT id PK
-            TEXT queue
-            TEXT task_name
-            BLOB payload
-            INTEGER status
-            INTEGER priority
-            INTEGER created_at
-            INTEGER scheduled_at
-            INTEGER started_at
-            INTEGER completed_at
-            INTEGER retry_count
-            INTEGER max_retries
-            BLOB result
-            TEXT error
-            INTEGER timeout_ms
-            TEXT unique_key
-            INTEGER progress
-            TEXT metadata
-            BOOLEAN cancel_requested
-            INTEGER expires_at
-            INTEGER result_ttl_ms
-        }`}
+    <EntitySchema
+      name="jobs"
+      fields={[
+        { name: "id", type: "TEXT", key: "PK" },
+        { name: "queue", type: "TEXT" },
+        { name: "task_name", type: "TEXT" },
+        { name: "payload", type: "BLOB" },
+        { name: "status", type: "INTEGER" },
+        { name: "priority", type: "INTEGER" },
+        { name: "created_at", type: "INTEGER" },
+        { name: "scheduled_at", type: "INTEGER" },
+        { name: "started_at", type: "INTEGER" },
+        { name: "completed_at", type: "INTEGER" },
+        { name: "retry_count", type: "INTEGER" },
+        { name: "max_retries", type: "INTEGER" },
+        { name: "result", type: "BLOB" },
+        { name: "error", type: "TEXT" },
+        { name: "timeout_ms", type: "INTEGER" },
+        { name: "unique_key", type: "TEXT" },
+        { name: "progress", type: "INTEGER" },
+        { name: "metadata", type: "TEXT" },
+        { name: "cancel_requested", type: "BOOLEAN" },
+        { name: "expires_at", type: "INTEGER" },
+        { name: "result_ttl_ms", type: "INTEGER" },
+      ]}
     />
   </DiagramSlide>
 
   <DiagramSlide title="dead_letter">
-    <Mermaid
-      chart={`erDiagram
-        dead_letter {
-            TEXT id PK
-            TEXT original_job_id
-            TEXT queue
-            TEXT task_name
-            BLOB payload
-            TEXT error
-            INTEGER retry_count
-            INTEGER failed_at
-            TEXT metadata
-            INTEGER priority
-            INTEGER max_retries
-            INTEGER timeout_ms
-            INTEGER result_ttl_ms
-        }`}
+    <EntitySchema
+      name="dead_letter"
+      fields={[
+        { name: "id", type: "TEXT", key: "PK" },
+        { name: "original_job_id", type: "TEXT" },
+        { name: "queue", type: "TEXT" },
+        { name: "task_name", type: "TEXT" },
+        { name: "payload", type: "BLOB" },
+        { name: "error", type: "TEXT" },
+        { name: "retry_count", type: "INTEGER" },
+        { name: "failed_at", type: "INTEGER" },
+        { name: "metadata", type: "TEXT" },
+        { name: "priority", type: "INTEGER" },
+        { name: "max_retries", type: "INTEGER" },
+        { name: "timeout_ms", type: "INTEGER" },
+        { name: "result_ttl_ms", type: "INTEGER" },
+      ]}
     />
   </DiagramSlide>
 
   <DiagramSlide title="job_errors">
-    <Mermaid
-      chart={`erDiagram
-        job_errors {
-            TEXT id PK
-            TEXT job_id FK
-            INTEGER attempt
-            TEXT error
-            INTEGER failed_at
-        }`}
+    <EntitySchema
+      name="job_errors"
+      fields={[
+        { name: "id", type: "TEXT", key: "PK" },
+        { name: "job_id", type: "TEXT", key: "FK" },
+        { name: "attempt", type: "INTEGER" },
+        { name: "error", type: "TEXT" },
+        { name: "failed_at", type: "INTEGER" },
+      ]}
     />
   </DiagramSlide>
 
   <DiagramSlide title="rate_limits">
-    <Mermaid
-      chart={`erDiagram
-        rate_limits {
-            TEXT key PK
-            REAL tokens
-            REAL max_tokens
-            REAL refill_rate
-            INTEGER last_refill
-        }`}
+    <EntitySchema
+      name="rate_limits"
+      fields={[
+        { name: "key", type: "TEXT", key: "PK" },
+        { name: "tokens", type: "REAL" },
+        { name: "max_tokens", type: "REAL" },
+        { name: "refill_rate", type: "REAL" },
+        { name: "last_refill", type: "INTEGER" },
+      ]}
     />
   </DiagramSlide>
 
   <DiagramSlide title="periodic_tasks">
-    <Mermaid
-      chart={`erDiagram
-        periodic_tasks {
-            TEXT name PK
-            TEXT task_name
-            TEXT cron_expr
-            BLOB args
-            BLOB kwargs
-            TEXT queue
-            BOOLEAN enabled
-            INTEGER last_run
-            INTEGER next_run
-        }`}
+    <EntitySchema
+      name="periodic_tasks"
+      fields={[
+        { name: "name", type: "TEXT", key: "PK" },
+        { name: "task_name", type: "TEXT" },
+        { name: "cron_expr", type: "TEXT" },
+        { name: "args", type: "BLOB" },
+        { name: "kwargs", type: "BLOB" },
+        { name: "queue", type: "TEXT" },
+        { name: "enabled", type: "BOOLEAN" },
+        { name: "last_run", type: "INTEGER" },
+        { name: "next_run", type: "INTEGER" },
+      ]}
     />
   </DiagramSlide>
 
   <DiagramSlide title="workers">
-    <Mermaid
-      chart={`erDiagram
-        workers {
-            TEXT worker_id PK
-            INTEGER last_heartbeat
-            TEXT queues
-            TEXT status
-        }`}
+    <EntitySchema
+      name="workers"
+      fields={[
+        { name: "worker_id", type: "TEXT", key: "PK" },
+        { name: "last_heartbeat", type: "INTEGER" },
+        { name: "queues", type: "TEXT" },
+        { name: "status", type: "TEXT" },
+      ]}
     />
   </DiagramSlide>
 
   <DiagramSlide title="relationships">
-    <Mermaid
-      chart={`erDiagram
-        jobs ||--o{ job_errors : "error history"
-        jobs ||--o| dead_letter : "DLQ on exhaustion"`}
+    <EntityRelations
+      relations={[
+        {
+          from: "jobs",
+          to: "job_errors",
+          cardinality: "1 ─── *",
+          label: "error history",
+        },
+        {
+          from: "jobs",
+          to: "dead_letter",
+          cardinality: "1 ─── 0..1",
+          label: "DLQ on exhaustion",
+        },
+      ]}
     />
   </DiagramSlide>
 </DiagramCarousel>

--- a/docs/content/docs/architecture/worker-pool.mdx
+++ b/docs/content/docs/architecture/worker-pool.mdx
@@ -5,22 +5,7 @@ description: "How the scheduler dispatches jobs to Python task functions across 
 
 The worker pool dispatches jobs from the scheduler to Python task functions.
 
-<Mermaid
-  chart={`flowchart TD
-    SCH["Scheduler\nTokio async · 50ms poll"]
-
-    SCH -->|"sync job"| JCH["Job Channel\nbounded: workers×2"]
-    SCH -->|"async job"| AP["Native Async Pool"]
-
-    JCH --> WP["Worker Threads\nGIL per task · N threads"]
-    AP --> EL["Async Executor\ndedicated event loop"]
-
-    WP -->|"Result"| RCH["Result Channel"]
-    EL -->|"PyResultSender"| RCH
-
-    RCH --> ML["Main Loop\npy.allow_threads"]
-    ML -->|"complete / retry / DLQ"| DB[("SQLite")]`}
-/>
+<WorkerDispatch />
 
 ## Design decisions
 

--- a/docs/src/app/(home)/_sections/index.ts
+++ b/docs/src/app/(home)/_sections/index.ts
@@ -1,8 +1,7 @@
+export { HowItWorks, WorkerPool } from "@/components/animated";
 export { ComparisonSection } from "./comparison-section";
 export { CTA } from "./cta";
 export { Features } from "./features";
 export { Hero } from "./hero";
-export { HowItWorks } from "./how-it-works";
 export { Integrations } from "./integrations";
 export { UseCases } from "./use-cases";
-export { WorkerPool } from "./worker-pool";

--- a/docs/src/components/animated/_primitives.tsx
+++ b/docs/src/components/animated/_primitives.tsx
@@ -1,0 +1,457 @@
+import type { ReactNode } from "react";
+
+const FILTER_ID = "taskito-sketch-filter";
+const ARROW_ID = "taskito-sketch-arrow";
+const ARROW_SOFT_ID = "taskito-sketch-arrow-soft";
+
+export const SKETCH_FILTER = `url(#${FILTER_ID})`;
+export const SKETCH_ARROW = `url(#${ARROW_ID})`;
+export const SKETCH_ARROW_SOFT = `url(#${ARROW_SOFT_ID})`;
+
+const FONT_MONO =
+  'var(--font-mono), "IBM Plex Mono", ui-monospace, SFMono-Regular, monospace';
+
+/**
+ * Sketch defs (filter + arrow markers). Render once inside each diagram's
+ * `<defs>`. URL references collide intentionally — every diagram uses the
+ * same filter/marker IDs so the sketch aesthetic stays consistent.
+ */
+export function SketchDefs() {
+  return (
+    <>
+      <filter id={FILTER_ID}>
+        <feTurbulence
+          type="fractalNoise"
+          baseFrequency="0.025"
+          numOctaves="2"
+          seed="3"
+        />
+        <feDisplacementMap in="SourceGraphic" scale="0.7" />
+      </filter>
+      <ArrowMarker id={ARROW_ID} stroke="var(--color-fd-foreground)" />
+      <ArrowMarker
+        id={ARROW_SOFT_ID}
+        stroke="var(--color-fd-muted-foreground)"
+      />
+    </>
+  );
+}
+
+function ArrowMarker({ id, stroke }: { id: string; stroke: string }) {
+  return (
+    <marker
+      id={id}
+      viewBox="0 0 12 12"
+      refX="9"
+      refY="6"
+      markerWidth="6"
+      markerHeight="6"
+      orient="auto"
+    >
+      <path
+        d="M 1 1 L 10 6 L 1 11"
+        fill="none"
+        stroke={stroke}
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </marker>
+  );
+}
+
+/* -------------------------------------------------------------------------- *
+ * Frame
+ * -------------------------------------------------------------------------- */
+
+export type DiagramFrameProps = {
+  ariaLabel: string;
+  width: number;
+  height: number;
+  className: string;
+  children: ReactNode;
+};
+
+/** Outer wrapper. Centers the SVG, applies handwritten font, defines defs. */
+export function DiagramFrame({
+  ariaLabel,
+  width,
+  height,
+  className,
+  children,
+}: DiagramFrameProps) {
+  return (
+    <div className="my-6 not-prose flex justify-center">
+      <svg
+        role="img"
+        aria-label={ariaLabel}
+        viewBox={`0 0 ${width} ${height}`}
+        className={`w-full max-w-3xl font-sans ${className}`}
+      >
+        <defs>
+          <SketchDefs />
+        </defs>
+        {children}
+      </svg>
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------------------- *
+ * NodeBox
+ * -------------------------------------------------------------------------- */
+
+export type NodeVariant = "default" | "primary" | "terminal" | "muted";
+
+export type NodeBoxProps = {
+  cx: number;
+  cy: number;
+  w?: number;
+  h?: number;
+  label: string;
+  hint?: string;
+  variant?: NodeVariant;
+  rx?: number;
+  className?: string;
+};
+
+const NODE_W = 110;
+const NODE_H = 44;
+
+export function NodeBox({
+  cx,
+  cy,
+  w = NODE_W,
+  h = NODE_H,
+  label,
+  hint,
+  variant = "default",
+  rx,
+  className,
+}: NodeBoxProps) {
+  const x = cx - w / 2;
+  const y = cy - h / 2;
+  const isPrimary = variant === "primary";
+  const isTerminal = variant === "terminal";
+  const isMuted = variant === "muted";
+
+  const stroke = isPrimary
+    ? "var(--color-fd-primary)"
+    : isMuted
+      ? "var(--color-fd-muted-foreground)"
+      : "var(--color-fd-sketch-strong)";
+  const strokeWidth = isPrimary ? 2.5 : 2;
+  const radius = rx ?? (isTerminal ? Math.min(h / 2, 22) : 9);
+
+  return (
+    <g className={className}>
+      <rect
+        x={x}
+        y={y}
+        width={w}
+        height={h}
+        rx={radius}
+        fill="var(--color-fd-card)"
+        stroke={stroke}
+        strokeWidth={strokeWidth}
+        strokeDasharray={isMuted ? "4 4" : undefined}
+        opacity={isMuted ? 0.85 : 1}
+        filter={SKETCH_FILTER}
+      />
+      {isTerminal ? (
+        <rect
+          x={x + 4}
+          y={y + 4}
+          width={w - 8}
+          height={h - 8}
+          rx={radius - 4}
+          fill="none"
+          stroke="var(--color-fd-sketch-strong)"
+          strokeWidth="1.2"
+          opacity="0.5"
+          filter={SKETCH_FILTER}
+        />
+      ) : null}
+      <text
+        x={cx}
+        y={hint ? cy - 2 : cy + 5}
+        textAnchor="middle"
+        fill="var(--color-fd-foreground)"
+        fontSize="14"
+        fontWeight="600"
+      >
+        {label}
+      </text>
+      {hint ? (
+        <text
+          x={cx}
+          y={cy + 12}
+          textAnchor="middle"
+          fill="var(--color-fd-muted-foreground)"
+          fontSize="9"
+          fontFamily={FONT_MONO}
+          opacity="0.9"
+        >
+          {hint}
+        </text>
+      ) : null}
+    </g>
+  );
+}
+
+/* -------------------------------------------------------------------------- *
+ * Cylinder (DB shape)
+ * -------------------------------------------------------------------------- */
+
+export type CylinderProps = {
+  cx: number;
+  cy: number;
+  rx: number;
+  ry: number;
+  label?: string;
+};
+
+export function Cylinder({ cx, cy, rx, ry, label }: CylinderProps) {
+  const lipR = Math.min(ry / 4, 8);
+  const stroke = "var(--color-fd-sketch-strong)";
+  return (
+    <g>
+      <ellipse
+        cx={cx}
+        cy={cy + ry - lipR}
+        rx={rx}
+        ry={lipR}
+        fill="var(--color-fd-card)"
+        stroke={stroke}
+        strokeWidth="2"
+        filter={SKETCH_FILTER}
+      />
+      <line
+        x1={cx - rx}
+        y1={cy - ry + lipR}
+        x2={cx - rx}
+        y2={cy + ry - lipR}
+        stroke={stroke}
+        strokeWidth="2"
+        filter={SKETCH_FILTER}
+      />
+      <line
+        x1={cx + rx}
+        y1={cy - ry + lipR}
+        x2={cx + rx}
+        y2={cy + ry - lipR}
+        stroke={stroke}
+        strokeWidth="2"
+        filter={SKETCH_FILTER}
+      />
+      <ellipse
+        cx={cx}
+        cy={cy - ry + lipR}
+        rx={rx}
+        ry={lipR}
+        fill="var(--color-fd-card)"
+        stroke={stroke}
+        strokeWidth="2"
+        filter={SKETCH_FILTER}
+      />
+      {label ? (
+        <text
+          x={cx}
+          y={cy + 5}
+          textAnchor="middle"
+          fill="var(--color-fd-foreground)"
+          fontSize="14"
+          fontWeight="600"
+        >
+          {label}
+        </text>
+      ) : null}
+    </g>
+  );
+}
+
+/* -------------------------------------------------------------------------- *
+ * Panel (labeled container)
+ * -------------------------------------------------------------------------- */
+
+export type PanelProps = {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  label?: string;
+  rx?: number;
+};
+
+export function Panel({ x, y, w, h, label, rx = 14 }: PanelProps) {
+  return (
+    <g>
+      <rect
+        x={x}
+        y={y}
+        width={w}
+        height={h}
+        rx={rx}
+        fill="var(--color-fd-card)"
+        stroke="var(--color-fd-sketch-strong)"
+        strokeWidth="1.5"
+        strokeDasharray="3 5"
+        opacity="0.4"
+        filter={SKETCH_FILTER}
+      />
+      {label ? (
+        <g>
+          <rect
+            x={x + 12}
+            y={y - 8}
+            width={label.length * 7 + 12}
+            height={14}
+            fill="var(--color-fd-background)"
+          />
+          <text
+            x={x + 18}
+            y={y + 3}
+            fill="var(--color-fd-foreground)"
+            fontSize="11"
+            fontFamily={FONT_MONO}
+            fontWeight="600"
+            letterSpacing="0.12em"
+            opacity="1"
+          >
+            {label}
+          </text>
+        </g>
+      ) : null}
+    </g>
+  );
+}
+
+/* -------------------------------------------------------------------------- *
+ * Arrow
+ * -------------------------------------------------------------------------- */
+
+export type ArrowVariant = "default" | "muted";
+
+export type ArrowProps = {
+  /** SVG path data. Use a straight line via "M x1 y1 L x2 y2", or any path. */
+  d: string;
+  variant?: ArrowVariant;
+  label?: string;
+  labelX?: number;
+  labelY?: number;
+  labelAnchor?: "start" | "middle" | "end";
+};
+
+export function Arrow({
+  d,
+  variant = "default",
+  label,
+  labelX,
+  labelY,
+  labelAnchor = "middle",
+}: ArrowProps) {
+  const muted = variant === "muted";
+  return (
+    <g>
+      <path
+        d={d}
+        fill="none"
+        stroke={
+          muted
+            ? "var(--color-fd-muted-foreground)"
+            : "var(--color-fd-foreground)"
+        }
+        strokeWidth={muted ? 2 : 2.4}
+        strokeDasharray={muted ? "4 4" : "6 4"}
+        strokeLinecap="round"
+        opacity={muted ? 0.6 : 0.9}
+        markerEnd={muted ? SKETCH_ARROW_SOFT : SKETCH_ARROW}
+      />
+      {label !== undefined && labelX !== undefined && labelY !== undefined ? (
+        <Caption x={labelX} y={labelY} anchor={labelAnchor} text={label} />
+      ) : null}
+    </g>
+  );
+}
+
+/* -------------------------------------------------------------------------- *
+ * Caption (small monospace label)
+ * -------------------------------------------------------------------------- */
+
+export type CaptionProps = {
+  x: number;
+  y: number;
+  text: string;
+  anchor?: "start" | "middle" | "end";
+  size?: number;
+};
+
+export function Caption({
+  x,
+  y,
+  text,
+  anchor = "middle",
+  size = 10,
+}: CaptionProps) {
+  return (
+    <text
+      x={x}
+      y={y}
+      textAnchor={anchor}
+      fill="var(--color-fd-foreground)"
+      fontSize={size}
+      fontFamily={FONT_MONO}
+      opacity="0.95"
+    >
+      {text}
+    </text>
+  );
+}
+
+/* -------------------------------------------------------------------------- *
+ * Lifeline (for sequence diagrams)
+ * -------------------------------------------------------------------------- */
+
+export type LifelineProps = {
+  x: number;
+  y1: number;
+  y2: number;
+};
+
+export function Lifeline({ x, y1, y2 }: LifelineProps) {
+  return (
+    <line
+      x1={x}
+      y1={y1}
+      x2={x}
+      y2={y2}
+      stroke="var(--color-fd-sketch-strong)"
+      strokeWidth="1.4"
+      strokeDasharray="3 6"
+      opacity="0.4"
+    />
+  );
+}
+
+/* -------------------------------------------------------------------------- *
+ * MotionStyles — emits keyframes + base styles unconditionally and gates
+ * animation rules behind prefers-reduced-motion: no-preference.
+ * -------------------------------------------------------------------------- */
+
+export type MotionStylesProps = {
+  /** Always emitted. Define @keyframes, base opacity:0 styles, etc. */
+  base: string;
+  /** Wrapped in @media (prefers-reduced-motion: no-preference). */
+  animations: string;
+};
+
+export function MotionStyles({ base, animations }: MotionStylesProps) {
+  return (
+    <style>{`
+${base}
+@media (prefers-reduced-motion: no-preference) {
+${animations}
+}
+`}</style>
+  );
+}

--- a/docs/src/components/animated/architecture-stack.tsx
+++ b/docs/src/components/animated/architecture-stack.tsx
@@ -1,0 +1,148 @@
+import {
+  Arrow,
+  DiagramFrame,
+  MotionStyles,
+  NodeBox,
+  Panel,
+} from "./_primitives";
+
+const VIEW_W = 640;
+const VIEW_H = 296;
+
+const PANELS = [
+  { id: "python", label: "python layer", y: 24, h: 76, cy: 62 },
+  { id: "rust", label: "rust core", y: 110, h: 76, cy: 148 },
+  { id: "storage", label: "storage", y: 196, h: 76, cy: 234 },
+] as const;
+
+type NodeData = {
+  id: string;
+  label: string;
+  hint?: string;
+  cx: number;
+  cy: number;
+  variant?: "primary";
+};
+
+const NODES: NodeData[] = [
+  { id: "queue", label: "Queue", hint: ".delay()", cx: 150, cy: 62 },
+  { id: "task", label: "@task fn", hint: "Python", cx: 490, cy: 62 },
+  { id: "pyqueue", label: "PyQueue", hint: "PyO3", cx: 150, cy: 148 },
+  {
+    id: "scheduler",
+    label: "Scheduler",
+    hint: "Tokio · 50ms",
+    cx: 320,
+    cy: 148,
+    variant: "primary",
+  },
+  {
+    id: "workerpool",
+    label: "Worker Pool",
+    hint: "Rust threads",
+    cx: 490,
+    cy: 148,
+  },
+  { id: "sqlite", label: "SQLite", hint: "default", cx: 260, cy: 234 },
+  { id: "postgres", label: "PostgreSQL", hint: "scale-out", cx: 420, cy: 234 },
+];
+
+const ARROWS = [
+  { id: "enqueue", d: "M 150 85 L 150 125" },
+  { id: "insert", d: "M 205 148 L 265 148" },
+  { id: "dispatch", d: "M 375 148 L 435 148" },
+  { id: "gil", d: "M 490 125 L 490 85" },
+  {
+    id: "persist",
+    d: "M 320 172 Q 320 188 340 200",
+    variant: "muted" as const,
+  },
+];
+
+export function ArchitectureStack() {
+  return (
+    <DiagramFrame
+      ariaLabel="Three-layer architecture: Python on top, Rust core in the middle, Storage at the bottom. Jobs flow from Queue to PyQueue to the Scheduler to Storage; workers acquire the GIL to call the Python task function."
+      width={VIEW_W}
+      height={VIEW_H}
+      className="taskito-stack"
+    >
+      {PANELS.map((p) => (
+        <Panel
+          key={p.id}
+          x={20}
+          y={p.y}
+          w={VIEW_W - 40}
+          h={p.h}
+          label={p.label}
+        />
+      ))}
+
+      {ARROWS.map((a) => (
+        <Arrow key={a.id} d={a.d} variant={a.variant} />
+      ))}
+
+      {NODES.map((n) => (
+        <NodeBox
+          key={n.id}
+          cx={n.cx}
+          cy={n.cy}
+          label={n.label}
+          hint={n.hint}
+          variant={n.variant}
+        />
+      ))}
+
+      <text
+        x={490}
+        y={108}
+        textAnchor="end"
+        fill="var(--color-fd-foreground)"
+        fontSize="11"
+        fontFamily='var(--font-mono), "IBM Plex Mono", ui-monospace, SFMono-Regular, monospace'
+        fontWeight="500"
+        opacity="0.9"
+      >
+        acquire GIL
+      </text>
+
+      <circle r="5" fill="var(--color-fd-primary)" className="token ingress" />
+      <circle r="5" fill="var(--color-fd-primary)" className="token execute" />
+
+      <MotionStyles
+        base={`
+.taskito-stack .token {
+  opacity: 0;
+  offset-rotate: 0deg;
+  cx: 0;
+  cy: 0;
+}
+.taskito-stack .ingress {
+  offset-path: path('M 150 62 L 150 148 L 320 148 Q 320 188 340 200');
+}
+.taskito-stack .execute {
+  offset-path: path('M 320 148 L 490 148 L 490 62');
+}
+
+@keyframes taskito-stack-traverse {
+  0%   { offset-distance: 0%;   opacity: 0; }
+  6%   { opacity: 1; }
+  92%  { offset-distance: 100%; opacity: 1; }
+  100% { offset-distance: 100%; opacity: 0; }
+}
+`}
+        animations={`
+.taskito-stack .ingress {
+  animation: taskito-stack-traverse 7s cubic-bezier(0.55, 0.05, 0.4, 0.95) infinite;
+  filter: drop-shadow(0 0 5px var(--color-fd-primary));
+}
+.taskito-stack .execute {
+  animation: taskito-stack-traverse 7s cubic-bezier(0.55, 0.05, 0.4, 0.95) infinite;
+  animation-delay: -3.5s;
+  filter: drop-shadow(0 0 5px var(--color-fd-primary));
+}
+`}
+      />
+    </DiagramFrame>
+  );
+}

--- a/docs/src/components/animated/crash-recovery-timeline.tsx
+++ b/docs/src/components/animated/crash-recovery-timeline.tsx
@@ -1,0 +1,287 @@
+import {
+  Arrow,
+  Caption,
+  DiagramFrame,
+  MotionStyles,
+  NodeBox,
+  SKETCH_FILTER,
+} from "./_primitives";
+
+const VIEW_W = 760;
+const VIEW_H = 260;
+const TRACK_Y = 150;
+const TRACK_LEFT = 50;
+const TRACK_RIGHT = 730;
+const WORKER_Y = 60;
+
+type Marker = {
+  id: string;
+  x: number;
+  time: string;
+  label: string;
+  variant?: "primary" | "danger" | "success";
+};
+
+const MARKERS: Marker[] = [
+  { id: "enqueue", x: 80, time: "T=0", label: "enqueue", variant: "primary" },
+  {
+    id: "dispatch",
+    x: 170,
+    time: "T=1s",
+    label: "dispatch",
+    variant: "primary",
+  },
+  { id: "crash", x: 250, time: "T=5s", label: "crash", variant: "danger" },
+  {
+    id: "reap",
+    x: 510,
+    time: "T=300s",
+    label: "reap_stale",
+    variant: "primary",
+  },
+  { id: "retry", x: 600, time: "T=301s", label: "retry", variant: "primary" },
+  { id: "done", x: 690, time: "T=302s", label: "complete", variant: "success" },
+];
+
+const POLLING_LEFT = 280;
+const POLLING_RIGHT = 480;
+
+export function CrashRecoveryTimeline() {
+  return (
+    <DiagramFrame
+      ariaLabel="Crash recovery timeline. A job is enqueued at T=0, dispatched at T=1s; the worker crashes at T=5s. The scheduler keeps polling every 50ms. At T=300s reap_stale_jobs() detects the abandoned job and schedules a retry which completes by T=302s."
+      width={VIEW_W}
+      height={VIEW_H}
+      className="taskito-crash"
+    >
+      {/* Worker boxes (above timeline) */}
+      <NodeBox cx={170} cy={WORKER_Y} w={120} h={40} label="Worker A" />
+      <NodeBox cx={600} cy={WORKER_Y} w={120} h={40} label="Worker B" />
+
+      {/* dispatch arrows from timeline up to workers */}
+      <Arrow d={`M 170 ${TRACK_Y - 8} L 170 ${WORKER_Y + 22}`} />
+      <Arrow d={`M 600 ${TRACK_Y - 8} L 600 ${WORKER_Y + 22}`} />
+
+      {/* horizontal timeline */}
+      <line
+        x1={TRACK_LEFT}
+        y1={TRACK_Y}
+        x2={TRACK_RIGHT}
+        y2={TRACK_Y}
+        stroke="var(--color-fd-sketch-accent)"
+        strokeWidth="2"
+        strokeDasharray="2 5"
+        strokeLinecap="round"
+        markerEnd="url(#taskito-sketch-arrow)"
+        filter={SKETCH_FILTER}
+      />
+      <Caption x={TRACK_RIGHT + 4} y={TRACK_Y + 4} text="time" anchor="start" />
+
+      {/* polling-ticks region between crash and reap */}
+      <PollingRegion x1={POLLING_LEFT} x2={POLLING_RIGHT} y={TRACK_Y} />
+
+      {/* polling annotation above the ticks (between crash and reap markers) */}
+      <Caption
+        x={(POLLING_LEFT + POLLING_RIGHT) / 2}
+        y={TRACK_Y - 14}
+        text="polls every 50ms · job sits in 'running'"
+        size={10}
+      />
+
+      {MARKERS.map((m) => (
+        <MarkerPin key={m.id} marker={m} />
+      ))}
+
+      {/* crash burst at worker A location */}
+      <CrashBurst cx={170} cy={WORKER_Y} />
+
+      {/* reap glow ring at T=300s marker */}
+      <circle
+        cx={510}
+        cy={TRACK_Y}
+        r="14"
+        fill="none"
+        stroke="var(--color-fd-primary)"
+        strokeWidth="1.6"
+        className="reap-ring"
+      />
+
+      {/* job dot animating across the timeline */}
+      <circle r="5.5" fill="var(--color-fd-primary)" className="job-dot" />
+
+      <MotionStyles
+        base={`
+.taskito-crash .job-dot,
+.taskito-crash .crash-burst,
+.taskito-crash .reap-ring,
+.taskito-crash .polling-tick { opacity: 0; }
+.taskito-crash .reap-ring {
+  transform-box: fill-box;
+  transform-origin: center;
+}
+
+.taskito-crash .job-dot {
+  offset-path: path('M 80 ${TRACK_Y} L 170 ${TRACK_Y} L 170 ${WORKER_Y + 22} L 170 ${TRACK_Y} L 510 ${TRACK_Y} L 600 ${TRACK_Y} L 600 ${WORKER_Y + 22} L 600 ${TRACK_Y} L 690 ${TRACK_Y}');
+  offset-rotate: 0deg;
+  cx: 0;
+  cy: 0;
+}
+@keyframes taskito-crash-job {
+  0%   { offset-distance: 0%;    opacity: 0; }
+  3%   { opacity: 1; }
+  14%  { offset-distance: 10%;   opacity: 1; }
+  18%  { offset-distance: 18%;   opacity: 1; }
+  24%  { offset-distance: 18%;   opacity: 0; }
+  60%  { offset-distance: 64%;   opacity: 0; }
+  66%  { offset-distance: 64%;   opacity: 1; }
+  76%  { offset-distance: 74.4%; opacity: 1; }
+  82%  { offset-distance: 82.1%; opacity: 1; }
+  88%  { offset-distance: 89.8%; opacity: 1; }
+  94%  { offset-distance: 100%;  opacity: 1; }
+  98%  { opacity: 0; }
+  100% { offset-distance: 100%;  opacity: 0; }
+}
+@keyframes taskito-crash-burst {
+  0%, 26%   { opacity: 0; transform: scale(0.5); }
+  30%       { opacity: 1; transform: scale(1.15); }
+  60%       { opacity: 0.5; transform: scale(1); }
+  100%      { opacity: 0; transform: scale(0.5); }
+}
+@keyframes taskito-crash-reap {
+  0%, 60%   { opacity: 0; transform: scale(0.5); }
+  68%       { opacity: 0.85; transform: scale(1); }
+  82%       { opacity: 0; transform: scale(2.4); }
+  100%      { opacity: 0; transform: scale(0.5); }
+}
+@keyframes taskito-crash-tick {
+  0%, 30%   { opacity: 0.15; }
+  50%       { opacity: 0.85; }
+  70%, 100% { opacity: 0.15; }
+}
+`}
+        animations={`
+.taskito-crash .job-dot {
+  animation: taskito-crash-job 14s cubic-bezier(0.55, 0.05, 0.4, 0.95) infinite;
+  filter: drop-shadow(0 0 6px var(--color-fd-primary));
+}
+.taskito-crash .crash-burst {
+  animation: taskito-crash-burst 14s ease-in-out infinite;
+}
+.taskito-crash .reap-ring {
+  animation: taskito-crash-reap 14s ease-out infinite;
+}
+.taskito-crash .polling-tick-0 { animation: taskito-crash-tick 1.4s ease-in-out infinite; animation-delay: -0.0s; }
+.taskito-crash .polling-tick-1 { animation: taskito-crash-tick 1.4s ease-in-out infinite; animation-delay: -0.35s; }
+.taskito-crash .polling-tick-2 { animation: taskito-crash-tick 1.4s ease-in-out infinite; animation-delay: -0.7s; }
+.taskito-crash .polling-tick-3 { animation: taskito-crash-tick 1.4s ease-in-out infinite; animation-delay: -1.05s; }
+`}
+      />
+    </DiagramFrame>
+  );
+}
+
+function MarkerPin({ marker }: { marker: Marker }) {
+  const color =
+    marker.variant === "danger"
+      ? "var(--color-fd-muted-foreground)"
+      : marker.variant === "success" || marker.variant === "primary"
+        ? "var(--color-fd-primary)"
+        : "var(--color-fd-muted-foreground)";
+  return (
+    <g>
+      <line
+        x1={marker.x}
+        y1={TRACK_Y - 8}
+        x2={marker.x}
+        y2={TRACK_Y + 8}
+        stroke={color}
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+      <circle cx={marker.x} cy={TRACK_Y} r="3.5" fill={color} />
+      <text
+        x={marker.x}
+        y={TRACK_Y + 22}
+        textAnchor="middle"
+        fill="var(--color-fd-muted-foreground)"
+        fontSize="10"
+        fontFamily='var(--font-mono), "IBM Plex Mono", ui-monospace, SFMono-Regular, monospace'
+        opacity="0.85"
+      >
+        {marker.time}
+      </text>
+      <text
+        x={marker.x}
+        y={TRACK_Y + 38}
+        textAnchor="middle"
+        fill="var(--color-fd-foreground)"
+        fontSize="11"
+        fontWeight="500"
+      >
+        {marker.label}
+      </text>
+    </g>
+  );
+}
+
+function CrashBurst({ cx, cy }: { cx: number; cy: number }) {
+  return (
+    <g
+      className="crash-burst"
+      style={{
+        transformBox: "fill-box",
+        transformOrigin: "center",
+        transform: `translate(${cx}px, ${cy}px)`,
+      }}
+    >
+      <line
+        x1={-10}
+        y1={-10}
+        x2={10}
+        y2={10}
+        stroke="var(--color-fd-muted-foreground)"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+      />
+      <line
+        x1={10}
+        y1={-10}
+        x2={-10}
+        y2={10}
+        stroke="var(--color-fd-muted-foreground)"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+      />
+      <circle
+        r="18"
+        fill="none"
+        stroke="var(--color-fd-muted-foreground)"
+        strokeWidth="1.4"
+        strokeDasharray="2 3"
+        opacity="0.6"
+      />
+    </g>
+  );
+}
+
+function PollingRegion({ x1, x2, y }: { x1: number; x2: number; y: number }) {
+  const count = Math.floor((x2 - x1) / 14);
+  return (
+    <g>
+      {Array.from({ length: count }, (_, i) => (
+        <line
+          // biome-ignore lint/suspicious/noArrayIndexKey: stable index for deterministic stagger
+          key={i}
+          x1={x1 + i * 14 + 7}
+          y1={y - 4}
+          x2={x1 + i * 14 + 7}
+          y2={y + 4}
+          stroke="var(--color-fd-muted-foreground)"
+          strokeWidth="1.4"
+          opacity="0.45"
+          className={`polling-tick polling-tick-${i % 4}`}
+        />
+      ))}
+    </g>
+  );
+}

--- a/docs/src/components/animated/dispatch-sequence.tsx
+++ b/docs/src/components/animated/dispatch-sequence.tsx
@@ -1,0 +1,200 @@
+import {
+  Arrow,
+  Caption,
+  DiagramFrame,
+  Lifeline,
+  MotionStyles,
+  NodeBox,
+} from "./_primitives";
+
+const VIEW_W = 760;
+const VIEW_H = 380;
+
+type Lane = { id: string; label: string; cx: number };
+
+const LANES: Lane[] = [
+  { id: "scheduler", label: "Scheduler", cx: 90 },
+  { id: "db", label: "Storage", cx: 240 },
+  { id: "rl", label: "RateLimiter", cx: 380 },
+  { id: "wp", label: "WorkerPool", cx: 520 },
+  { id: "worker", label: "Worker", cx: 660 },
+];
+
+const HEADER_Y = 24;
+const HEADER_H = 36;
+const LIFELINE_TOP = HEADER_Y + HEADER_H + 4;
+const LIFELINE_BOTTOM = 358;
+
+type Msg = {
+  num: number;
+  fromLane: string;
+  toLane: string;
+  label: string;
+  y: number;
+  reply?: boolean;
+};
+
+const MSGS: Msg[] = [
+  {
+    num: 1,
+    fromLane: "scheduler",
+    toLane: "db",
+    label: "dequeue_from()",
+    y: 88,
+  },
+  {
+    num: 2,
+    fromLane: "db",
+    toLane: "scheduler",
+    label: "pending job",
+    y: 124,
+    reply: true,
+  },
+  { num: 3, fromLane: "scheduler", toLane: "rl", label: "check(task)", y: 160 },
+  {
+    num: 4,
+    fromLane: "rl",
+    toLane: "scheduler",
+    label: "ok",
+    y: 196,
+    reply: true,
+  },
+  {
+    num: 5,
+    fromLane: "scheduler",
+    toLane: "wp",
+    label: "mpsc.send(job)",
+    y: 232,
+  },
+  { num: 6, fromLane: "wp", toLane: "worker", label: "execute()", y: 268 },
+  {
+    num: 7,
+    fromLane: "worker",
+    toLane: "scheduler",
+    label: "result",
+    y: 304,
+    reply: true,
+  },
+  {
+    num: 8,
+    fromLane: "scheduler",
+    toLane: "db",
+    label: "handle_result()",
+    y: 340,
+  },
+];
+
+const TOTAL_DURATION = 14;
+const SLOT_PERCENT = 8;
+const TRAVEL_PERCENT = 6.5;
+const FADE_IN_PERCENT = 0.5;
+const FADE_OUT_PERCENT = TRAVEL_PERCENT + 0.5;
+
+function laneCx(id: string): number {
+  const lane = LANES.find((l) => l.id === id);
+  if (!lane) throw new Error(`unknown lane: ${id}`);
+  return lane.cx;
+}
+
+export function DispatchSequence() {
+  return (
+    <DiagramFrame
+      ariaLabel="Dispatch sequence diagram. Numbered messages flow between Scheduler, Storage, RateLimiter, Worker Pool, and Worker — including the rate-limited fallback branch."
+      width={VIEW_W}
+      height={VIEW_H}
+      className="taskito-seq"
+    >
+      {LANES.map((lane) => (
+        <g key={lane.id}>
+          <NodeBox
+            cx={lane.cx}
+            cy={HEADER_Y + HEADER_H / 2}
+            w={120}
+            h={HEADER_H}
+            label={lane.label}
+          />
+          <Lifeline x={lane.cx} y1={LIFELINE_TOP} y2={LIFELINE_BOTTOM} />
+        </g>
+      ))}
+
+      {MSGS.map((msg) => {
+        const x1 = laneCx(msg.fromLane);
+        const x2 = laneCx(msg.toLane);
+        const dir = x2 > x1 ? 1 : -1;
+        const startX = x1 + dir * 6;
+        const endX = x2 - dir * 6;
+        return (
+          <g key={msg.num}>
+            <Arrow
+              d={`M ${startX} ${msg.y} L ${endX} ${msg.y}`}
+              variant={msg.reply ? "muted" : "default"}
+            />
+            <text
+              x={(startX + endX) / 2}
+              y={msg.y - 6}
+              textAnchor="middle"
+              fill="var(--color-fd-foreground)"
+              fontSize="11"
+              fontFamily='var(--font-mono), "IBM Plex Mono", ui-monospace, SFMono-Regular, monospace'
+            >
+              <tspan fill="var(--color-fd-primary)" fontWeight="700">
+                {`${msg.num} `}
+              </tspan>
+              {msg.label}
+            </text>
+          </g>
+        );
+      })}
+
+      <Caption
+        x={388}
+        y={208}
+        text="alt: rate-limited → reschedule +1s"
+        anchor="start"
+        size={9}
+      />
+
+      {/* animated tokens — one per message, staggered to fire in order */}
+      {MSGS.map((msg, i) => (
+        <circle
+          key={`tok-${msg.num}`}
+          r="6"
+          fill="var(--color-fd-primary)"
+          className={`tok tok-${msg.num}`}
+          style={{
+            animationDelay: `${(i * TOTAL_DURATION * SLOT_PERCENT) / 100 - TOTAL_DURATION}s`,
+          }}
+        />
+      ))}
+
+      <MotionStyles
+        base={`
+.taskito-seq .tok { opacity: 0; }
+${MSGS.map((m) => keyframeFor(m)).join("\n")}
+`}
+        animations={`
+${MSGS.map(
+  (m) => `.taskito-seq .tok-${m.num} {
+  animation: taskito-seq-msg-${m.num} ${TOTAL_DURATION}s linear infinite;
+  filter: drop-shadow(0 0 6px var(--color-fd-primary));
+}`,
+).join("\n")}
+`}
+      />
+    </DiagramFrame>
+  );
+}
+
+function keyframeFor(msg: Msg): string {
+  const startX = laneCx(msg.fromLane);
+  const endX = laneCx(msg.toLane);
+  return `
+@keyframes taskito-seq-msg-${msg.num} {
+  0%                       { cx: ${startX}px; cy: ${msg.y}px; opacity: 0; }
+  ${FADE_IN_PERCENT}%      { cx: ${startX}px; cy: ${msg.y}px; opacity: 1; }
+  ${TRAVEL_PERCENT}%       { cx: ${endX}px;   cy: ${msg.y}px; opacity: 1; }
+  ${FADE_OUT_PERCENT}%     { cx: ${endX}px;   cy: ${msg.y}px; opacity: 0; }
+  ${SLOT_PERCENT}%         { cx: ${startX}px; cy: ${msg.y}px; opacity: 0; }
+  100%                     { cx: ${startX}px; cy: ${msg.y}px; opacity: 0; }
+}`;
+}

--- a/docs/src/components/animated/entity-schema.tsx
+++ b/docs/src/components/animated/entity-schema.tsx
@@ -1,0 +1,246 @@
+import { DiagramFrame, SKETCH_FILTER } from "./_primitives";
+
+const FONT_MONO =
+  'var(--font-mono), "IBM Plex Mono", ui-monospace, SFMono-Regular, monospace';
+
+type Field = {
+  name: string;
+  type: string;
+  key?: "PK" | "FK";
+};
+
+type EntitySchemaProps = {
+  name: string;
+  fields: Field[];
+};
+
+const ROW_H = 22;
+const HEADER_H = 36;
+const PAD_X = 18;
+const SCHEMA_W = 360;
+
+export function EntitySchema({ name, fields }: EntitySchemaProps) {
+  const h = HEADER_H + fields.length * ROW_H + 14;
+  return (
+    <DiagramFrame
+      ariaLabel={`${name} table schema`}
+      width={SCHEMA_W}
+      height={h}
+      className="taskito-entity"
+    >
+      <rect
+        x={2}
+        y={2}
+        width={SCHEMA_W - 4}
+        height={h - 4}
+        rx="10"
+        fill="var(--color-fd-card)"
+        stroke="var(--color-fd-sketch-strong)"
+        strokeWidth="2"
+        filter={SKETCH_FILTER}
+      />
+      <line
+        x1={2}
+        y1={HEADER_H}
+        x2={SCHEMA_W - 2}
+        y2={HEADER_H}
+        stroke="var(--color-fd-sketch-strong)"
+        strokeWidth="1.5"
+        opacity="0.7"
+        filter={SKETCH_FILTER}
+      />
+      <text
+        x={PAD_X}
+        y={HEADER_H - 12}
+        fill="var(--color-fd-foreground)"
+        fontSize="16"
+        fontWeight="700"
+      >
+        {name}
+      </text>
+      <text
+        x={SCHEMA_W - PAD_X}
+        y={HEADER_H - 12}
+        textAnchor="end"
+        fill="var(--color-fd-muted-foreground)"
+        fontSize="10"
+        fontFamily={FONT_MONO}
+        opacity="0.7"
+      >
+        table
+      </text>
+
+      {fields.map((field, i) => (
+        <FieldRow
+          key={field.name}
+          field={field}
+          y={HEADER_H + 16 + i * ROW_H}
+        />
+      ))}
+    </DiagramFrame>
+  );
+}
+
+function FieldRow({ field, y }: { field: Field; y: number }) {
+  const tagX = SCHEMA_W - PAD_X - 30;
+  const tagColor =
+    field.key === "PK"
+      ? "var(--color-fd-primary)"
+      : "var(--color-fd-muted-foreground)";
+  return (
+    <g>
+      <text
+        x={PAD_X}
+        y={y}
+        fill="var(--color-fd-foreground)"
+        fontSize="12"
+        fontFamily={FONT_MONO}
+      >
+        {field.name}
+      </text>
+      <text
+        x={SCHEMA_W - PAD_X - 36}
+        y={y}
+        textAnchor="end"
+        fill="var(--color-fd-muted-foreground)"
+        fontSize="11"
+        fontFamily={FONT_MONO}
+        opacity="0.85"
+      >
+        {field.type}
+      </text>
+      {field.key ? (
+        <g>
+          <rect
+            x={tagX}
+            y={y - 11}
+            width={28}
+            height={14}
+            rx="4"
+            fill="none"
+            stroke={tagColor}
+            strokeWidth="1.4"
+          />
+          <text
+            x={tagX + 14}
+            y={y - 1}
+            textAnchor="middle"
+            fill={tagColor}
+            fontSize="9"
+            fontWeight="700"
+            fontFamily={FONT_MONO}
+          >
+            {field.key}
+          </text>
+        </g>
+      ) : null}
+    </g>
+  );
+}
+
+type EntityRelationsProps = {
+  caption?: string;
+  relations: Array<{
+    from: string;
+    to: string;
+    cardinality: string;
+    label?: string;
+  }>;
+};
+
+export function EntityRelations({ caption, relations }: EntityRelationsProps) {
+  const names = Array.from(new Set(relations.flatMap((r) => [r.from, r.to])));
+  const w = 600;
+  const slotW = w / Math.max(names.length, 1);
+  const boxW = Math.min(slotW - 24, 160);
+  const boxH = 56;
+  const topY = 40;
+  const linkBaseY = topY + boxH + 50;
+  const linkSpacing = 60;
+  const h = topY + boxH + 60 + linkSpacing * relations.length;
+
+  const xFor = (entity: string) => {
+    const i = names.indexOf(entity);
+    return slotW * i + slotW / 2;
+  };
+
+  return (
+    <div className="my-4 not-prose flex flex-col items-center gap-2">
+      <DiagramFrame
+        ariaLabel="Table relationships"
+        width={w}
+        height={h}
+        className="taskito-relations"
+      >
+        {names.map((name) => {
+          const cx = xFor(name);
+          return (
+            <g key={name}>
+              <rect
+                x={cx - boxW / 2}
+                y={topY}
+                width={boxW}
+                height={boxH}
+                rx="10"
+                fill="var(--color-fd-card)"
+                stroke="var(--color-fd-sketch-strong)"
+                strokeWidth="2"
+                filter={SKETCH_FILTER}
+              />
+              <text
+                x={cx}
+                y={topY + boxH / 2 + 5}
+                textAnchor="middle"
+                fill="var(--color-fd-foreground)"
+                fontSize="16"
+                fontWeight="700"
+                fontFamily={FONT_MONO}
+              >
+                {name}
+              </text>
+            </g>
+          );
+        })}
+
+        {relations.map((rel, i) => {
+          const x1 = xFor(rel.from);
+          const x2 = xFor(rel.to);
+          const y = linkBaseY + i * linkSpacing;
+          const midX = (x1 + x2) / 2;
+          return (
+            // biome-ignore lint/suspicious/noArrayIndexKey: relations are statically authored; index disambiguates same-pair duplicates
+            <g key={`${rel.from}-${rel.to}-${i}`}>
+              <path
+                d={`M ${x1} ${topY + boxH} Q ${x1} ${y} ${midX} ${y} Q ${x2} ${y} ${x2} ${topY + boxH}`}
+                fill="none"
+                stroke="var(--color-fd-foreground)"
+                strokeWidth="2.2"
+                strokeDasharray="6 4"
+                strokeLinecap="round"
+                opacity="0.9"
+              />
+              <text
+                x={midX}
+                y={y - 8}
+                textAnchor="middle"
+                fill="var(--color-fd-foreground)"
+                fontSize="13"
+                fontWeight="500"
+                fontFamily={FONT_MONO}
+                opacity="0.95"
+              >
+                {rel.cardinality}
+                {rel.label ? `  ·  ${rel.label}` : ""}
+              </text>
+            </g>
+          );
+        })}
+      </DiagramFrame>
+      {caption ? (
+        <p className="text-xs text-fd-muted-foreground text-center">
+          {caption}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/docs/src/components/animated/how-it-works.tsx
+++ b/docs/src/components/animated/how-it-works.tsx
@@ -51,7 +51,7 @@ export function HowItWorks() {
   return (
     <section className="px-4 pb-20 max-w-3xl mx-auto w-full">
       <div className="text-center mb-10">
-        <h2 className="font-handwritten text-3xl sm:text-4xl text-fd-foreground mb-2">
+        <h2 className="font-sans text-3xl sm:text-4xl font-semibold text-fd-foreground mb-2">
           how it works
         </h2>
         <p className="text-sm text-fd-muted-foreground">
@@ -66,7 +66,7 @@ export function HowItWorks() {
           role="img"
           aria-label="Job lifecycle: enqueue from your code, durable queue, Rust worker pool, result returned"
           viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
-          className="w-full max-w-2xl font-handwritten taskito-flow"
+          className="w-full max-w-2xl font-sans taskito-flow"
         >
           <defs>
             <filter id="taskito-flow-sketch">
@@ -193,7 +193,7 @@ function StationNode({ station }: { station: Station }) {
         textAnchor="middle"
         fill="var(--color-fd-muted-foreground)"
         fontSize="9"
-        fontFamily="ui-monospace, SFMono-Regular, monospace"
+        fontFamily='var(--font-mono), "IBM Plex Mono", ui-monospace, SFMono-Regular, monospace'
         opacity="0.7"
       >
         {station.hint}

--- a/docs/src/components/animated/index.ts
+++ b/docs/src/components/animated/index.ts
@@ -1,0 +1,10 @@
+export { ArchitectureStack } from "./architecture-stack";
+export { CrashRecoveryTimeline } from "./crash-recovery-timeline";
+export { DispatchSequence } from "./dispatch-sequence";
+export { EntityRelations, EntitySchema } from "./entity-schema";
+export { HowItWorks } from "./how-it-works";
+export { JobStateMachine } from "./job-state-machine";
+export { ResourcePipeline } from "./resource-pipeline";
+export { SchedulerPollLoop } from "./scheduler-poll-loop";
+export { WorkerDispatch } from "./worker-dispatch";
+export { WorkerPool } from "./worker-pool";

--- a/docs/src/components/animated/job-state-machine.tsx
+++ b/docs/src/components/animated/job-state-machine.tsx
@@ -1,0 +1,204 @@
+import { Arrow, DiagramFrame, MotionStyles, NodeBox } from "./_primitives";
+
+const VIEW_W = 580;
+const VIEW_H = 280;
+const NODE_W = 116;
+const NODE_H = 46;
+const ROW_LIVE = 90;
+const ROW_FAULT = 200;
+
+type StateData = {
+  id: string;
+  label: string;
+  cx: number;
+  cy: number;
+  variant?: "primary" | "terminal";
+};
+
+const STATES: StateData[] = [
+  { id: "pending", label: "Pending", cx: 100, cy: ROW_LIVE },
+  {
+    id: "running",
+    label: "Running",
+    cx: 290,
+    cy: ROW_LIVE,
+    variant: "primary",
+  },
+  {
+    id: "complete",
+    label: "Complete",
+    cx: 480,
+    cy: ROW_LIVE,
+    variant: "terminal",
+  },
+  {
+    id: "cancelled",
+    label: "Cancelled",
+    cx: 100,
+    cy: ROW_FAULT,
+    variant: "terminal",
+  },
+  { id: "failed", label: "Failed", cx: 290, cy: ROW_FAULT },
+  { id: "dead", label: "Dead", cx: 480, cy: ROW_FAULT, variant: "terminal" },
+];
+
+type EdgeData = {
+  id: string;
+  d: string;
+  label?: string;
+  labelX?: number;
+  labelY?: number;
+  anchor?: "start" | "middle" | "end";
+  variant?: "muted";
+};
+
+const EDGES: EdgeData[] = [
+  {
+    id: "dequeue",
+    d: `M 158 ${ROW_LIVE} L 232 ${ROW_LIVE}`,
+    label: "dequeue",
+    labelX: 195,
+    labelY: ROW_LIVE - 10,
+  },
+  {
+    id: "success",
+    d: `M 348 ${ROW_LIVE} L 422 ${ROW_LIVE}`,
+    label: "success",
+    labelX: 385,
+    labelY: ROW_LIVE - 10,
+  },
+  {
+    id: "raise",
+    d: `M 290 ${ROW_LIVE + NODE_H / 2} L 290 ${ROW_FAULT - NODE_H / 2}`,
+    label: "raise",
+    labelX: 302,
+    labelY: 145,
+    anchor: "start",
+  },
+  {
+    id: "cancel",
+    d: `M 100 ${ROW_LIVE + NODE_H / 2} L 100 ${ROW_FAULT - NODE_H / 2}`,
+    label: "cancel",
+    labelX: 92,
+    labelY: 158,
+    anchor: "end",
+    variant: "muted",
+  },
+  {
+    id: "exhausted",
+    d: `M 348 ${ROW_FAULT} L 422 ${ROW_FAULT}`,
+    label: "exhausted",
+    labelX: 385,
+    labelY: ROW_FAULT - 10,
+  },
+  {
+    id: "retry",
+    d: `M 232 ${ROW_FAULT - 6} Q 175 ${ROW_FAULT - 4} 158 ${ROW_LIVE + NODE_H / 2 - 2}`,
+    label: "retry · backoff",
+    labelX: 222,
+    labelY: 142,
+    anchor: "end",
+  },
+  {
+    id: "retry-dead",
+    d: `M 480 ${ROW_FAULT + NODE_H / 2} Q 290 ${VIEW_H - 10} 100 ${ROW_LIVE + NODE_H / 2 + 14}`,
+    label: "retry_dead()",
+    labelX: 290,
+    labelY: VIEW_H - 14,
+    variant: "muted",
+  },
+];
+
+// Composite trajectories — each token traces a coherent story along the arrows.
+const PATH_HAPPY = "M 100 90 L 290 90 L 480 90";
+const PATH_RETRY =
+  "M 100 90 L 290 90 L 290 200 Q 175 196 158 113 L 290 90 L 480 90";
+const PATH_DEATH = "M 100 90 L 290 90 L 290 200 L 480 200";
+
+export function JobStateMachine() {
+  return (
+    <DiagramFrame
+      ariaLabel="Job state machine. Pending → Running → Complete on the happy path. Running can drop to Failed; Failed retries to Pending or moves to Dead when retries are exhausted. Pending can also be Cancelled. Dead jobs can be revived via retry_dead()."
+      width={VIEW_W}
+      height={VIEW_H}
+      className="taskito-states"
+    >
+      {EDGES.map((e) => (
+        <Arrow
+          key={e.id}
+          d={e.d}
+          variant={e.variant}
+          label={e.label}
+          labelX={e.labelX}
+          labelY={e.labelY}
+          labelAnchor={e.anchor}
+        />
+      ))}
+
+      {STATES.map((s) => (
+        <NodeBox
+          key={s.id}
+          cx={s.cx}
+          cy={s.cy}
+          w={NODE_W}
+          h={NODE_H}
+          label={s.label}
+          variant={s.variant}
+        />
+      ))}
+
+      <circle
+        r="5"
+        fill="var(--color-fd-primary)"
+        className="token token-happy"
+      />
+      <circle
+        r="5"
+        fill="var(--color-fd-primary)"
+        className="token token-retry"
+      />
+      <circle
+        r="5"
+        fill="var(--color-fd-primary)"
+        className="token token-death"
+      />
+
+      <MotionStyles
+        base={`
+.taskito-states .token {
+  opacity: 0;
+  offset-rotate: 0deg;
+  cx: 0;
+  cy: 0;
+}
+.taskito-states .token-happy { offset-path: path('${PATH_HAPPY}'); }
+.taskito-states .token-retry { offset-path: path('${PATH_RETRY}'); }
+.taskito-states .token-death { offset-path: path('${PATH_DEATH}'); }
+
+@keyframes taskito-state-traverse {
+  0%   { offset-distance: 0%;   opacity: 0; }
+  6%   { opacity: 1; }
+  92%  { offset-distance: 100%; opacity: 1; }
+  100% { offset-distance: 100%; opacity: 0; }
+}
+`}
+        animations={`
+.taskito-states .token-happy {
+  animation: taskito-state-traverse 6s cubic-bezier(0.55, 0.05, 0.4, 0.95) infinite;
+  filter: drop-shadow(0 0 5px var(--color-fd-primary));
+}
+.taskito-states .token-retry {
+  animation: taskito-state-traverse 11s cubic-bezier(0.55, 0.05, 0.4, 0.95) infinite;
+  animation-delay: -2.5s;
+  filter: drop-shadow(0 0 5px var(--color-fd-primary));
+}
+.taskito-states .token-death {
+  animation: taskito-state-traverse 8s cubic-bezier(0.55, 0.05, 0.4, 0.95) infinite;
+  animation-delay: -4.5s;
+  filter: drop-shadow(0 0 5px var(--color-fd-primary));
+}
+`}
+      />
+    </DiagramFrame>
+  );
+}

--- a/docs/src/components/animated/resource-pipeline.tsx
+++ b/docs/src/components/animated/resource-pipeline.tsx
@@ -1,0 +1,251 @@
+import {
+  Arrow,
+  Caption,
+  Cylinder,
+  DiagramFrame,
+  MotionStyles,
+  NodeBox,
+  Panel,
+} from "./_primitives";
+
+const VIEW_W = 820;
+const VIEW_H = 380;
+
+const ENQ_X = 20;
+const ENQ_Y = 24;
+const ENQ_W = 340;
+const ENQ_H = 332;
+const ENQ_CX = ENQ_X + ENQ_W / 2; // 190
+
+const WRK_X = 400;
+const WRK_Y = 24;
+const WRK_W = 400;
+const WRK_H = 332;
+const WRK_CX = WRK_X + WRK_W / 2; // 600
+
+const QUEUE_CX = 380;
+const QUEUE_CY = 196;
+const QUEUE_RX = 24;
+const QUEUE_RY = 16;
+
+const ROW_TOP = 78;
+const ROW_MID = 152;
+const ROW_PROXY = 232;
+const ROW_FN = 304;
+
+type NodeData = {
+  id: string;
+  label: string;
+  hint?: string;
+  cx: number;
+  cy: number;
+  w: number;
+  h: number;
+  variant?: "primary" | "muted";
+};
+
+const ENQ_NODES: NodeData[] = [
+  {
+    id: "args",
+    label: "Task arguments",
+    cx: ENQ_CX,
+    cy: ROW_TOP,
+    w: 200,
+    h: 40,
+  },
+  {
+    id: "ic",
+    label: "ArgumentInterceptor",
+    hint: "PASS · CONVERT · REDIRECT · PROXY",
+    cx: ENQ_CX,
+    cy: ROW_MID,
+    w: 260,
+    h: 50,
+    variant: "primary",
+  },
+  {
+    id: "px",
+    label: "ProxyHandler",
+    hint: ".deconstruct()",
+    cx: ENQ_CX,
+    cy: ROW_PROXY,
+    w: 200,
+    h: 42,
+  },
+  {
+    id: "ser",
+    label: "Serializer",
+    hint: "bytes",
+    cx: ENQ_CX,
+    cy: ROW_FN,
+    w: 170,
+    h: 42,
+  },
+];
+
+const WORKER_NODES: NodeData[] = [
+  { id: "de", label: "Deserialize", cx: WRK_CX, cy: ROW_TOP, w: 170, h: 40 },
+  {
+    id: "rc",
+    label: "reconstruct_args()",
+    cx: WRK_CX,
+    cy: ROW_MID,
+    w: 220,
+    h: 46,
+  },
+  {
+    id: "pxr",
+    label: "ProxyHandler",
+    hint: ".reconstruct()",
+    cx: 510,
+    cy: ROW_PROXY,
+    w: 140,
+    h: 42,
+    variant: "muted",
+  },
+  {
+    id: "rr",
+    label: "ResourceRuntime",
+    hint: "inject()",
+    cx: 690,
+    cy: ROW_PROXY,
+    w: 140,
+    h: 42,
+    variant: "muted",
+  },
+  {
+    id: "fn",
+    label: "Task function",
+    hint: "f(**args)",
+    cx: WRK_CX,
+    cy: ROW_FN,
+    w: 180,
+    h: 50,
+    variant: "primary",
+  },
+];
+
+export function ResourcePipeline() {
+  return (
+    <DiagramFrame
+      ariaLabel="Resource pipeline. On enqueue: arguments flow through ArgumentInterceptor, optionally through a ProxyHandler, into the Serializer, into the Queue. On worker dispatch: payloads are deserialized, reconstructed, and reconstituted with proxies and resource injection before the task function runs."
+      width={VIEW_W}
+      height={VIEW_H}
+      className="taskito-resources"
+    >
+      <Panel x={ENQ_X} y={ENQ_Y} w={ENQ_W} h={ENQ_H} label="enqueue()" />
+      <Panel x={WRK_X} y={WRK_Y} w={WRK_W} h={WRK_H} label="worker dispatch" />
+
+      {/* ENQ vertical chain: Args → IC → PX → SER */}
+      <Arrow d={`M ${ENQ_CX} ${ROW_TOP + 20} L ${ENQ_CX} ${ROW_MID - 25}`} />
+      <Arrow
+        d={`M ${ENQ_CX} ${ROW_MID + 25} L ${ENQ_CX} ${ROW_PROXY - 21}`}
+        label="PROXY"
+        labelX={ENQ_CX + 12}
+        labelY={ROW_MID + 50}
+        labelAnchor="start"
+      />
+      <Arrow d={`M ${ENQ_CX} ${ROW_PROXY + 21} L ${ENQ_CX} ${ROW_FN - 21}`} />
+
+      {/* PASS bypass */}
+      <Arrow
+        d={`M ${ENQ_CX - 130} ${ROW_MID} Q ${ENQ_X + 16} ${ROW_MID} ${ENQ_X + 16} ${ROW_FN} Q ${ENQ_X + 16} ${ROW_FN} ${ENQ_CX - 85} ${ROW_FN}`}
+        variant="muted"
+        label="PASS"
+        labelX={ENQ_X + 24}
+        labelY={ROW_PROXY + 4}
+        labelAnchor="start"
+      />
+
+      {/* SER → Queue → DE */}
+      <Arrow
+        d={`M ${ENQ_CX + 85} ${ROW_FN} Q ${(ENQ_CX + QUEUE_CX) / 2} ${ROW_FN} ${QUEUE_CX} ${QUEUE_CY + QUEUE_RY + 4}`}
+      />
+      <Arrow
+        d={`M ${QUEUE_CX} ${QUEUE_CY - QUEUE_RY - 4} Q ${QUEUE_CX} ${ROW_TOP} ${WRK_CX - 85} ${ROW_TOP}`}
+      />
+
+      {/* WRK chain: DE → RC → FN */}
+      <Arrow d={`M ${WRK_CX} ${ROW_TOP + 20} L ${WRK_CX} ${ROW_MID - 23}`} />
+      <Arrow d={`M ${WRK_CX} ${ROW_MID + 23} L ${WRK_CX} ${ROW_FN - 25}`} />
+
+      {/* PXR → FN (diagonal down-right) */}
+      <Arrow
+        d={`M 510 ${ROW_PROXY + 21} Q 510 ${ROW_PROXY + 50} ${WRK_CX - 50} ${ROW_FN - 21}`}
+        variant="muted"
+      />
+      {/* RR → FN (diagonal down-left) */}
+      <Arrow
+        d={`M 690 ${ROW_PROXY + 21} Q 690 ${ROW_PROXY + 50} ${WRK_CX + 50} ${ROW_FN - 21}`}
+        variant="muted"
+      />
+
+      <Cylinder
+        cx={QUEUE_CX}
+        cy={QUEUE_CY}
+        rx={QUEUE_RX}
+        ry={QUEUE_RY}
+        label="Queue"
+      />
+      <Caption
+        x={QUEUE_CX}
+        y={QUEUE_CY - QUEUE_RY - 14}
+        text="bytes"
+        size={9}
+      />
+
+      {ENQ_NODES.map((n) => (
+        <NodeBox key={n.id} {...n} />
+      ))}
+      {WORKER_NODES.map((n) => (
+        <NodeBox key={n.id} {...n} />
+      ))}
+
+      <circle
+        r="5"
+        fill="var(--color-fd-primary)"
+        className="token token-pass"
+      />
+      <circle
+        r="5"
+        fill="var(--color-fd-primary)"
+        className="token token-proxy"
+      />
+
+      <MotionStyles
+        base={`
+.taskito-resources .token {
+  opacity: 0;
+  offset-rotate: 0deg;
+  cx: 0;
+  cy: 0;
+}
+.taskito-resources .token-pass {
+  offset-path: path('M ${ENQ_CX} ${ROW_TOP} L ${ENQ_CX} ${ROW_MID} Q ${ENQ_X + 16} ${ROW_MID} ${ENQ_X + 16} ${ROW_FN} Q ${ENQ_X + 16} ${ROW_FN} ${ENQ_CX} ${ROW_FN} Q ${(ENQ_CX + QUEUE_CX) / 2} ${ROW_FN} ${QUEUE_CX} ${QUEUE_CY} Q ${QUEUE_CX} ${ROW_TOP} ${WRK_CX} ${ROW_TOP} L ${WRK_CX} ${ROW_MID} L ${WRK_CX} ${ROW_FN}');
+}
+.taskito-resources .token-proxy {
+  offset-path: path('M ${ENQ_CX} ${ROW_TOP} L ${ENQ_CX} ${ROW_MID} L ${ENQ_CX} ${ROW_PROXY} L ${ENQ_CX} ${ROW_FN} Q ${(ENQ_CX + QUEUE_CX) / 2} ${ROW_FN} ${QUEUE_CX} ${QUEUE_CY} Q ${QUEUE_CX} ${ROW_TOP} ${WRK_CX} ${ROW_TOP} L ${WRK_CX} ${ROW_MID} L ${WRK_CX} ${ROW_FN}');
+}
+
+@keyframes taskito-resources-traverse {
+  0%   { offset-distance: 0%;   opacity: 0; }
+  6%   { opacity: 1; }
+  92%  { offset-distance: 100%; opacity: 1; }
+  100% { offset-distance: 100%; opacity: 0; }
+}
+`}
+        animations={`
+.taskito-resources .token-pass {
+  animation: taskito-resources-traverse 9s cubic-bezier(0.55, 0.05, 0.4, 0.95) infinite;
+  filter: drop-shadow(0 0 5px var(--color-fd-primary));
+}
+.taskito-resources .token-proxy {
+  animation: taskito-resources-traverse 9s cubic-bezier(0.55, 0.05, 0.4, 0.95) infinite;
+  animation-delay: -4.5s;
+  filter: drop-shadow(0 0 5px var(--color-fd-primary));
+}
+`}
+      />
+    </DiagramFrame>
+  );
+}

--- a/docs/src/components/animated/scheduler-poll-loop.tsx
+++ b/docs/src/components/animated/scheduler-poll-loop.tsx
@@ -1,0 +1,291 @@
+import {
+  Arrow,
+  Caption,
+  DiagramFrame,
+  MotionStyles,
+  NodeBox,
+  SKETCH_FILTER,
+} from "./_primitives";
+
+const VIEW_W = 760;
+const VIEW_H = 380;
+const CENTER_X = 510;
+const CENTER_Y = 200;
+const ORBIT_R = 120;
+
+type LoopNode = {
+  id: string;
+  label: string;
+  hint?: string;
+  cx: number;
+  cy: number;
+  shape: "rect" | "diamond" | "pill";
+  variant?: "primary";
+};
+
+const LOOP_NODES: LoopNode[] = [
+  {
+    id: "tick",
+    label: "loop tick",
+    cx: CENTER_X,
+    cy: CENTER_Y - ORBIT_R,
+    shape: "pill",
+  },
+  {
+    id: "sleep",
+    label: "sleep",
+    hint: "50ms",
+    cx: CENTER_X + ORBIT_R,
+    cy: CENTER_Y,
+    shape: "rect",
+  },
+  {
+    id: "dispatch",
+    label: "try_dispatch()",
+    cx: CENTER_X,
+    cy: CENTER_Y + ORBIT_R,
+    shape: "rect",
+    variant: "primary",
+  },
+  {
+    id: "periodic",
+    label: "iteration % N",
+    cx: CENTER_X - ORBIT_R,
+    cy: CENTER_Y,
+    shape: "diamond",
+  },
+];
+
+type Branch = {
+  id: string;
+  label: string;
+  every: string;
+  cx: number;
+  cy: number;
+  /** Where the arrow exits the diamond. */
+  startX: number;
+  startY: number;
+  pulseClass: string;
+};
+
+// Diamond geometry: center at (CENTER_X - ORBIT_R, CENTER_Y) = (390, 200).
+// halfX=64, halfY=40 → vertices: top (390,160), right (454,200), bottom
+// (390,240), left (326,200). Each branch arrow exits from a distinct point
+// on the diamond's left half so arrows are visibly anchored to the shape.
+const DIAMOND_CX = CENTER_X - ORBIT_R;
+const DIAMOND_TOP_LEFT = { x: DIAMOND_CX - 32, y: CENTER_Y - 20 };
+const DIAMOND_LEFT = { x: DIAMOND_CX - 64, y: CENTER_Y };
+const DIAMOND_BOTTOM_LEFT = { x: DIAMOND_CX - 32, y: CENTER_Y + 20 };
+
+const BRANCHES: Branch[] = [
+  {
+    id: "checkp",
+    label: "check_periodic()",
+    every: "every ~60",
+    cx: 160,
+    cy: 100,
+    startX: DIAMOND_TOP_LEFT.x,
+    startY: DIAMOND_TOP_LEFT.y,
+    pulseClass: "pulse-fast",
+  },
+  {
+    id: "reap",
+    label: "reap_stale()",
+    every: "every ~100",
+    cx: 130,
+    cy: 200,
+    startX: DIAMOND_LEFT.x,
+    startY: DIAMOND_LEFT.y,
+    pulseClass: "pulse-mid",
+  },
+  {
+    id: "cleanup",
+    label: "auto_cleanup()",
+    every: "every ~1200",
+    cx: 160,
+    cy: 300,
+    startX: DIAMOND_BOTTOM_LEFT.x,
+    startY: DIAMOND_BOTTOM_LEFT.y,
+    pulseClass: "pulse-slow",
+  },
+];
+
+export function SchedulerPollLoop() {
+  return (
+    <DiagramFrame
+      ariaLabel="Scheduler poll loop. A four-node ring (loop tick → sleep 50ms → try_dispatch → iteration check) with three branch tasks (check_periodic, reap_stale, auto_cleanup) firing at coprime multiples."
+      width={VIEW_W}
+      height={VIEW_H}
+      className="taskito-poll"
+    >
+      <circle
+        cx={CENTER_X}
+        cy={CENTER_Y}
+        r={ORBIT_R}
+        fill="none"
+        stroke="var(--color-fd-sketch-accent)"
+        strokeWidth="1.8"
+        strokeDasharray="3 7"
+        opacity="0.55"
+        filter={SKETCH_FILTER}
+      />
+
+      {[45, 135, 225, 315].map((angle) => (
+        <OrbitTick key={angle} angle={angle} />
+      ))}
+
+      {LOOP_NODES.map((node) => (
+        <LoopNodeShape key={node.id} node={node} />
+      ))}
+
+      {BRANCHES.map((b) => {
+        const endX = b.cx + 80;
+        const endY = b.cy;
+        const midX = (b.startX + endX) / 2;
+        const midY = (b.startY + endY) / 2;
+        return (
+          <g key={b.id}>
+            <Arrow
+              d={`M ${b.startX} ${b.startY} Q ${midX} ${midY} ${endX} ${endY}`}
+              variant="muted"
+            />
+            <Caption x={midX} y={midY - 8} text={b.every} size={10} />
+            <NodeBox
+              cx={b.cx}
+              cy={b.cy}
+              w={160}
+              h={40}
+              label={b.label}
+              variant="muted"
+            />
+            <circle
+              cx={b.cx + 80 - 12}
+              cy={b.cy - 20 + 8}
+              r="3.5"
+              fill="var(--color-fd-primary)"
+              className={b.pulseClass}
+            />
+          </g>
+        );
+      })}
+
+      <circle
+        cx={CENTER_X}
+        cy={CENTER_Y - ORBIT_R}
+        r="6"
+        fill="var(--color-fd-primary)"
+        className="orbit-dot"
+      />
+
+      <MotionStyles
+        base={`
+.taskito-poll .orbit-dot { opacity: 0; }
+.taskito-poll .pulse-fast,
+.taskito-poll .pulse-mid,
+.taskito-poll .pulse-slow { opacity: 0; }
+
+@keyframes taskito-poll-orbit {
+  0%   { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+@keyframes taskito-poll-pulse {
+  0%, 100% { opacity: 0; }
+  50%      { opacity: 1; }
+}
+`}
+        animations={`
+.taskito-poll .orbit-dot {
+  opacity: 1;
+  transform-box: view-box;
+  transform-origin: ${CENTER_X}px ${CENTER_Y}px;
+  animation: taskito-poll-orbit 4s linear infinite;
+  filter: drop-shadow(0 0 6px var(--color-fd-primary));
+}
+.taskito-poll .pulse-fast {
+  animation: taskito-poll-pulse 2.4s ease-in-out infinite;
+}
+.taskito-poll .pulse-mid {
+  animation: taskito-poll-pulse 4s ease-in-out infinite;
+  animation-delay: -1s;
+}
+.taskito-poll .pulse-slow {
+  animation: taskito-poll-pulse 6s ease-in-out infinite;
+  animation-delay: -3s;
+}
+`}
+      />
+    </DiagramFrame>
+  );
+}
+
+function LoopNodeShape({ node }: { node: LoopNode }) {
+  if (node.shape === "diamond") {
+    const halfX = 64;
+    const halfY = 40;
+    return (
+      <g>
+        <polygon
+          points={`${node.cx},${node.cy - halfY} ${node.cx + halfX},${node.cy} ${node.cx},${node.cy + halfY} ${node.cx - halfX},${node.cy}`}
+          fill="var(--color-fd-card)"
+          stroke="var(--color-fd-sketch-strong)"
+          strokeWidth="2"
+          filter={SKETCH_FILTER}
+        />
+        <text
+          x={node.cx}
+          y={node.cy + 4}
+          textAnchor="middle"
+          fill="var(--color-fd-foreground)"
+          fontSize="12"
+          fontWeight="600"
+        >
+          {node.label}
+        </text>
+      </g>
+    );
+  }
+
+  if (node.shape === "pill") {
+    return (
+      <NodeBox
+        cx={node.cx}
+        cy={node.cy}
+        w={140}
+        h={42}
+        label={node.label}
+        rx={21}
+      />
+    );
+  }
+
+  return (
+    <NodeBox
+      cx={node.cx}
+      cy={node.cy}
+      w={160}
+      h={50}
+      label={node.label}
+      hint={node.hint}
+      variant={node.variant}
+    />
+  );
+}
+
+function OrbitTick({ angle }: { angle: number }) {
+  const rad = (angle * Math.PI) / 180;
+  const x = CENTER_X + ORBIT_R * Math.cos(rad);
+  const y = CENTER_Y + ORBIT_R * Math.sin(rad);
+  const tangent = angle + 90;
+  return (
+    <g transform={`translate(${x} ${y}) rotate(${tangent})`} opacity="0.5">
+      <path
+        d="M -4 -3 L 0 0 L -4 3"
+        fill="none"
+        stroke="var(--color-fd-sketch-accent)"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </g>
+  );
+}

--- a/docs/src/components/animated/worker-dispatch.tsx
+++ b/docs/src/components/animated/worker-dispatch.tsx
@@ -1,0 +1,336 @@
+import type { CSSProperties } from "react";
+import {
+  Arrow,
+  Caption,
+  Cylinder,
+  DiagramFrame,
+  MotionStyles,
+  NodeBox,
+  SKETCH_FILTER,
+} from "./_primitives";
+
+const VIEW_W = 720;
+const VIEW_H = 320;
+
+const SCHED_CX = 80;
+const SCHED_CY = 160;
+const SCHED_W = 120;
+const SCHED_H = 60;
+
+const SYNC_LANE_Y = 110;
+const ASYNC_LANE_Y = 230;
+
+const WORKER_SIZE = 36;
+const WORKER_GAP = 10;
+const POOL_LEFT = 232;
+const POOL_TOP = SYNC_LANE_Y - WORKER_SIZE - WORKER_GAP / 2;
+const POOL_W = 3 * WORKER_SIZE + 2 * WORKER_GAP;
+const POOL_RIGHT = POOL_LEFT + POOL_W;
+
+const ASYNC_LEFT = 232;
+const ASYNC_W = POOL_W;
+const ASYNC_H = 44;
+const ASYNC_RIGHT = ASYNC_LEFT + ASYNC_W;
+
+const RESULT_CX = 460;
+const RESULT_CY = SCHED_CY;
+const RESULT_W = 116;
+const RESULT_H = 60;
+const RESULT_LEFT = RESULT_CX - RESULT_W / 2;
+const RESULT_RIGHT = RESULT_CX + RESULT_W / 2;
+
+const SQLITE_CX = 620;
+const SQLITE_CY = SCHED_CY;
+const SQLITE_RX = 50;
+const SQLITE_RY = 30;
+
+type Worker = {
+  id: number;
+  cx: number;
+  cy: number;
+  delay: string;
+  duration: string;
+};
+
+const WORKERS: Worker[] = [
+  {
+    id: 0,
+    cx: POOL_LEFT + WORKER_SIZE / 2,
+    cy: POOL_TOP + WORKER_SIZE / 2,
+    delay: "0s",
+    duration: "2.4s",
+  },
+  {
+    id: 1,
+    cx: POOL_LEFT + WORKER_SIZE * 1.5 + WORKER_GAP,
+    cy: POOL_TOP + WORKER_SIZE / 2,
+    delay: "-0.4s",
+    duration: "2.8s",
+  },
+  {
+    id: 2,
+    cx: POOL_LEFT + WORKER_SIZE * 2.5 + WORKER_GAP * 2,
+    cy: POOL_TOP + WORKER_SIZE / 2,
+    delay: "-1.1s",
+    duration: "2.6s",
+  },
+  {
+    id: 3,
+    cx: POOL_LEFT + WORKER_SIZE / 2,
+    cy: POOL_TOP + WORKER_SIZE * 1.5 + WORKER_GAP,
+    delay: "-0.7s",
+    duration: "3.1s",
+  },
+  {
+    id: 4,
+    cx: POOL_LEFT + WORKER_SIZE * 1.5 + WORKER_GAP,
+    cy: POOL_TOP + WORKER_SIZE * 1.5 + WORKER_GAP,
+    delay: "-1.6s",
+    duration: "2.5s",
+  },
+  {
+    id: 5,
+    cx: POOL_LEFT + WORKER_SIZE * 2.5 + WORKER_GAP * 2,
+    cy: POOL_TOP + WORKER_SIZE * 1.5 + WORKER_GAP,
+    delay: "-0.2s",
+    duration: "2.9s",
+  },
+];
+
+const SYNC_DOTS = ["0s", "-0.6s", "-1.2s", "-1.8s"];
+const ASYNC_DOTS = ["-0.3s", "-1.5s"];
+const RESULT_DOTS = ["-0.2s", "-1.0s", "-1.7s"];
+
+export function WorkerDispatch() {
+  return (
+    <DiagramFrame
+      ariaLabel="Worker pool dispatch. The Scheduler routes sync jobs to a six-thread worker pool and async jobs to a dedicated async executor; both lanes converge at the Result Channel which writes back to SQLite."
+      width={VIEW_W}
+      height={VIEW_H}
+      className="taskito-dispatch"
+    >
+      <NodeBox
+        cx={SCHED_CX}
+        cy={SCHED_CY}
+        w={SCHED_W}
+        h={SCHED_H}
+        label="Scheduler"
+        hint="Tokio · 50ms"
+        variant="primary"
+      />
+
+      <Caption
+        x={POOL_LEFT + POOL_W / 2}
+        y={POOL_TOP - 20}
+        text="sync · 6 worker threads"
+      />
+      <Caption
+        x={ASYNC_LEFT + ASYNC_W / 2}
+        y={ASYNC_LANE_Y + ASYNC_H / 2 + 22}
+        text="async · dedicated event loop"
+      />
+
+      {/* Scheduler -> sync entry */}
+      <Arrow
+        d={`M ${SCHED_CX + SCHED_W / 2} ${SCHED_CY - 12} Q ${SCHED_CX + SCHED_W / 2 + 30} ${SYNC_LANE_Y} ${POOL_LEFT - 10} ${SYNC_LANE_Y}`}
+      />
+      {/* Scheduler -> async entry */}
+      <Arrow
+        d={`M ${SCHED_CX + SCHED_W / 2} ${SCHED_CY + 12} Q ${SCHED_CX + SCHED_W / 2 + 30} ${ASYNC_LANE_Y} ${ASYNC_LEFT - 10} ${ASYNC_LANE_Y}`}
+      />
+      {/* sync -> result */}
+      <Arrow
+        d={`M ${POOL_RIGHT + 8} ${SYNC_LANE_Y} Q ${(POOL_RIGHT + RESULT_LEFT) / 2} ${SYNC_LANE_Y} ${RESULT_LEFT - 4} ${RESULT_CY - 12}`}
+      />
+      {/* async -> result */}
+      <Arrow
+        d={`M ${ASYNC_RIGHT + 8} ${ASYNC_LANE_Y} Q ${(ASYNC_RIGHT + RESULT_LEFT) / 2} ${ASYNC_LANE_Y} ${RESULT_LEFT - 4} ${RESULT_CY + 12}`}
+      />
+      {/* result -> SQLite */}
+      <Arrow
+        d={`M ${RESULT_RIGHT + 4} ${RESULT_CY} L ${SQLITE_CX - SQLITE_RX - 6} ${SQLITE_CY}`}
+      />
+
+      {WORKERS.map((w) => (
+        <WorkerCell key={w.id} worker={w} />
+      ))}
+
+      <NodeBox
+        cx={ASYNC_LEFT + ASYNC_W / 2}
+        cy={ASYNC_LANE_Y}
+        w={ASYNC_W}
+        h={ASYNC_H}
+        label="Async Executor"
+        rx={ASYNC_H / 2}
+      />
+
+      <NodeBox
+        cx={RESULT_CX}
+        cy={RESULT_CY}
+        w={RESULT_W}
+        h={RESULT_H}
+        label="Result"
+        hint="channel"
+      />
+
+      <Cylinder
+        cx={SQLITE_CX}
+        cy={SQLITE_CY}
+        rx={SQLITE_RX}
+        ry={SQLITE_RY}
+        label="SQLite"
+      />
+
+      {SYNC_DOTS.map((d) => (
+        <circle
+          key={`sd-${d}`}
+          r="4"
+          fill="var(--color-fd-primary)"
+          className="ingress-sync"
+          style={{ animationDelay: d }}
+        />
+      ))}
+
+      {ASYNC_DOTS.map((d) => (
+        <circle
+          key={`ad-${d}`}
+          r="4"
+          fill="var(--color-fd-primary)"
+          className="ingress-async"
+          style={{ animationDelay: d }}
+        />
+      ))}
+
+      {RESULT_DOTS.map((d) => (
+        <circle
+          key={`rd-${d}`}
+          r="4"
+          fill="var(--color-fd-primary)"
+          className="result-out"
+          style={{ animationDelay: d }}
+        />
+      ))}
+
+      <MotionStyles
+        base={`
+.taskito-dispatch .ingress-sync,
+.taskito-dispatch .ingress-async,
+.taskito-dispatch .result-out,
+.taskito-dispatch .worker-active,
+.taskito-dispatch .worker-ring { opacity: 0; }
+.taskito-dispatch .worker-active,
+.taskito-dispatch .worker-ring {
+  transform-box: fill-box;
+  transform-origin: center;
+}
+
+.taskito-dispatch .ingress-sync,
+.taskito-dispatch .ingress-async,
+.taskito-dispatch .result-out {
+  offset-rotate: 0deg;
+  cx: 0;
+  cy: 0;
+}
+.taskito-dispatch .ingress-sync {
+  offset-path: path('M ${SCHED_CX + SCHED_W / 2} ${SCHED_CY - 12} Q ${SCHED_CX + SCHED_W / 2 + 30} ${SYNC_LANE_Y} ${POOL_LEFT - 10} ${SYNC_LANE_Y}');
+}
+.taskito-dispatch .ingress-async {
+  offset-path: path('M ${SCHED_CX + SCHED_W / 2} ${SCHED_CY + 12} Q ${SCHED_CX + SCHED_W / 2 + 30} ${ASYNC_LANE_Y} ${ASYNC_LEFT - 10} ${ASYNC_LANE_Y}');
+}
+.taskito-dispatch .result-out {
+  offset-path: path('M ${RESULT_RIGHT + 4} ${RESULT_CY} L ${SQLITE_CX - SQLITE_RX - 6} ${SQLITE_CY}');
+}
+
+@keyframes taskito-dispatch-flow {
+  0%   { offset-distance: 0%;   opacity: 0; }
+  10%  { opacity: 1; }
+  90%  { offset-distance: 100%; opacity: 1; }
+  100% { offset-distance: 100%; opacity: 0; }
+}
+@keyframes taskito-dispatch-worker-active {
+  0%, 35%   { opacity: 0; transform: scale(0.6); }
+  50%       { opacity: 1; transform: scale(1); }
+  85%       { opacity: 1; transform: scale(1); }
+  100%      { opacity: 0; transform: scale(0.6); }
+}
+@keyframes taskito-dispatch-worker-ring {
+  0%, 35%   { opacity: 0; transform: scale(0.55); }
+  55%       { opacity: 0.55; transform: scale(1.5); }
+  100%      { opacity: 0; transform: scale(2.1); }
+}
+`}
+        animations={`
+.taskito-dispatch .ingress-sync {
+  animation: taskito-dispatch-flow 2.4s linear infinite;
+  filter: drop-shadow(0 0 3px var(--color-fd-primary));
+}
+.taskito-dispatch .ingress-async {
+  animation: taskito-dispatch-flow 2.8s linear infinite;
+  filter: drop-shadow(0 0 3px var(--color-fd-primary));
+}
+.taskito-dispatch .result-out {
+  animation: taskito-dispatch-flow 2.6s linear infinite;
+  filter: drop-shadow(0 0 3px var(--color-fd-primary));
+}
+.taskito-dispatch .worker-active {
+  animation: taskito-dispatch-worker-active var(--worker-duration) ease-in-out infinite;
+  animation-delay: var(--worker-delay);
+}
+.taskito-dispatch .worker-ring {
+  animation: taskito-dispatch-worker-ring var(--worker-duration) ease-out infinite;
+  animation-delay: var(--worker-delay);
+}
+`}
+      />
+    </DiagramFrame>
+  );
+}
+
+function WorkerCell({ worker }: { worker: Worker }) {
+  const half = WORKER_SIZE / 2;
+  return (
+    <g
+      style={
+        {
+          "--worker-delay": worker.delay,
+          "--worker-duration": worker.duration,
+        } as CSSProperties
+      }
+    >
+      <rect
+        x={worker.cx - half}
+        y={worker.cy - half}
+        width={WORKER_SIZE}
+        height={WORKER_SIZE}
+        rx="6"
+        fill="var(--color-fd-card)"
+        stroke="var(--color-fd-sketch-strong)"
+        strokeWidth="2"
+        filter={SKETCH_FILTER}
+      />
+      <circle
+        cx={worker.cx}
+        cy={worker.cy}
+        r="6"
+        fill="none"
+        stroke="var(--color-fd-primary)"
+        strokeWidth="1.4"
+        className="worker-ring"
+      />
+      <circle
+        cx={worker.cx}
+        cy={worker.cy}
+        r="2.5"
+        fill="var(--color-fd-muted-foreground)"
+        opacity="0.5"
+      />
+      <circle
+        cx={worker.cx}
+        cy={worker.cy}
+        r="2.5"
+        fill="var(--color-fd-primary)"
+        className="worker-active"
+      />
+    </g>
+  );
+}

--- a/docs/src/components/animated/worker-pool.tsx
+++ b/docs/src/components/animated/worker-pool.tsx
@@ -38,7 +38,7 @@ export function WorkerPool() {
   return (
     <section className="px-4 pb-24 max-w-3xl mx-auto w-full">
       <div className="text-center mb-10">
-        <h2 className="font-handwritten text-3xl sm:text-4xl text-fd-foreground mb-2">
+        <h2 className="font-sans text-3xl sm:text-4xl font-semibold text-fd-foreground mb-2">
           six workers, constant flow
         </h2>
         <p className="text-sm text-fd-muted-foreground">
@@ -51,7 +51,7 @@ export function WorkerPool() {
           role="img"
           aria-label="Six-worker pool with jobs streaming in from the left and results streaming out to the right"
           viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
-          className="w-full max-w-2xl font-handwritten taskito-pool"
+          className="w-full max-w-2xl font-sans taskito-pool"
         >
           <defs>
             <filter id="taskito-pool-sketch">

--- a/docs/src/components/mdx.tsx
+++ b/docs/src/components/mdx.tsx
@@ -1,5 +1,18 @@
 import defaultMdxComponents from "fumadocs-ui/mdx";
 import type { MDXComponents } from "mdx/types";
+import {
+  ArchitectureStack,
+  CrashRecoveryTimeline,
+  DispatchSequence,
+  EntityRelations,
+  EntitySchema,
+  HowItWorks,
+  JobStateMachine,
+  ResourcePipeline,
+  SchedulerPollLoop,
+  WorkerDispatch,
+  WorkerPool,
+} from "./animated";
 import { DiagramCarousel, DiagramSlide } from "./diagram-carousel";
 import { Mermaid } from "./mermaid";
 
@@ -9,6 +22,17 @@ export function getMDXComponents(components?: MDXComponents) {
     Mermaid,
     DiagramCarousel,
     DiagramSlide,
+    ArchitectureStack,
+    CrashRecoveryTimeline,
+    DispatchSequence,
+    EntityRelations,
+    EntitySchema,
+    HowItWorks,
+    JobStateMachine,
+    ResourcePipeline,
+    SchedulerPollLoop,
+    WorkerDispatch,
+    WorkerPool,
     ...components,
   } satisfies MDXComponents;
 }


### PR DESCRIPTION
## Summary

- Replaces every Mermaid diagram under `docs/content/docs/architecture/` with custom animated SVG components in the same hand-drawn aesthetic as the homepage (`HowItWorks`, `WorkerPool`).
- Moves the two existing homepage components into a shared `docs/src/components/animated/` directory so docs and homepage now share a single source of truth (re-exported via `_sections/index.ts` so the homepage keeps rendering unchanged).
- Adds shared primitives (`SketchDefs`, `DiagramFrame`, `NodeBox`, `Cylinder`, `Panel`, `Arrow`, `Caption`, `MotionStyles`) in `_primitives.tsx` to eliminate per-diagram boilerplate.

## New diagrams

| Page | Component |
|---|---|
| overview | `ArchitectureStack` — three-layer panel (python / rust / storage) with traversing tokens |
| job-lifecycle | `JobStateMachine` — six states + 7 edges; three tokens trace happy / retry / death stories along the arrows |
| worker-pool | `WorkerDispatch` — sync 6-cell grid + async executor → result channel → SQLite |
| resources | `ResourcePipeline` — enqueue lane + worker dispatch lane with ProxyHandler + ResourceRuntime side feeds |
| scheduler (×2) | `SchedulerPollLoop` (orbit + branch boxes from diamond vertices) and `DispatchSequence` (numbered swimlane messages) |
| failure-model | `CrashRecoveryTimeline` — Worker A → crash → reap_stale → Worker B with polling-tick region |
| storage (×7) | `EntitySchema` + `EntityRelations` — static sketchy ER tables and relationship arcs |

## Implementation notes

- Pure CSS keyframes; no framer-motion, no lottie, no new deps.
- Tokens traverse the actual arrow paths via CSS `offset-path` + `offset-distance` keyframes (not point-to-point cx/cy hops).
- All animations gated behind `@media (prefers-reduced-motion: no-preference)`.
- Typography: IBM Plex Sans + IBM Plex Mono via `var(--font-sans)` / `var(--font-mono)`.
- Colors use only fumadocs tokens (`--color-fd-foreground`, `--color-fd-primary`, `--color-fd-card`, `--color-fd-muted-foreground`, `--color-fd-sketch-strong`, `--color-fd-sketch-accent`) — light + dark theme parity is automatic.

## Test plan

- [x] `pnpm --dir docs lint`
- [x] `pnpm --dir docs types:check`
- [x] `pnpm --dir docs build` (all 306 routes generated)
- [ ] Visit each page and confirm: animation loops smoothly, no label/arrow overlaps, both themes legible
  - `/docs/architecture/overview`
  - `/docs/architecture/job-lifecycle`
  - `/docs/architecture/worker-pool`
  - `/docs/architecture/resources`
  - `/docs/architecture/scheduler`
  - `/docs/architecture/failure-model`
  - `/docs/architecture/storage`
- [ ] Toggle OS-level "reduce motion" and confirm a sensible static frame remains
- [ ] Homepage `/` still renders `HowItWorks` and `WorkerPool` unchanged