### PR TITLE
fix(ci): use existing labels in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,7 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - dependencies
-      - area/rust
+      - rust
     commit-message:
       prefix: chore
       include: scope
@@ -36,7 +36,7 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - dependencies
-      - area/python
+      - python
     commit-message:
       prefix: chore
       include: scope
@@ -56,7 +56,7 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - dependencies
-      - area/dashboard
+      - dashboard
     commit-message:
       prefix: chore
       include: scope
@@ -83,7 +83,7 @@ updates:
     open-pull-requests-limit: 3
     labels:
       - dependencies
-      - area/ci
+      - ci
     commit-message:
       prefix: chore(ci)
     groups:


### PR DESCRIPTION
## Summary
- Dependabot was configured to apply `area/rust`, `area/python`, `area/dashboard`, and `area/ci` labels, but only `area/ci` existed in the repo. The recent dashboard deps PR failed with: *"The following labels could not be found: area/dashboard"*.
- Swap to the existing label names (`rust`, `python`, `dashboard`, `ci`) so future Dependabot PRs label cleanly. Pure config change — no code touched.

## Test plan
- [ ] Next Dependabot run applies labels without the "labels could not be found" error.