### PR TITLE
ci(dashboard): verify routeTree.gen.ts is regenerated

### DIFF
--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -30,6 +30,15 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/dashboard-build
 
+      - name: Verify routeTree.gen.ts is regenerated
+        working-directory: ${{ github.workspace }}
+        run: |
+          if ! git diff --exit-code --quiet dashboard/src/routeTree.gen.ts; then
+            echo "::error::dashboard/src/routeTree.gen.ts is stale. Run 'pnpm --dir dashboard exec tsr generate' and commit the result."
+            git --no-pager diff dashboard/src/routeTree.gen.ts
+            exit 1
+          fi
+
       - name: Biome (lint + format)
         run: pnpm exec biome ci src/
 


### PR DESCRIPTION
## Summary

Adds a guard step to the dashboard CI workflow that fails the build if `dashboard/src/routeTree.gen.ts` differs from the freshly-generated tree.

The composite `dashboard-build` action already runs `pnpm exec tsr generate` before typecheck/test/build, so a stale committed `routeTree.gen.ts` would silently be overwritten in CI. Without this check a developer can add a route, forget to regenerate, and have the build still pass — leaving the committed tree drifted from source.

The step runs only in the dashboard PR/push workflow (`dashboard.yml`), not in the publish workflow, so release builds aren't blocked by drift detection.

Addresses recommendation 11 from the 2026-05-08 audit (`.claude/reports/audit-2026-05-08.md`).

## Test plan

- [x] Local: re-running `pnpm exec tsr generate` against the current source produces no diff against the committed file.
- [ ] CI: this PR exercises the new step; expect green.
- [ ] Manual: add a stub route, push without regenerating, observe the step fail with the helpful error message.