### PR TITLE
fix(ci): unbreak macOS by disabling rust-cache bin caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,15 @@ jobs:
 
       - name: Restore Cargo cache
         uses: Swatinem/rust-cache@v2
+        with:
+          # Skip caching ~/.cargo/bin/ — rustup 1.28's multicall binary
+          # interacts badly with this action's cache-clean step and ends up
+          # restoring a `cargo` that responds as `rustup-init`. Proxies are
+          # reinstalled on every run by dtolnay/rust-toolchain.
+          # See: https://github.com/Swatinem/rust-cache/issues/16
+          cache-bin: false
+          # Bump to evict any v0-* caches that already contain the corrupted bin dir.
+          prefix-key: v1-rust-bin-fix
 
       - name: Check Rust formatting
         run: cargo fmt --all --check
@@ -107,6 +116,8 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           save-if: false
+          cache-bin: false
+          prefix-key: v1-rust-bin-fix
 
       - name: Run Rust test suite
         run: cargo test --workspace
@@ -151,6 +162,8 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           save-if: false
+          cache-bin: false
+          prefix-key: v1-rust-bin-fix
 
       - name: Run Rust test suite (PostgreSQL backend)
         run: cargo test --workspace --features postgres
@@ -189,6 +202,8 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           save-if: false
+          cache-bin: false
+          prefix-key: v1-rust-bin-fix
 
       - name: Run Rust test suite (Redis backend)
         run: cargo test --workspace --features redis
@@ -237,6 +252,8 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ matrix.os != 'ubuntu-latest' }}
+          cache-bin: false
+          prefix-key: v1-rust-bin-fix
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0


### PR DESCRIPTION
## Summary

The `Python Tests (macos-latest / Python 3.13)` job has been failing on every master push since the Swatinem rust-cache action's saved `~/.cargo/bin/` got poisoned ([master run 25851399868](https://github.com/ByteVeda/taskito/actions/runs/25851399868), [master run 25845951470](https://github.com/ByteVeda/taskito/actions/runs/25845951470)). `uv sync --extra dev` runs maturin → `cargo metadata`, and macOS responds with:

```
error: error: unexpected argument 'metadata' found
Usage: rustup-init[EXE] [OPTIONS]
```

i.e. the cached `cargo` proxy is dispatching as `rustup-init`.

## Root cause

Two upstream behaviours compose into the failure:

1. **rustup 1.28** turned the toolchain installer into a multicall binary — `cargo`, `rustc`, `rustup`, `rustup-init` are hardlinks/symlinks to the same executable, dispatching by `argv[0]`.
2. **`Swatinem/rust-cache@v2`** caches `~/.cargo/bin/` by default and runs a "cache clean" pass that mutates the directory. Under the rustup 1.28 layout, restoring the cached bin dir overwrites the freshly-installed multicall binary with a stale `rustup-init`, breaking the `cargo` proxy.

The action's README documents this exact failure mode under "Known Issues" and recommends `cache-bin: false` as the fix. References:

- [Swatinem/rust-cache README — Known Issues](https://github.com/Swatinem/rust-cache/blob/master/README.md)
- [Swatinem/rust-cache #16 — `cargo` and `rustup` get deleted when saving cache](https://github.com/Swatinem/rust-cache/issues/16)
- [rust-lang/rustup #4239 — cargo proxy has corrupted arg0 for rustup v1.28](https://github.com/rust-lang/rustup/issues/4239)

## Fix

Two inputs added to **every** `Swatinem/rust-cache@v2` invocation in `.github/workflows/ci.yml` (5 jobs: `lint`, `rust-test`, `rust-test-postgres`, `rust-test-redis`, `test`):

- `cache-bin: false` — stop caching `~/.cargo/bin/`. `dtolnay/rust-toolchain@stable` reinstalls the proxies in <5 s on every run; there is no meaningful cache-hit benefit from including the bin dir, and the failure class is eliminated.
- `prefix-key: v1-rust-bin-fix` — bumps the cache key so the existing `v0-*` caches (which contain the poisoned macOS bin dir) are evicted. Without this the very next run would still restore the broken cache before the new `cache-bin: false` directive applies on save.

Applied to all five call sites (not only the macOS-affected `test` job) for consistency and to immunize the Linux/Windows runners against the same regression when their runner images rotate to rustup 1.28.

The valuable caches (`target/`, `~/.cargo/registry/`, `~/.cargo/git/db/`) are unaffected.

## Test plan

- [ ] **PR CI must pass on macOS**: `Python Tests (macos-latest / Python 3.13)` and `Python Tests (macos-latest / Python 3.10)` complete `uv sync --extra dev`, the maturin build, and `pytest tests/ -v`.
- [ ] Linux + Windows matrix entries still pass, no regression in timings.
- [ ] After merge, the next master push CI run is fully green.
- [ ] `gh cache list --ref refs/heads/master` shows new entries starting with `v1-rust-bin-fix-…` after the post-merge run.