### PR TITLE
fix: mute asyncio "pipe closed by peer" spam on worker shutdown

### DIFF
--- a/py_src/taskito/log_config.py
+++ b/py_src/taskito/log_config.py
@@ -22,7 +22,13 @@ from typing import TextIO
 
 from taskito._taskito import _init_rust_logging
 
-__all__ = ["DEFAULT_DATEFMT", "DEFAULT_FORMAT", "configure"]
+__all__ = [
+    "DEFAULT_DATEFMT",
+    "DEFAULT_FORMAT",
+    "configure",
+    "restore_asyncio_pipe_noise",
+    "silence_asyncio_pipe_noise",
+]
 
 DEFAULT_FORMAT = "[%(asctime)s] %(levelname)s %(message)s"
 DEFAULT_DATEFMT = "%Y-%m-%d %I:%M:%S %p"
@@ -128,3 +134,55 @@ def configure(
 
         _LAST_CONFIG = signature
         return logging.getLogger(_PY_LOGGER)
+
+
+# --- asyncio shutdown noise suppression ---------------------------------------
+#
+# When a taskito worker receives SIGINT (Ctrl+C in a terminal), the kernel
+# broadcasts the signal to every process in the foreground process group,
+# including subprocesses the user task spawned (Playwright browsers, ffmpeg,
+# any asyncio.create_subprocess_exec child). Those subprocesses exit and close
+# their stdin pipes. Asyncio's _UnixWritePipeTransport.write() silently
+# tolerates the first 5 failed writes, then emits a WARNING on every write
+# thereafter — flooding the drain window with messages whose underlying error
+# was already lost. The filter demotes that specific record to DEBUG so it
+# stops drowning out the legitimate "Warm shutdown" / "Worker stopped" lines,
+# while still being recoverable by anyone running the asyncio logger at DEBUG.
+
+
+_ASYNCIO_LOGGER_NAME = "asyncio"
+
+
+class _AsyncioPipeClosedFilter(logging.Filter):
+    """Demote asyncio's spurious 'pipe closed by peer' WARNING to DEBUG."""
+
+    _NEEDLE = "pipe closed by peer or os.write"
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if record.levelno == logging.WARNING and self._NEEDLE in record.getMessage():
+            record.levelno = logging.DEBUG
+            record.levelname = "DEBUG"
+        return True
+
+
+_PIPE_CLOSED_FILTER = _AsyncioPipeClosedFilter()
+
+
+def silence_asyncio_pipe_noise() -> None:
+    """Demote the spurious asyncio 'pipe closed by peer' warning to DEBUG.
+
+    Idempotent — attaches the filter only once per process. Pair with
+    :func:`restore_asyncio_pipe_noise` when the noisy window ends so unrelated
+    asyncio activity is unaffected.
+    """
+    logger = logging.getLogger(_ASYNCIO_LOGGER_NAME)
+    if _PIPE_CLOSED_FILTER not in logger.filters:
+        logger.addFilter(_PIPE_CLOSED_FILTER)
+
+
+def restore_asyncio_pipe_noise() -> None:
+    """Detach the filter installed by :func:`silence_asyncio_pipe_noise`.
+
+    Safe to call when the filter is not attached.
+    """
+    logging.getLogger(_ASYNCIO_LOGGER_NAME).removeFilter(_PIPE_CLOSED_FILTER)

--- a/py_src/taskito/mixins/lifecycle.py
+++ b/py_src/taskito/mixins/lifecycle.py
@@ -18,6 +18,7 @@ from taskito._taskito import PyQueue, PyTaskConfig
 from taskito.context import _set_queue_ref
 from taskito.events import EventType
 from taskito.log_config import configure as configure_logging
+from taskito.log_config import restore_asyncio_pipe_noise, silence_asyncio_pipe_noise
 from taskito.resources.health import HealthChecker
 from taskito.resources.runtime import ResourceRuntime
 from taskito.testing import TestMode
@@ -172,6 +173,12 @@ class QueueLifecycleMixin:
 
             def shutdown_handler(signum: int, frame: Any) -> None:
                 logger.info("Warm shutdown (waiting for running tasks to finish)...")
+                # Subprocesses spawned by user tasks (e.g. Playwright browsers)
+                # receive the same SIGINT via the foreground process group; the
+                # resulting broken-pipe spam from asyncio would otherwise drown
+                # out the drain window. Suppressed only for the drain — the
+                # filter is removed in the finally block below.
+                silence_asyncio_pipe_noise()
                 with contextlib.suppress(Exception):
                     self._inner.set_worker_status(worker_id, "draining")
                 self._inner.request_shutdown()
@@ -254,6 +261,7 @@ class QueueLifecycleMixin:
             if self._resource_runtime is not None:
                 self._resource_runtime.teardown()
                 self._resource_runtime = None
+            restore_asyncio_pipe_noise()
             logger.info("Worker stopped.")
             if is_main:
                 if original_sigint is not None:

--- a/py_src/taskito/prefork/child.py
+++ b/py_src/taskito/prefork/child.py
@@ -21,6 +21,7 @@ import json
 import logging
 import os
 import queue as _queue_mod
+import signal
 import sys
 import threading
 import time
@@ -36,6 +37,7 @@ from taskito.context import (
     set_local_cancel_check,
 )
 from taskito.exceptions import TaskCancelledError
+from taskito.log_config import silence_asyncio_pipe_noise
 
 logger = logging.getLogger("taskito.prefork.child")
 
@@ -219,11 +221,31 @@ def _spawn_stdin_reader(
     return thread
 
 
+def _install_shutdown_signal_handler() -> None:
+    """Mute asyncio's spurious 'pipe closed by peer' WARNING when SIGINT
+    arrives, then re-raise ``KeyboardInterrupt`` so the main loop's existing
+    cleanup path still runs. Subprocesses the user task spawned (Playwright
+    browsers etc.) get the same SIGINT via the foreground process group and
+    flood the asyncio logger as they die; the warning is informational only
+    (asyncio already swallowed the underlying error) so demoting it to DEBUG
+    keeps the child's output readable."""
+    if threading.current_thread() is not threading.main_thread():
+        return
+
+    def handler(signum: int, frame: Any) -> None:
+        silence_asyncio_pipe_noise()
+        raise KeyboardInterrupt
+
+    signal.signal(signal.SIGINT, handler)
+
+
 def main() -> None:
     """Child process main loop. Called via ``python -m taskito.prefork <app_path>``."""
     if len(sys.argv) < 2:
         sys.stderr.write("Usage: python -m taskito.prefork <app_path>\n")
         sys.exit(1)
+
+    _install_shutdown_signal_handler()
 
     app_path = sys.argv[1]
 

--- a/tests/observability/test_log_config.py
+++ b/tests/observability/test_log_config.py
@@ -10,9 +10,12 @@ import pytest
 
 from taskito import log_config
 from taskito.log_config import (
+    _PIPE_CLOSED_FILTER,
     DEFAULT_DATEFMT,
     DEFAULT_FORMAT,
     configure,
+    restore_asyncio_pipe_noise,
+    silence_asyncio_pipe_noise,
 )
 
 _MANAGED_LOGGERS = (
@@ -124,3 +127,79 @@ def test_format_constants_are_stable() -> None:
     # the public surface (downstream tools that grep logs may rely on them).
     assert DEFAULT_FORMAT == "[%(asctime)s] %(levelname)s %(message)s"
     assert "%p" in DEFAULT_DATEFMT
+
+
+# --- asyncio pipe-noise filter ------------------------------------------------
+
+
+@pytest.fixture
+def _cleanup_pipe_filter() -> Iterator[None]:
+    """Ensure each filter test starts and ends with the filter detached."""
+    restore_asyncio_pipe_noise()
+    yield
+    restore_asyncio_pipe_noise()
+
+
+def _asyncio_record(message: str, level: int = logging.WARNING) -> logging.LogRecord:
+    return logging.LogRecord(
+        name="asyncio",
+        level=level,
+        pathname=__file__,
+        lineno=0,
+        msg=message,
+        args=None,
+        exc_info=None,
+    )
+
+
+def test_pipe_filter_demotes_spurious_warning_to_debug() -> None:
+    record = _asyncio_record("pipe closed by peer or os.write(pipe, data) raised exception.")
+
+    assert _PIPE_CLOSED_FILTER.filter(record) is True
+    assert record.levelno == logging.DEBUG
+    assert record.levelname == "DEBUG"
+
+
+def test_pipe_filter_passes_other_asyncio_warnings_unchanged() -> None:
+    record = _asyncio_record("socket.send() raised exception.")
+
+    assert _PIPE_CLOSED_FILTER.filter(record) is True
+    assert record.levelno == logging.WARNING
+    assert record.levelname == "WARNING"
+
+
+def test_pipe_filter_does_not_touch_non_warning_records() -> None:
+    record = _asyncio_record(
+        "pipe closed by peer or os.write(pipe, data) raised exception.",
+        level=logging.ERROR,
+    )
+
+    assert _PIPE_CLOSED_FILTER.filter(record) is True
+    assert record.levelno == logging.ERROR
+
+
+def test_silence_and_restore_are_idempotent(_cleanup_pipe_filter: None) -> None:
+    asyncio_logger = logging.getLogger("asyncio")
+
+    silence_asyncio_pipe_noise()
+    silence_asyncio_pipe_noise()
+    assert asyncio_logger.filters.count(_PIPE_CLOSED_FILTER) == 1
+
+    restore_asyncio_pipe_noise()
+    restore_asyncio_pipe_noise()
+    assert _PIPE_CLOSED_FILTER not in asyncio_logger.filters
+
+
+def test_silence_suppresses_warning_end_to_end(
+    caplog: pytest.LogCaptureFixture,
+    _cleanup_pipe_filter: None,
+) -> None:
+    asyncio_logger = logging.getLogger("asyncio")
+    silence_asyncio_pipe_noise()
+
+    with caplog.at_level(logging.WARNING, logger="asyncio"):
+        asyncio_logger.warning("pipe closed by peer or os.write(pipe, data) raised exception.")
+        asyncio_logger.warning("a different asyncio warning")
+
+    warning_messages = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+    assert warning_messages == ["a different asyncio warning"]


### PR DESCRIPTION
## Summary
- New `_AsyncioPipeClosedFilter` in `taskito.log_config` demotes asyncio's `"pipe closed by peer or os.write..."` WARNING to DEBUG.
- Wired into the thread-pool worker's `shutdown_handler` (installed on SIGINT/SIGTERM) and removed in the `run_worker` `finally` block, so the filter is active only during the drain window.
- Installed in the prefork child's SIGINT handler before re-raising `KeyboardInterrupt`, so the existing cleanup path is unchanged.
- Demotes rather than drops — messages remain visible when the asyncio logger is set to DEBUG.

## Why
Ctrl+C in a terminal broadcasts SIGINT to the foreground process group, killing any subprocess a user task spawned (Playwright browsers, ffmpeg, asyncio subprocesses). CPython's `_UnixWritePipeTransport.write()` silently tolerates 5 failed writes, then logs that WARNING on every subsequent write — flooding the warm-shutdown drain window for up to `drain_timeout` seconds (30s default). The drain itself is correct: it's waiting for in-flight tasks. The noise is purely cosmetic and the underlying error info is already lost (asyncio swallowed it 5+ times before logging).

## Changes
- `py_src/taskito/log_config.py` — `_AsyncioPipeClosedFilter`, `silence_asyncio_pipe_noise()`, `restore_asyncio_pipe_noise()`
- `py_src/taskito/mixins/lifecycle.py` — wire filter into `shutdown_handler` and `run_worker` finally block
- `py_src/taskito/prefork/child.py` — `_install_shutdown_signal_handler()` mutes the filter on SIGINT before re-raising
- `tests/observability/test_log_config.py` — 5 new tests (demotion correctness, unrelated warnings untouched, non-WARNING records untouched, install/restore idempotency, end-to-end via caplog)

## Test plan
- [x] \`uv run python -m pytest tests/ -q\` — 618 passed, 9 skipped
- [x] \`uv run ruff check py_src/ tests/\` — clean
- [x] \`uv run mypy py_src/taskito/ --no-incremental\` — clean
- [x] \`cargo check --workspace\` — clean
- [x] Pre-commit hooks (cargo fmt, clippy, ruff, ruff-format, mypy) pass on every commit