### PR TITLE
feat(logging): central taskito logger with AM/PM timestamps

### DIFF
--- a/crates/taskito-python/Cargo.toml
+++ b/crates/taskito-python/Cargo.toml
@@ -28,4 +28,5 @@ serde_json = { workspace = true }
 serde = { workspace = true }
 base64 = "0.22"
 log = { workspace = true }
+pyo3-log = "0.11"
 gethostname = "1.1.0"

--- a/crates/taskito-python/src/lib.rs
+++ b/crates/taskito-python/src/lib.rs
@@ -14,8 +14,19 @@ use py_config::PyTaskConfig;
 use py_job::PyJob;
 use py_queue::PyQueue;
 
+/// Activate the Rust → Python logging bridge.
+///
+/// Called explicitly from `taskito.log_config.configure()` rather than from
+/// module init so that cold imports (which can run while a connection pool
+/// is blocking the GIL on retries) don't trip pyo3-log's flush path.
+#[pyfunction]
+fn _init_rust_logging() {
+    let _ = pyo3_log::try_init();
+}
+
 #[pymodule]
 fn _taskito(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(_init_rust_logging, m)?)?;
     m.add_class::<PyQueue>()?;
     m.add_class::<PyJob>()?;
     m.add_class::<PyTaskConfig>()?;

--- a/crates/taskito-python/src/py_queue/mod.rs
+++ b/crates/taskito-python/src/py_queue/mod.rs
@@ -63,6 +63,7 @@ impl PyQueue {
     #[pyo3(signature = (db_path=".taskito/taskito.db", workers=0, default_retry=3, default_timeout=300, default_priority=0, result_ttl=None, backend="sqlite", db_url=None, schema="taskito", pool_size=None, scheduler_poll_interval_ms=50, scheduler_reap_interval=100, scheduler_cleanup_interval=1200, namespace=None))]
     #[allow(clippy::too_many_arguments)]
     pub fn new(
+        py: Python<'_>,
         db_path: &str,
         workers: usize,
         default_retry: i32,
@@ -78,49 +79,57 @@ impl PyQueue {
         scheduler_cleanup_interval: u32,
         namespace: Option<String>,
     ) -> PyResult<Self> {
-        let storage = match backend {
-            "sqlite" => {
-                let s = SqliteStorage::new(db_path)
-                    .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
-                StorageBackend::Sqlite(s)
-            }
-            #[cfg(feature = "postgres")]
-            "postgres" | "postgresql" => {
-                let url = db_url.ok_or_else(|| {
-                    pyo3::exceptions::PyValueError::new_err(
-                        "db_url is required for postgres backend",
-                    )
-                })?;
-                let s = PostgresStorage::with_schema_and_pool_size(
-                    url,
-                    schema,
-                    pool_size.unwrap_or(10),
-                )
-                .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
-                StorageBackend::Postgres(s)
-            }
-            #[cfg(feature = "redis")]
-            "redis" => {
-                let url = db_url.ok_or_else(|| {
-                    pyo3::exceptions::PyValueError::new_err("db_url is required for redis backend")
-                })?;
-                let s = RedisStorage::new(url)
-                    .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
-                StorageBackend::Redis(s)
-            }
-            _ => {
-                #[allow(unused_mut, clippy::useless_vec)]
-                let mut available = vec!["sqlite"];
+        // Storage init blocks on connection-pool builders that may emit
+        // `log::*` records from worker threads. With the pyo3-log bridge
+        // active, those records need the GIL to deliver to Python — so we
+        // must release it here to avoid a deadlock.
+        let storage = py.allow_threads(|| -> PyResult<StorageBackend> {
+            match backend {
+                "sqlite" => {
+                    let s = SqliteStorage::new(db_path)
+                        .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+                    Ok(StorageBackend::Sqlite(s))
+                }
                 #[cfg(feature = "postgres")]
-                available.push("postgres");
+                "postgres" | "postgresql" => {
+                    let url = db_url.ok_or_else(|| {
+                        pyo3::exceptions::PyValueError::new_err(
+                            "db_url is required for postgres backend",
+                        )
+                    })?;
+                    let s = PostgresStorage::with_schema_and_pool_size(
+                        url,
+                        schema,
+                        pool_size.unwrap_or(10),
+                    )
+                    .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+                    Ok(StorageBackend::Postgres(s))
+                }
                 #[cfg(feature = "redis")]
-                available.push("redis");
-                return Err(pyo3::exceptions::PyValueError::new_err(format!(
-                    "Unknown backend: '{backend}'. Available backends: {}.",
-                    available.join(", ")
-                )));
+                "redis" => {
+                    let url = db_url.ok_or_else(|| {
+                        pyo3::exceptions::PyValueError::new_err(
+                            "db_url is required for redis backend",
+                        )
+                    })?;
+                    let s = RedisStorage::new(url)
+                        .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+                    Ok(StorageBackend::Redis(s))
+                }
+                _ => {
+                    #[allow(unused_mut, clippy::useless_vec)]
+                    let mut available = vec!["sqlite"];
+                    #[cfg(feature = "postgres")]
+                    available.push("postgres");
+                    #[cfg(feature = "redis")]
+                    available.push("redis");
+                    Err(pyo3::exceptions::PyValueError::new_err(format!(
+                        "Unknown backend: '{backend}'. Available backends: {}.",
+                        available.join(", ")
+                    )))
+                }
             }
-        };
+        })?;
 
         let num_workers = if workers == 0 {
             std::thread::available_parallelism()

--- a/py_src/taskito/__init__.py
+++ b/py_src/taskito/__init__.py
@@ -26,6 +26,7 @@ from taskito.exceptions import (
 )
 from taskito.inject import Inject
 from taskito.interception import InterceptionError, InterceptionReport
+from taskito.log_config import configure as configure_logging
 from taskito.middleware import TaskMiddleware
 from taskito.proxies.no_proxy import NoProxy
 from taskito.result import JobResult
@@ -80,6 +81,7 @@ __all__ = [
     "chain",
     "chord",
     "chunks",
+    "configure_logging",
     "current_job",
     "group",
     "starmap",

--- a/py_src/taskito/_taskito.pyi
+++ b/py_src/taskito/_taskito.pyi
@@ -385,3 +385,7 @@ class PyResultSender:
         task_name: str,
         wall_time_ns: int,
     ) -> None: ...
+
+def _init_rust_logging() -> None:
+    """Activate the Rust → Python `logging` bridge (idempotent)."""
+    ...

--- a/py_src/taskito/cli.py
+++ b/py_src/taskito/cli.py
@@ -11,11 +11,16 @@ import time
 
 from taskito.app import Queue
 from taskito.dashboard import serve_dashboard
+from taskito.log_config import configure as configure_logging
 from taskito.scaler import serve_scaler
 
 
 def main() -> None:
     """Parse CLI arguments and dispatch to the appropriate subcommand."""
+    # Configure the central taskito logger before any subcommand runs so
+    # ``info``, ``dashboard``, ``scaler``, etc. all share the same sink.
+    configure_logging()
+
     parser = argparse.ArgumentParser(
         prog="taskito",
         description="taskito — Rust-powered task queue for Python",

--- a/py_src/taskito/log_config.py
+++ b/py_src/taskito/log_config.py
@@ -1,0 +1,130 @@
+"""Central log configuration for taskito.
+
+A single entry point — :func:`configure` — owns the ``taskito`` Python logger
+and the parallel logger names that PyO3-log uses for Rust crates
+(``taskito_core``, ``taskito_python``, ``taskito_async``, ``taskito_workflows``).
+Calling it more than once is a no-op when the resolved settings haven't
+changed; passing different arguments swaps the managed handler in place
+rather than stacking handlers.
+
+The Rust side is bridged into Python's :mod:`logging` by ``pyo3_log::try_init``
+inside the ``_taskito`` extension module init, so a single configure call
+captures Rust ``log::*`` output too.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import threading
+from typing import TextIO
+
+from taskito._taskito import _init_rust_logging
+
+__all__ = ["DEFAULT_DATEFMT", "DEFAULT_FORMAT", "configure"]
+
+DEFAULT_FORMAT = "[%(asctime)s] %(levelname)s %(message)s"
+DEFAULT_DATEFMT = "%Y-%m-%d %I:%M:%S %p"
+
+# Logger names that taskito emits under. The Python logger is well-known;
+# the Rust ones are derived from cargo crate names (``_`` form) by pyo3-log.
+_PY_LOGGER = "taskito"
+_RUST_LOGGERS = (
+    "taskito_core",
+    "taskito_python",
+    "taskito_async",
+    "taskito_workflows",
+)
+_ALL_LOGGERS = (_PY_LOGGER, *_RUST_LOGGERS)
+
+# Sentinel attribute set on a handler we manage, so we never double-attach
+# and we leave caller-installed handlers untouched.
+_OWN_HANDLER_ATTR = "_taskito_managed"
+
+# Guards concurrent calls to ``configure`` from multiple threads (CLI startup
+# vs. ``Queue.run_worker`` background thread).
+_CONFIG_LOCK = threading.Lock()
+
+# Cached signature of the last successful configure() call, so identical
+# repeat calls short-circuit instead of churning handlers.
+_LAST_CONFIG: tuple[int, int] | None = None
+
+
+def _resolve_level(level: int | str | None) -> int:
+    """Resolve a level argument or ``TASKITO_LOG_LEVEL`` env var to a logging int."""
+    if level is None:
+        level = os.environ.get("TASKITO_LOG_LEVEL", "INFO")
+    if isinstance(level, str):
+        try:
+            return int(level)
+        except ValueError:
+            pass
+        resolved = logging.getLevelName(level.upper())
+        if isinstance(resolved, int):
+            return resolved
+        return logging.INFO
+    return level
+
+
+def _build_handler(stream: TextIO) -> logging.Handler:
+    handler = logging.StreamHandler(stream)
+    handler.setFormatter(logging.Formatter(DEFAULT_FORMAT, datefmt=DEFAULT_DATEFMT))
+    setattr(handler, _OWN_HANDLER_ATTR, True)
+    return handler
+
+
+def _detach_managed(logger: logging.Logger) -> None:
+    for existing in list(logger.handlers):
+        if getattr(existing, _OWN_HANDLER_ATTR, False):
+            logger.removeHandler(existing)
+
+
+def configure(
+    level: int | str | None = None,
+    *,
+    stream: TextIO | None = None,
+) -> logging.Logger:
+    """Configure the central ``taskito`` logger and its Rust counterparts.
+
+    Idempotent: identical repeat calls are no-ops; argument changes swap the
+    managed handler in place rather than stacking handlers. Caller-installed
+    handlers on the same loggers are left intact.
+
+    Args:
+        level: Logging level as an int (e.g. ``logging.DEBUG``) or string
+            (``"INFO"``). Falls back to ``TASKITO_LOG_LEVEL``, then ``INFO``.
+        stream: Where to write log lines. Defaults to ``sys.stderr``.
+
+    Returns:
+        The configured ``taskito`` Python logger.
+    """
+    global _LAST_CONFIG
+
+    resolved_level = _resolve_level(level)
+    target_stream = stream if stream is not None else sys.stderr
+    signature = (resolved_level, id(target_stream))
+
+    with _CONFIG_LOCK:
+        if signature == _LAST_CONFIG:
+            return logging.getLogger(_PY_LOGGER)
+
+        # Activate the Rust → Python log bridge once. Doing this here (rather
+        # than from `_taskito` module init) avoids a deadlock during cold
+        # imports where the GIL is held by a blocking connection-pool retry.
+        _init_rust_logging()
+
+        handler = _build_handler(target_stream)
+        for name in _ALL_LOGGERS:
+            logger = logging.getLogger(name)
+            _detach_managed(logger)
+            logger.addHandler(handler)
+            logger.setLevel(resolved_level)
+            # Leave `propagate` alone. Embedded hosts (Django, FastAPI) that
+            # already have a root handler can set `propagate = False` on the
+            # `taskito` logger themselves to avoid duplicate lines; flipping
+            # it here would silently break pytest `caplog` and any other
+            # consumer that listens at the root.
+
+        _LAST_CONFIG = signature
+        return logging.getLogger(_PY_LOGGER)

--- a/py_src/taskito/mixins/lifecycle.py
+++ b/py_src/taskito/mixins/lifecycle.py
@@ -17,6 +17,7 @@ import taskito
 from taskito._taskito import PyQueue, PyTaskConfig
 from taskito.context import _set_queue_ref
 from taskito.events import EventType
+from taskito.log_config import configure as configure_logging
 from taskito.resources.health import HealthChecker
 from taskito.resources.runtime import ResourceRuntime
 from taskito.testing import TestMode
@@ -142,12 +143,7 @@ class QueueLifecycleMixin:
                 timezone=pc.get("timezone"),
             )
 
-        if not logging.root.handlers:
-            logging.basicConfig(
-                level=logging.INFO,
-                format="[%(asctime)s] %(levelname)s %(message)s",
-                datefmt="%Y-%m-%d %H:%M:%S",
-            )
+        configure_logging()
 
         worker_queues = queue_list or ["default"]
         self._print_banner(worker_queues)

--- a/tests/observability/test_log_config.py
+++ b/tests/observability/test_log_config.py
@@ -1,0 +1,126 @@
+"""Tests for the central log configuration module."""
+
+from __future__ import annotations
+
+import io
+import logging
+from collections.abc import Iterator
+
+import pytest
+
+from taskito import log_config
+from taskito.log_config import (
+    DEFAULT_DATEFMT,
+    DEFAULT_FORMAT,
+    configure,
+)
+
+_MANAGED_LOGGERS = (
+    "taskito",
+    "taskito_core",
+    "taskito_python",
+    "taskito_async",
+    "taskito_workflows",
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_taskito_loggers() -> Iterator[None]:
+    """Strip any handlers/state on the taskito loggers between tests.
+
+    The module keeps a process-wide cache so tests must isolate themselves
+    from each other (and from anything an earlier import may have set up).
+    """
+    log_config._LAST_CONFIG = None
+    for name in _MANAGED_LOGGERS:
+        logger = logging.getLogger(name)
+        logger.handlers.clear()
+        logger.setLevel(logging.NOTSET)
+        logger.propagate = True
+    yield
+    log_config._LAST_CONFIG = None
+    for name in _MANAGED_LOGGERS:
+        logger = logging.getLogger(name)
+        logger.handlers.clear()
+        logger.setLevel(logging.NOTSET)
+        logger.propagate = True
+
+
+def test_configure_attaches_handler_to_all_known_loggers() -> None:
+    stream = io.StringIO()
+    configure(level="DEBUG", stream=stream)
+
+    for name in _MANAGED_LOGGERS:
+        logger = logging.getLogger(name)
+        managed = [h for h in logger.handlers if getattr(h, "_taskito_managed", False)]
+        assert len(managed) == 1, f"{name} should have exactly one managed handler"
+        assert logger.level == logging.DEBUG
+
+
+def test_configure_is_idempotent_for_identical_calls() -> None:
+    stream = io.StringIO()
+    configure(level="INFO", stream=stream)
+    handler_before = logging.getLogger("taskito").handlers[0]
+
+    configure(level="INFO", stream=stream)
+    handler_after = logging.getLogger("taskito").handlers[0]
+
+    assert handler_before is handler_after, "no-op call must not rebuild the handler"
+    assert len(logging.getLogger("taskito").handlers) == 1
+
+
+def test_configure_swaps_handler_when_level_changes() -> None:
+    stream = io.StringIO()
+    configure(level="INFO", stream=stream)
+    first = logging.getLogger("taskito").handlers[0]
+
+    configure(level="DEBUG", stream=stream)
+    second = logging.getLogger("taskito").handlers[0]
+
+    assert first is not second
+    assert logging.getLogger("taskito").level == logging.DEBUG
+    # Still exactly one managed handler — the old one was detached.
+    assert len(logging.getLogger("taskito").handlers) == 1
+
+
+def test_configure_leaves_caller_handlers_alone() -> None:
+    stream = io.StringIO()
+    foreign = logging.StreamHandler(io.StringIO())
+    logging.getLogger("taskito").addHandler(foreign)
+
+    configure(level="INFO", stream=stream)
+    handlers = logging.getLogger("taskito").handlers
+    assert foreign in handlers, "caller-installed handlers must be preserved"
+    managed = [h for h in handlers if getattr(h, "_taskito_managed", False)]
+    assert len(managed) == 1
+
+
+def test_level_resolution_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TASKITO_LOG_LEVEL", "WARNING")
+    configure()
+    assert logging.getLogger("taskito").level == logging.WARNING
+
+
+def test_level_resolution_falls_back_to_info(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("TASKITO_LOG_LEVEL", raising=False)
+    configure()
+    assert logging.getLogger("taskito").level == logging.INFO
+
+
+def test_default_format_emits_am_pm_timestamp() -> None:
+    stream = io.StringIO()
+    configure(level="INFO", stream=stream)
+
+    logging.getLogger("taskito").info("hello")
+    output = stream.getvalue()
+
+    assert "INFO" in output
+    assert "hello" in output
+    assert ("AM" in output) or ("PM" in output), "default datefmt must include AM/PM marker"
+
+
+def test_format_constants_are_stable() -> None:
+    # Catch accidental drift in the default format strings — these are part of
+    # the public surface (downstream tools that grep logs may rely on them).
+    assert DEFAULT_FORMAT == "[%(asctime)s] %(levelname)s %(message)s"
+    assert "%p" in DEFAULT_DATEFMT


### PR DESCRIPTION
## Summary

One canonical entry point — \`taskito.configure_logging()\` — that owns the \`taskito\` logger and bridges Rust \`log::*\` records into the same sink. Used by every CLI subcommand and \`Queue.run_worker\` so all 'app runs' paths share one format and one destination.

- New \`taskito.log_config\` module with a single public \`configure(level=, stream=)\` that's idempotent, thread-safe, and respects \`TASKITO_LOG_LEVEL\`.
- Default format kept as \`[%(asctime)s] %(levelname)s %(message)s\`; timestamp now \`%Y-%m-%d %I:%M:%S %p\` so log lines carry AM/PM (per request).
- \`pyo3-log\` bridges every \`log::*\` record from \`taskito-core\`, \`taskito-python\`, \`taskito-async\` and \`taskito-workflows\` into Python's \`logging\` module under matching logger names; \`configure()\` attaches a managed handler to all five.
- \`PyQueue::new\` now releases the GIL during storage init. Without this, r2d2 pool builders that emit \`log::error!(\"database is locked\")\` from worker threads deadlock against the main thread holding the GIL during retries. The pyo3-log bridge would have surfaced this latent issue immediately; releasing the GIL is the correct production fix regardless.
- \`pyo3-log\` is activated lazily via a \`_init_rust_logging\` PyO3 function called from \`configure()\` rather than from module init, so cold imports don't trip the same flush path.
- The previously buried \`logging.basicConfig\` in \`mixins/lifecycle.py\` is replaced by \`configure_logging()\`. \`taskito.configure_logging\` is exported from the top-level package for embedded users (Django/FastAPI) who don't go through the CLI.

## Sample output

\`\`\`
[2026-05-08 04:08:18 PM] INFO smoke message from python
[2026-05-08 04:08:18 PM] INFO smoke from sub-logger
\`\`\`

## Test plan

- [x] \`uv run python -m pytest tests/ --ignore=tests/worker/test_prefork.py\` — 506 passed, 8 skipped
- [x] \`uv run python -m pytest tests/worker/test_prefork.py\` — 8 passed, 1 skipped
- [x] \`uv run python -m pytest tests/observability/test_log_config.py\` — 8 new tests passed
- [x] \`uv run ruff check\`, \`uv run mypy\` — clean
- [x] \`cargo check --workspace\`, \`--features postgres\`, \`--features redis\` — clean
- [x] \`cargo test --workspace\` — 89 passed
- [x] Manual smoke: \`taskito.configure_logging(level=\"DEBUG\")\` produces AM/PM-timestamped lines on \`taskito\` and \`taskito.<sub>\` child loggers.