### PR TITLE
fix(docs): respect basePath in static search index URL

### DIFF
--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -15,6 +15,9 @@ const config = {
   images: {
     unoptimized: true,
   },
+  env: {
+    NEXT_PUBLIC_DOCS_BASE_PATH: basePath,
+  },
 };
 
 export default withMDX(config);

--- a/docs/src/components/search.tsx
+++ b/docs/src/components/search.tsx
@@ -22,12 +22,15 @@ function initOrama() {
   });
 }
 
+const basePath = process.env.NEXT_PUBLIC_DOCS_BASE_PATH ?? "";
+
 export default function DefaultSearchDialog(props: SharedProps) {
   const { locale } = useI18n(); // (optional) for i18n
   const { search, setSearch, query } = useDocsSearch({
     type: "static",
     initOrama,
     locale,
+    from: `${basePath}/api/search`,
   });
 
   return (


### PR DESCRIPTION
## Summary

Search on `docs.byteveda.org/taskito` returns no results — typing "workflows" doesn't even render the "No result" placeholder.

**Root cause:** the docs ship with `DOCS_BASE_PATH=/taskito` (CI in `.github/workflows/docs.yml`), but fumadocs' static Orama client hardcodes the index URL to `/api/search` and is unaware of Next's `basePath`. So the deployed site fetches `https://docs.byteveda.org/api/search` (404) instead of `https://docs.byteveda.org/taskito/api/search` (200, 5.6 MB index). The rejected promise is then cached forever in `getDBCached`, and the dialog stays at `items === null` (hidden — that's why no "No result" message either).

**Fix:** expose `basePath` to the client as `NEXT_PUBLIC_DOCS_BASE_PATH` and pass it to `useDocsSearch` via the documented `from` option:

```ts
useDocsSearch({
  type: "static",
  initOrama,
  locale,
  from: `${basePath}/api/search`,
});
```

Locally with `pnpm dev` (no basePath) `from` becomes `/api/search` and behavior is unchanged.

## Test plan

- [x] `pnpm types:check` passes
- [x] `pnpm lint` passes
- [ ] Local sanity: `pnpm dev` → search "workflows" → results show
- [ ] Local with basePath: `DOCS_BASE_PATH=/taskito pnpm build && pnpm start` → open `localhost:3000/taskito` → search "workflows" → results show (this reproduces the prod bug without the fix)
- [ ] After merge: `https://docs.byteveda.org/taskito` → search works