### PR TITLE
fix(tests): poll for on_timeout middleware in prefork test

### DIFF
--- a/tests/worker/test_prefork.py
+++ b/tests/worker/test_prefork.py
@@ -161,7 +161,7 @@ def _wait_for_terminal(job: Any, timeout: float) -> str:
 
 
 @prefork_unix_only
-def test_prefork_kills_hung_task(timeout_app: object) -> None:
+def test_prefork_kills_hung_task(timeout_app: object, poll_until: Any) -> None:
     """A task that hangs past its `timeout=` is SIGKILLed by the watchdog and
     reported as a timeout failure within the timeout + watchdog tick budget."""
     timeouts_seen: list[str] = []
@@ -185,7 +185,14 @@ def test_prefork_kills_hung_task(timeout_app: object) -> None:
     assert status == "dead", f"expected 'dead', got {status!r} (error={job.error!r})"
     assert "timed out" in (job.error or "").lower()
     assert elapsed < 12, f"hung task took {elapsed:.1f}s to be killed (expected < 12s)"
-    assert job.id in timeouts_seen, "on_timeout middleware did not fire"
+    # The DB status flips to 'dead' inside `handle_result()`, but `on_timeout`
+    # fires a moment later in `dispatch_outcome` on the worker thread — poll
+    # rather than asserting on a single observation to avoid that race.
+    poll_until(
+        lambda: job.id in timeouts_seen,
+        timeout=5,
+        message="on_timeout middleware did not fire",
+    )
 
 
 @prefork_unix_only


### PR DESCRIPTION
## Summary

Master CI [run 25539963938](https://github.com/ByteVeda/taskito/actions/runs/25539963938) failed on `tests/worker/test_prefork.py::test_prefork_kills_hung_task` (Python 3.10 / Ubuntu) with:

```
AssertionError: on_timeout middleware did not fire
assert '019e063d-…' in []
```

The job *was* killed correctly (status `dead`, error `"timed out"`, well under the 12s budget), but the `on_timeout` spy hadn't fired yet.

**Race:** the worker thread, on receiving the timeout result, runs

```rust
let outcome = handle_result(result);   // writes status='dead' to the DB
dispatch_outcome(py, outcome);         // fires on_timeout middleware
```

`_wait_for_terminal` polls the DB and returns as soon as it sees `dead` — which can happen between those two calls. On a fast Ubuntu 3.10 runner the test thread observes `dead`, races back, and asserts on `timeouts_seen` before `dispatch_outcome` reaches the middleware call.

**Fix:** wait for the side effect we actually care about. The `poll_until` fixture in `tests/conftest.py` already exists for this exact pattern (used in `test_prefork_cancel_running_job_stops_quickly`). Replace the bare `assert job.id in timeouts_seen` with `poll_until(lambda: job.id in timeouts_seen, timeout=5, …)`.

Five seconds is well above the worst-case window between the DB write and the middleware call (which is microseconds in practice), but it gives slow CI runners enough headroom to never flake again.

The middleware ordering itself isn't a bug — `dispatch_outcome` deliberately runs after `handle_result` so the DB is the source of truth for status. The test was simply asserting on a moving target.

## Test plan

- [x] `uv run python -m pytest tests/worker/test_prefork.py::test_prefork_kills_hung_task -v` passes locally
- [x] `ruff check`, `mypy` clean
- [ ] CI green on master after merge