### PR TITLE
feat: log task lifecycle events celery-style

### DIFF
--- a/py_src/taskito/mixins/decorators.py
+++ b/py_src/taskito/mixins/decorators.py
@@ -8,6 +8,7 @@ import inspect
 import logging
 import os
 import sys
+import time
 import typing
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
@@ -16,6 +17,7 @@ from taskito._taskito import PyTaskConfig
 from taskito.async_support.helpers import run_maybe_async
 from taskito.context import _clear_context, current_job
 from taskito.events import EventType
+from taskito.exceptions import TaskCancelledError
 from taskito.inject import Inject, _InjectAlias
 from taskito.interception.reconstruct import reconstruct_args
 from taskito.predicates.core import coerce_predicate
@@ -34,6 +36,24 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger("taskito")
+
+# Cap the result repr length in the "succeeded" log so a task returning a
+# large structure can't blow out the worker output. Matches Celery's
+# `CELERYD_TASK_LOG_FORMAT` truncation in spirit.
+_MAX_RESULT_REPR = 80
+
+
+def _safe_result_repr(value: Any) -> str:
+    """Render a task return value for the success log, bounded and crash-proof."""
+    if value is None:
+        return "None"
+    try:
+        text = repr(value)
+    except Exception:
+        return "<unrepresentable>"
+    if len(text) > _MAX_RESULT_REPR:
+        return text[: _MAX_RESULT_REPR - 1] + "…"
+    return text
 
 
 def _resolve_module_name(module_name: str) -> str:
@@ -104,6 +124,10 @@ class QueueDecoratorMixin:
 
         @functools.wraps(fn)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
+            job_id = current_job.id
+            logger.info("Task %s[%s] received", task_name, job_id)
+            started_at = time.perf_counter()
+
             # Worker-dispatch predicate gate. Evaluated on the raw
             # deserialized payload (before arg/proxy reconstruction) so
             # re-enqueue on defer can round-trip cleanly.
@@ -180,10 +204,36 @@ class QueueDecoratorMixin:
                 result = ret
             except Exception as exc:
                 error = exc
+                elapsed = time.perf_counter() - started_at
+                if isinstance(exc, TaskCancelledError):
+                    logger.info(
+                        "Task %s[%s] cancelled in %.3fs: %s",
+                        task_name,
+                        job_id,
+                        elapsed,
+                        exc,
+                    )
+                else:
+                    logger.error(
+                        "Task %s[%s] raised %s in %.3fs: %r",
+                        task_name,
+                        job_id,
+                        type(exc).__name__,
+                        elapsed,
+                        exc,
+                    )
                 for hook in hooks["on_failure"]:
                     hook(task_name, args, kwargs, exc)
                 raise
             else:
+                elapsed = time.perf_counter() - started_at
+                logger.info(
+                    "Task %s[%s] succeeded in %.3fs: %s",
+                    task_name,
+                    job_id,
+                    elapsed,
+                    _safe_result_repr(result),
+                )
                 for hook in hooks["on_success"]:
                     hook(task_name, args, kwargs, result)
                 return result
@@ -261,6 +311,10 @@ class QueueDecoratorMixin:
             dont_retry_on: List of exception classes that should never be retried.
             soft_timeout: Soft timeout in seconds. Checked via ``current_job.check_timeout()``.
             middleware: Per-task middleware instances (in addition to global middleware).
+            retry_delays: Explicit per-attempt delay schedule in seconds, e.g.
+                ``[1.0, 5.0, 30.0]``. Overrides ``retry_backoff`` when set; the
+                final value is reused for any further retries up to
+                ``max_retries``.
             inject: List of resource names to inject as keyword arguments.
             serializer: Per-task serializer. Falls back to the queue-level serializer.
             max_retry_delay: Maximum backoff delay in seconds. Defaults to 300
@@ -289,6 +343,15 @@ class QueueDecoratorMixin:
             default_defer_seconds: Default delay when ``on_false="defer"``
                 and the predicate returns plain ``False`` (no explicit
                 ``Defer(seconds=...)``). Ignored otherwise.
+
+        Returns:
+            A decorator that wraps the function in a :class:`~taskito.task.TaskWrapper`
+            exposing ``.delay(*args, **kwargs)`` and
+            ``.apply_async(args=..., kwargs=..., ...)`` for enqueueing.
+
+        Raises:
+            ValueError: ``on_false`` is not ``"defer"`` or ``"cancel"``, or
+                ``default_defer_seconds`` is negative.
         """
         if on_false not in {"defer", "cancel"}:
             raise ValueError(f"on_false must be 'defer' or 'cancel', got {on_false!r}")
@@ -443,6 +506,13 @@ class QueueDecoratorMixin:
             args: Positional arguments to pass to the task on each run.
             kwargs: Keyword arguments to pass to the task on each run.
             queue: Named queue to submit to.
+            timezone: IANA timezone name (e.g. ``"America/New_York"``) the cron
+                expression is evaluated in. Defaults to UTC.
+
+        Returns:
+            A decorator that registers the function as both a normal task and
+            a periodic schedule entry, returning the underlying
+            :class:`~taskito.task.TaskWrapper`.
         """
 
         def decorator(fn: Callable) -> TaskWrapper:

--- a/py_src/taskito/workflows/analysis.py
+++ b/py_src/taskito/workflows/analysis.py
@@ -112,6 +112,7 @@ def critical_path(steps: dict[str, _Step], costs: dict[str, float]) -> tuple[lis
     Uses dynamic programming on topological order.
 
     Args:
+        steps: Mapping of step name → ``_Step`` carrying its predecessors.
         costs: Mapping of step name → estimated duration.
 
     Returns:

--- a/py_src/taskito/workflows/builder.py
+++ b/py_src/taskito/workflows/builder.py
@@ -136,6 +136,10 @@ class Workflow:
                 return value into one job per element.
             fan_in: Fan-in strategy. ``"all"`` collects all fan-out children's
                 results into a list passed to this step.
+            condition: Optional gate expression evaluated against upstream
+                results. Either a string DSL expression or a callable
+                receiving the workflow context; when it returns falsy the
+                step (and its descendants) are skipped.
 
         Returns:
             ``self`` for chaining.

--- a/tests/observability/test_task_lifecycle_logs.py
+++ b/tests/observability/test_task_lifecycle_logs.py
@@ -1,0 +1,120 @@
+"""Tests for the Celery-style ``Task X[id] received|succeeded|raised`` logs."""
+
+from __future__ import annotations
+
+import logging
+import re
+
+import pytest
+
+from taskito import Queue
+from taskito.exceptions import TaskCancelledError
+from taskito.mixins.decorators import _MAX_RESULT_REPR, _safe_result_repr
+
+_RECEIVED = re.compile(r"^Task (\S+)\[(\S+)\] received$")
+_SUCCEEDED = re.compile(r"^Task (\S+)\[(\S+)\] succeeded in \d+\.\d{3}s: (.+)$")
+_RAISED = re.compile(r"^Task (\S+)\[(\S+)\] raised (\w+) in \d+\.\d{3}s: (.+)$")
+_CANCELLED = re.compile(r"^Task (\S+)\[(\S+)\] cancelled in \d+\.\d{3}s: (.+)$")
+
+
+def _taskito_records(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:
+    return [r for r in caplog.records if r.name == "taskito"]
+
+
+def test_safe_result_repr_truncates_long_values() -> None:
+    long = "x" * (_MAX_RESULT_REPR * 2)
+    rendered = _safe_result_repr(long)
+    assert len(rendered) == _MAX_RESULT_REPR
+    assert rendered.endswith("…")
+
+
+def test_safe_result_repr_handles_none() -> None:
+    assert _safe_result_repr(None) == "None"
+
+
+def test_safe_result_repr_survives_broken_repr() -> None:
+    class Boom:
+        def __repr__(self) -> str:
+            raise RuntimeError("nope")
+
+    assert _safe_result_repr(Boom()) == "<unrepresentable>"
+
+
+def _invoke_registered(queue: Queue, task_name: str, *args: object, **kwargs: object) -> object:
+    """Drive the wrapped task through the same path the Rust worker uses.
+
+    Sets up a job context, calls the registered wrapper, then tears the
+    context down — exercising the full ``_wrap_task`` lifecycle (hooks,
+    middleware, lifecycle logs) without booting an actual worker.
+    """
+    from taskito.context import _clear_context, _set_context
+
+    _set_context("job-" + task_name, task_name, 0, "default")
+    try:
+        return queue._task_registry[task_name](*args, **kwargs)
+    finally:
+        _clear_context()
+
+
+def test_received_and_succeeded_logged_for_successful_task(
+    queue: Queue, caplog: pytest.LogCaptureFixture
+) -> None:
+    @queue.task()
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    caplog.set_level(logging.INFO, logger="taskito")
+    assert _invoke_registered(queue, add.name, 2, 3) == 5
+
+    messages = [r.getMessage() for r in _taskito_records(caplog) if r.levelno == logging.INFO]
+    received = [m for m in messages if _RECEIVED.match(m)]
+    succeeded = [m for m in messages if _SUCCEEDED.match(m)]
+
+    assert len(received) == 1, messages
+    assert len(succeeded) == 1, messages
+    m = _SUCCEEDED.match(succeeded[0])
+    assert m is not None
+    assert m.group(1) == add.name
+    assert m.group(3) == "5"
+
+
+def test_raised_logged_at_error_for_failing_task(
+    queue: Queue, caplog: pytest.LogCaptureFixture
+) -> None:
+    @queue.task()
+    def boom() -> None:
+        raise ValueError("bad input")
+
+    caplog.set_level(logging.INFO, logger="taskito")
+    with pytest.raises(ValueError):
+        _invoke_registered(queue, boom.name)
+
+    raised = [
+        r
+        for r in _taskito_records(caplog)
+        if r.levelno == logging.ERROR and _RAISED.match(r.getMessage())
+    ]
+    assert len(raised) == 1
+    m = _RAISED.match(raised[0].getMessage())
+    assert m is not None
+    assert m.group(3) == "ValueError"
+    assert "bad input" in m.group(4)
+
+
+def test_cancelled_logged_at_info_for_task_cancelled(
+    queue: Queue, caplog: pytest.LogCaptureFixture
+) -> None:
+    @queue.task()
+    def stoppable() -> None:
+        raise TaskCancelledError("user pulled the plug")
+
+    caplog.set_level(logging.INFO, logger="taskito")
+    with pytest.raises(TaskCancelledError):
+        _invoke_registered(queue, stoppable.name)
+
+    cancel_records = [r for r in _taskito_records(caplog) if _CANCELLED.match(r.getMessage())]
+    assert len(cancel_records) == 1
+    assert cancel_records[0].levelno == logging.INFO
+
+    error_records = [r for r in _taskito_records(caplog) if r.levelno == logging.ERROR]
+    assert error_records == []


### PR DESCRIPTION
## Summary
- Every task now logs three Celery-style lifecycle lines around its execution:
  - \`Task <name>[<job_id>] received\` (INFO) when the worker picks it up
  - \`Task <name>[<job_id>] succeeded in 0.012s: <repr>\` (INFO) on return — result repr truncated at 80 chars
  - \`Task <name>[<job_id>] raised <ExcType> in 0.003s: <repr>\` (ERROR) on exception
  - \`Task <name>[<job_id>] cancelled in 0.001s: <message>\` (INFO) when \`TaskCancelledError\` propagates — separated from generic failures so cancellation doesn't pollute error metrics
- Added \`retry_delays\` (was undocumented) and \`Returns:\` / \`Raises:\` sections to the \`@queue.task()\` docstring; added \`timezone\` to \`@queue.periodic()\`.
- AST audit of every public function in \`py_src/taskito/\` (139 files) surfaced 2 other docstrings with missing param docs in \`workflows/analysis.py\` and \`workflows/builder.py\` — both fixed; re-running the audit returns 0 incomplete docstrings.

## Why
Operators wanted a Celery-equivalent at-a-glance view of what the worker is doing — \"received\" → \"succeeded/failed\" pairs with duration. The result repr cap (80 chars) prevents a task that returns a large structure from flooding stderr.

## Changes
- \`py_src/taskito/mixins/decorators.py\` — \`_safe_result_repr\` helper + lifecycle log lines inside \`_wrap_task.wrapper\`; docstring fills.
- \`py_src/taskito/workflows/analysis.py\` — document \`steps\` on \`critical_path\`.
- \`py_src/taskito/workflows/builder.py\` — document \`condition\` on \`Workflow.step\`.
- \`tests/observability/test_task_lifecycle_logs.py\` — 6 new tests (received/succeeded pair, raised at ERROR, cancelled at INFO, result-repr truncation, None handling, broken \`__repr__\` safety).

## Test plan
- [x] \`uv run python -m pytest tests/observability/test_task_lifecycle_logs.py -v\` — 6/6 pass
- [x] \`uv run python -m pytest tests/ -q --ignore=tests/dashboard\` — 624 passed, 9 skipped (pre-existing skips)
- [x] \`uv run ruff check py_src/ tests/\` — clean
- [x] \`uv run mypy py_src/taskito/ --no-incremental\` — clean
- [x] Pre-commit hooks (cargo fmt, clippy, ruff, ruff-format, mypy) pass on every commit