### PR TITLE
feat(dashboard): oauth foundation (config, state store, identity, auth.py)

### DIFF
--- a/dashboard/src/features/auth/api.test.ts
+++ b/dashboard/src/features/auth/api.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { oauthStartUrl } from "./api";
+
+describe("oauthStartUrl", () => {
+  it("returns the slot-rooted path when no next is supplied", () => {
+    expect(oauthStartUrl("google")).toBe("/api/auth/oauth/start/google");
+  });
+
+  it("URL-encodes the next path so it survives querystring parsing", () => {
+    expect(oauthStartUrl("google", "/jobs?status=failed")).toBe(
+      "/api/auth/oauth/start/google?next=%2Fjobs%3Fstatus%3Dfailed",
+    );
+  });
+
+  it("URL-encodes provider slots that contain reserved characters", () => {
+    // OIDC slot names must match ^[a-z][a-z0-9_-]{0,31}$ at the server,
+    // so this is defence-in-depth — but the encoding must not break the
+    // slot regex on the way out.
+    expect(oauthStartUrl("acme-okta", "/")).toBe("/api/auth/oauth/start/acme-okta?next=%2F");
+  });
+
+  it("ignores empty / undefined next gracefully", () => {
+    expect(oauthStartUrl("github", undefined)).toBe("/api/auth/oauth/start/github");
+    expect(oauthStartUrl("github", "")).toBe("/api/auth/oauth/start/github");
+  });
+});

--- a/dashboard/src/features/auth/api.ts
+++ b/dashboard/src/features/auth/api.ts
@@ -1,8 +1,30 @@
 import { api } from "@/lib/api-client";
-import type { AuthStatus, LoginResponse, SetupResponse, WhoamiResponse } from "./types";
+import type {
+  AuthStatus,
+  LoginResponse,
+  ProvidersResponse,
+  SetupResponse,
+  WhoamiResponse,
+} from "./types";
 
 export function fetchAuthStatus(signal?: AbortSignal): Promise<AuthStatus> {
   return api.get<AuthStatus>("/api/auth/status", { signal });
+}
+
+export function fetchProviders(signal?: AbortSignal): Promise<ProvidersResponse> {
+  return api.get<ProvidersResponse>("/api/auth/providers", { signal });
+}
+
+/** Browser URL the user is sent to when they click an OAuth provider button.
+ *
+ * The server's ``/api/auth/oauth/start/{slot}`` endpoint will mint state and
+ * 302 to the provider. We append ``next`` so the post-login callback can
+ * land the user back where they were trying to go.
+ */
+export function oauthStartUrl(slot: string, next?: string): string {
+  const base = `/api/auth/oauth/start/${encodeURIComponent(slot)}`;
+  if (!next) return base;
+  return `${base}?next=${encodeURIComponent(next)}`;
 }
 
 export function fetchWhoami(signal?: AbortSignal): Promise<WhoamiResponse> {

--- a/dashboard/src/features/auth/components/login-form.tsx
+++ b/dashboard/src/features/auth/components/login-form.tsx
@@ -1,10 +1,11 @@
-import { useNavigate } from "@tanstack/react-router";
+import { useNavigate, useSearch } from "@tanstack/react-router";
 import { AlertCircle, LogIn } from "lucide-react";
 import { type FormEvent, useState } from "react";
 import { Button } from "@/components/ui";
 import { Input } from "@/components/ui/input";
 import { ApiError } from "@/lib/api-client";
-import { useLogin } from "../hooks";
+import { useAuthProviders, useLogin } from "../hooks";
+import { OAuthButton } from "./oauth-button";
 
 const ERROR_MESSAGES: Record<string, string> = {
   invalid_credentials: "Invalid username or password.",
@@ -13,9 +14,19 @@ const ERROR_MESSAGES: Record<string, string> = {
 
 export function LoginForm() {
   const navigate = useNavigate();
+  const search = useSearch({ strict: false }) as { next?: string } | undefined;
+  const nextPath = typeof search?.next === "string" ? search.next : undefined;
+
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const login = useLogin();
+  const providers = useAuthProviders();
+
+  // Default to password-on while the providers query is in flight so the
+  // form doesn't flash empty on the first render.
+  const passwordEnabled = providers.data?.password_enabled ?? true;
+  const oauthProviders = providers.data?.providers ?? [];
+  const hasOAuth = oauthProviders.length > 0;
 
   function onSubmit(event: FormEvent<HTMLFormElement>): void {
     event.preventDefault();
@@ -23,7 +34,7 @@ export function LoginForm() {
       { username, password },
       {
         onSuccess: () => {
-          void navigate({ to: "/" });
+          void navigate({ to: nextPath ?? "/" });
         },
       },
     );
@@ -33,52 +44,86 @@ export function LoginForm() {
   const disabled = login.isPending || !username || !password;
 
   return (
-    <form
-      onSubmit={onSubmit}
-      className="flex w-full max-w-sm flex-col gap-4 rounded-xl border border-[var(--border)] bg-[var(--surface-1)] p-6 shadow-sm"
-    >
+    <div className="flex w-full max-w-sm flex-col gap-4 rounded-xl border border-[var(--border)] bg-[var(--surface-1)] p-6 shadow-sm">
       <div>
         <h1 className="text-lg font-semibold">Sign in</h1>
         <p className="mt-1 text-sm text-[var(--fg-muted)]">
-          Enter your dashboard credentials to continue.
+          {passwordEnabled
+            ? "Enter your dashboard credentials to continue."
+            : "Choose a provider to continue."}
         </p>
       </div>
-      <label htmlFor="login-username" className="flex flex-col gap-1.5 text-sm">
-        <span className="font-medium">Username</span>
-        <Input
-          id="login-username"
-          type="text"
-          autoComplete="username"
-          value={username}
-          onChange={(e) => setUsername(e.target.value)}
-          required
-          autoFocus
-        />
-      </label>
-      <label htmlFor="login-password" className="flex flex-col gap-1.5 text-sm">
-        <span className="font-medium">Password</span>
-        <Input
-          id="login-password"
-          type="password"
-          autoComplete="current-password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          required
-        />
-      </label>
-      {error ? (
-        <div
-          role="alert"
-          className="flex items-start gap-2 rounded-md bg-danger-dim px-3 py-2 text-sm text-danger"
-        >
-          <AlertCircle className="mt-0.5 size-4 shrink-0" aria-hidden />
-          <span>{error}</span>
+
+      {hasOAuth ? (
+        <div className="flex flex-col gap-2">
+          {oauthProviders.map((provider) => (
+            <OAuthButton key={provider.slot} provider={provider} next={nextPath} />
+          ))}
         </div>
       ) : null}
-      <Button type="submit" disabled={disabled}>
-        <LogIn aria-hidden /> {login.isPending ? "Signing in…" : "Sign in"}
-      </Button>
-    </form>
+
+      {hasOAuth && passwordEnabled ? (
+        <div className="flex items-center gap-3 text-xs text-[var(--fg-subtle)]">
+          <div className="h-px flex-1 bg-[var(--border)]" />
+          <span>or sign in with password</span>
+          <div className="h-px flex-1 bg-[var(--border)]" />
+        </div>
+      ) : null}
+
+      {passwordEnabled ? (
+        <form onSubmit={onSubmit} className="flex flex-col gap-4">
+          <label htmlFor="login-username" className="flex flex-col gap-1.5 text-sm">
+            <span className="font-medium">Username</span>
+            <Input
+              id="login-username"
+              type="text"
+              autoComplete="username"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              required
+              autoFocus={!hasOAuth}
+            />
+          </label>
+          <label htmlFor="login-password" className="flex flex-col gap-1.5 text-sm">
+            <span className="font-medium">Password</span>
+            <Input
+              id="login-password"
+              type="password"
+              autoComplete="current-password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+            />
+          </label>
+          {error ? (
+            <div
+              role="alert"
+              className="flex items-start gap-2 rounded-md bg-danger-dim px-3 py-2 text-sm text-danger"
+            >
+              <AlertCircle className="mt-0.5 size-4 shrink-0" aria-hidden />
+              <span>{error}</span>
+            </div>
+          ) : null}
+          <Button type="submit" disabled={disabled}>
+            <LogIn aria-hidden /> {login.isPending ? "Signing in…" : "Sign in"}
+          </Button>
+        </form>
+      ) : null}
+
+      {!passwordEnabled && !hasOAuth ? (
+        <div
+          role="alert"
+          className="flex items-start gap-2 rounded-md bg-warning-dim px-3 py-2 text-sm text-warning"
+        >
+          <AlertCircle className="mt-0.5 size-4 shrink-0" aria-hidden />
+          <span>
+            No login methods are configured. Set{" "}
+            <code>TASKITO_DASHBOARD_PASSWORD_AUTH_ENABLED=true</code> or configure an OAuth
+            provider.
+          </span>
+        </div>
+      ) : null}
+    </div>
   );
 }
 

--- a/dashboard/src/features/auth/components/oauth-button.tsx
+++ b/dashboard/src/features/auth/components/oauth-button.tsx
@@ -1,0 +1,85 @@
+import { KeyRound } from "lucide-react";
+import { oauthStartUrl } from "../api";
+import type { AuthProvider } from "../types";
+
+interface OAuthButtonProps {
+  provider: AuthProvider;
+  /** Path to send the user to after a successful login. Validated server-side. */
+  next?: string;
+}
+
+/** "Sign in with X" button — renders as a plain anchor so the browser
+ * follows the 302 from ``/api/auth/oauth/start/{slot}`` natively.
+ *
+ * Styling matches the dashboard's design system without depending on the
+ * primary :class:`Button` component (we need anchor semantics, not button).
+ */
+export function OAuthButton({ provider, next }: OAuthButtonProps) {
+  return (
+    <a
+      href={oauthStartUrl(provider.slot, next)}
+      className="inline-flex h-9 w-full items-center justify-center gap-2 rounded-md border border-[var(--border)] bg-[var(--surface-2)] px-3 text-sm font-medium text-[var(--fg)] transition-colors hover:bg-[var(--surface-3)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--surface-1)]"
+      data-slot={provider.slot}
+      data-type={provider.type}
+    >
+      <ProviderIcon type={provider.type} />
+      <span>Continue with {provider.label}</span>
+    </a>
+  );
+}
+
+function ProviderIcon({ type }: { type: AuthProvider["type"] }) {
+  if (type === "google") {
+    return <GoogleGlyph />;
+  }
+  if (type === "github") {
+    return <GitHubGlyph />;
+  }
+  // Generic OIDC — operator-configured SSO.
+  return <KeyRound className="size-4" aria-hidden />;
+}
+
+/** Official Google "G" mark — inlined SVG so we don't pull in a brand-asset
+ * dependency. Matches Google's brand guidelines for sign-in buttons.
+ */
+function GoogleGlyph() {
+  return (
+    <svg viewBox="0 0 24 24" className="size-4" role="img" aria-label="Google" focusable="false">
+      <title>Google</title>
+      <path
+        fill="#4285F4"
+        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09Z"
+      />
+      <path
+        fill="#34A853"
+        d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.99.66-2.25 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84A11 11 0 0 0 12 23Z"
+      />
+      <path
+        fill="#FBBC05"
+        d="M5.84 14.09a6.6 6.6 0 0 1 0-4.18V7.07H2.18a11 11 0 0 0 0 9.86l3.66-2.84Z"
+      />
+      <path
+        fill="#EA4335"
+        d="M12 5.38c1.62 0 3.06.56 4.2 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84C6.71 7.31 9.14 5.38 12 5.38Z"
+      />
+    </svg>
+  );
+}
+
+/** GitHub Octocat (Mark) — inlined so we don't depend on a brand-icon set
+ * that might drop it (lucide-react 1.x removed brand icons).
+ */
+function GitHubGlyph() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className="size-4 fill-current"
+      role="img"
+      aria-label="GitHub"
+      focusable="false"
+    >
+      <title>GitHub</title>
+      <path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.1.79-.25.79-.56v-2.21c-3.2.7-3.88-1.36-3.88-1.36-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.03 1.76 2.69 1.25 3.35.96.1-.74.4-1.25.73-1.54-2.55-.29-5.23-1.27-5.23-5.66 0-1.25.45-2.27 1.18-3.07-.12-.29-.51-1.45.11-3.02 0 0 .96-.31 3.15 1.17a10.9 10.9 0 0 1 5.74 0c2.19-1.48 3.15-1.17 3.15-1.17.62 1.57.23 2.73.11 3.02.73.8 1.18 1.82 1.18 3.07 0 4.4-2.69 5.37-5.25 5.65.41.36.78 1.05.78 2.12v3.14c0 .31.21.67.79.56A11.5 11.5 0 0 0 23.5 12C23.5 5.65 18.35.5 12 .5Z" />
+    </svg>
+  );
+}

--- a/dashboard/src/features/auth/hooks.ts
+++ b/dashboard/src/features/auth/hooks.ts
@@ -1,10 +1,19 @@
 import { queryOptions, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ApiError } from "@/lib/api-client";
-import { changePassword, fetchAuthStatus, fetchWhoami, login, logout, setup } from "./api";
+import {
+  changePassword,
+  fetchAuthStatus,
+  fetchProviders,
+  fetchWhoami,
+  login,
+  logout,
+  setup,
+} from "./api";
 import type { WhoamiResponse } from "./types";
 
 export const AUTH_STATUS_KEY = ["auth", "status"] as const;
 export const WHOAMI_KEY = ["auth", "whoami"] as const;
+export const PROVIDERS_KEY = ["auth", "providers"] as const;
 
 export function authStatusQuery() {
   return queryOptions({
@@ -42,12 +51,25 @@ export function whoamiQuery() {
   });
 }
 
+/** List of OAuth providers exposed by the server. */
+export function providersQuery() {
+  return queryOptions({
+    queryKey: PROVIDERS_KEY,
+    queryFn: ({ signal }) => fetchProviders(signal),
+    staleTime: 60_000,
+  });
+}
+
 export function useAuthStatus() {
   return useQuery(authStatusQuery());
 }
 
 export function useWhoami() {
   return useQuery(whoamiQuery());
+}
+
+export function useAuthProviders() {
+  return useQuery(providersQuery());
 }
 
 export function useLogin() {

--- a/dashboard/src/features/auth/index.ts
+++ b/dashboard/src/features/auth/index.ts
@@ -1,9 +1,12 @@
 export { AuthGate } from "./components/auth-gate";
 export { LoginForm } from "./components/login-form";
+export { OAuthButton } from "./components/oauth-button";
 export { SetupForm } from "./components/setup-form";
 export { UserMenu } from "./components/user-menu";
 export {
   authStatusQuery,
+  providersQuery,
+  useAuthProviders,
   useAuthStatus,
   useChangePassword,
   useLogin,
@@ -13,10 +16,12 @@ export {
   whoamiQuery,
 } from "./hooks";
 export type {
+  AuthProvider,
   AuthSession,
   AuthStatus,
   AuthUser,
   LoginResponse,
+  ProvidersResponse,
   SetupResponse,
   WhoamiResponse,
 } from "./types";

--- a/dashboard/src/features/auth/types.ts
+++ b/dashboard/src/features/auth/types.ts
@@ -30,3 +30,18 @@ export interface WhoamiResponse {
   csrf_token: string;
   expires_at: number;
 }
+
+/** One entry in the providers listing response. */
+export interface AuthProvider {
+  /** Stable URL-safe identifier used in the callback path. */
+  slot: string;
+  /** Human-readable button label. */
+  label: string;
+  /** Provider type, drives which icon is rendered. */
+  type: "google" | "github" | "oidc";
+}
+
+export interface ProvidersResponse {
+  password_enabled: boolean;
+  providers: AuthProvider[];
+}

--- a/docs/content/docs/guides/observability/dashboard-auth.mdx
+++ b/docs/content/docs/guides/observability/dashboard-auth.mdx
@@ -146,13 +146,18 @@ Set `TASKITO_WEBHOOKS_ALLOW_PRIVATE=1` to disable the guard for local
 development against `http://localhost`. Production should keep the
 guard on.
 
+## SSO / OAuth login
+
+Native sign-in with Google, GitHub, and any OIDC-compliant provider
+(Okta, Auth0, Keycloak, Microsoft Entra) is available alongside
+password auth — see [Dashboard SSO (OAuth & OIDC)](./dashboard-oauth).
+Operators can mix-and-match providers or run an OAuth-only deployment
+by setting `TASKITO_DASHBOARD_PASSWORD_AUTH_ENABLED=false`.
+
 ## Limitations
 
 - **One role** today (`admin`). Read-only viewers and per-route
   permissions are planned; the column already exists on the user
   record.
-- **No SSO / OIDC** out of the box. Put the dashboard behind a reverse
-  proxy (oauth2-proxy, Cloudflare Access) if your team uses SSO; the
-  built-in auth then becomes a fallback for service accounts.
 - **Password rotation** has an endpoint but no UI yet — invoke
   `POST /api/auth/change-password` directly.

--- a/docs/content/docs/guides/observability/dashboard-oauth.mdx
+++ b/docs/content/docs/guides/observability/dashboard-oauth.mdx
@@ -1,0 +1,288 @@
+---
+title: Dashboard SSO (OAuth & OIDC)
+description: "Sign in with Google, GitHub, or any OIDC provider. Per-domain / per-org allowlists, OAuth-only mode."
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+import { Tab, Tabs } from "fumadocs-ui/components/tabs";
+
+The dashboard ships native sign-in for **Google**, **GitHub**, and any
+**OIDC-compliant** provider (Okta, Auth0, Keycloak, Microsoft Entra, Dex,
+…). Multiple OIDC providers can run side-by-side, each rendered as its
+own button on the login screen.
+
+OAuth is **off by default**. Setting any provider's env vars turns it
+on; password login remains enabled unless you opt out explicitly.
+
+<Callout title="Optional dependency">
+  OAuth requires the `authlib` extra:
+
+  ```bash
+  pip install 'taskito[oauth]'
+  # or with uv:
+  uv pip install 'taskito[oauth]'
+  ```
+
+  Skip this if you only use password login.
+</Callout>
+
+## How it works
+
+```
+Browser           Dashboard            Provider
+   │                  │                    │
+   │ GET /login       │                    │
+   ├─────────────────►│                    │
+   │ GET /api/auth/providers               │
+   ├─────────────────►│                    │
+   │ {providers, password_enabled}         │
+   │◄─────────────────┤                    │
+   │ click "Continue with Google"          │
+   │ GET /api/auth/oauth/start/google      │
+   ├─────────────────►│ mint state+nonce+PKCE
+   │                  │ persist state row  │
+   │ 302 Location: <google authorize URL>  │
+   │◄─────────────────┤                    │
+   │ GET <provider>   ─────────────────────►
+   │ user consents on Google               │
+   │◄──────────────────────────────────────┤
+   │ GET /api/auth/oauth/callback/google?code=…&state=…
+   ├─────────────────►│ validate state     │
+   │                  │ POST /token        │
+   │                  ├───────────────────►│
+   │                  │ {id_token, access_token}
+   │                  │◄───────────────────┤
+   │                  │ verify JWKS / nonce / aud / iss
+   │                  │ check allowlist    │
+   │                  │ get_or_create User │
+   │                  │ create Session     │
+   │ 302 Location: /  + taskito_session cookie + taskito_csrf cookie
+   │◄─────────────────┤                    │
+```
+
+State is **single-use** and **time-bounded** (5-min default TTL). PKCE
+S256, OIDC nonce, ID-token signature (via the provider's JWKS),
+`iss` / `aud` / `exp` are all enforced server-side.
+
+## Quick start: Google login
+
+1. **Create an OAuth client.** Visit the
+   [Google Cloud Console → APIs & Services → Credentials](https://console.cloud.google.com/apis/credentials),
+   create an OAuth 2.0 Client ID of type *Web application*, and register
+   the callback URL:
+
+   ```
+   https://taskito.your-company.com/api/auth/oauth/callback/google
+   ```
+
+   (For local development, `http://localhost:8000/api/auth/oauth/callback/google`
+   works without HTTPS.)
+
+2. **Set env vars** before starting the dashboard:
+
+   ```bash
+   export TASKITO_DASHBOARD_OAUTH_REDIRECT_BASE_URL=https://taskito.your-company.com
+   export TASKITO_DASHBOARD_OAUTH_GOOGLE_CLIENT_ID=...apps.googleusercontent.com
+   export TASKITO_DASHBOARD_OAUTH_GOOGLE_CLIENT_SECRET=...
+   # Restrict logins to your Google Workspace domain:
+   export TASKITO_DASHBOARD_OAUTH_GOOGLE_ALLOWED_DOMAINS=your-company.com
+   ```
+
+3. **Start the dashboard.** The login screen now shows a "Continue with
+   Google" button above the password form.
+
+## GitHub login
+
+GitHub is OAuth2-only (no OIDC), so the dashboard hits `/user` and
+`/user/emails` to derive an identity. Org membership is verified via
+`/orgs/{org}/members/{login}`.
+
+1. Create a [GitHub OAuth App](https://github.com/settings/developers).
+   Set the *Authorization callback URL* to
+   `https://taskito.your-company.com/api/auth/oauth/callback/github`.
+
+2. Env vars:
+
+   ```bash
+   export TASKITO_DASHBOARD_OAUTH_GITHUB_CLIENT_ID=Iv1.xxxxx
+   export TASKITO_DASHBOARD_OAUTH_GITHUB_CLIENT_SECRET=...
+   # Restrict logins to members of these GitHub orgs:
+   export TASKITO_DASHBOARD_OAUTH_GITHUB_ALLOWED_ORGS=your-org,partner-org
+   ```
+
+When `ALLOWED_ORGS` is set the OAuth scope automatically expands to
+include `read:org` so the membership endpoint returns reliable results
+for private orgs. Users who consent without the additional scope are
+rejected at the allowlist gate.
+
+<Callout type="warn" title="Verified primary email only">
+  GitHub accounts that have no `verified=true` primary email
+  (returned by `GET /user/emails`) are always assigned the `viewer`
+  role, even if listed in `TASKITO_DASHBOARD_OAUTH_ADMIN_EMAILS`. This
+  prevents privilege escalation via spoofed email claims.
+</Callout>
+
+## Generic OIDC (Okta, Auth0, Keycloak, Microsoft, …)
+
+Generic OIDC providers are configured as **named slots**. Each slot has
+its own callback URL, own user namespace, and own button on the login
+screen.
+
+```bash
+export TASKITO_DASHBOARD_OAUTH_REDIRECT_BASE_URL=https://taskito.your-company.com
+
+# List the slots first.
+export TASKITO_DASHBOARD_OAUTH_OIDC_PROVIDERS=okta,microsoft
+
+# Then per-slot config (slot name uppercase, separators normalised to _).
+export TASKITO_DASHBOARD_OAUTH_OIDC_OKTA_CLIENT_ID=...
+export TASKITO_DASHBOARD_OAUTH_OIDC_OKTA_CLIENT_SECRET=...
+export TASKITO_DASHBOARD_OAUTH_OIDC_OKTA_DISCOVERY_URL=https://acme.okta.com/.well-known/openid-configuration
+export TASKITO_DASHBOARD_OAUTH_OIDC_OKTA_LABEL="Acme SSO"
+export TASKITO_DASHBOARD_OAUTH_OIDC_OKTA_ALLOWED_DOMAINS=your-company.com
+
+export TASKITO_DASHBOARD_OAUTH_OIDC_MICROSOFT_CLIENT_ID=...
+export TASKITO_DASHBOARD_OAUTH_OIDC_MICROSOFT_CLIENT_SECRET=...
+export TASKITO_DASHBOARD_OAUTH_OIDC_MICROSOFT_DISCOVERY_URL=https://login.microsoftonline.com/<tenant>/v2.0/.well-known/openid-configuration
+export TASKITO_DASHBOARD_OAUTH_OIDC_MICROSOFT_LABEL="Microsoft 365"
+```
+
+The callback URL for each slot is
+`{REDIRECT_BASE_URL}/api/auth/oauth/callback/{slot}` — register that
+exact URL with your IdP.
+
+Slot names must match `^[a-z][a-z0-9_-]{0,31}$` and must not collide
+with `google` / `github` (the built-ins). The Taskito user generated
+for an OIDC login is namespaced as `{slot}:{sub}`, so two different
+Okta tenants stay distinct users even when subjects overlap.
+
+## Role assignment for OAuth users
+
+The first time someone signs in via OAuth, the dashboard decides their
+role using this rule:
+
+1. **`TASKITO_DASHBOARD_OAUTH_ADMIN_EMAILS` match** — case-insensitive
+   match against a verified email → role `admin`.
+2. **Empty user table fallback** — if no users (password or OAuth) exist
+   yet, the first OAuth user with a verified email becomes `admin`.
+3. **Everyone else** → role `viewer`.
+
+```bash
+export TASKITO_DASHBOARD_OAUTH_ADMIN_EMAILS=alice@your-company.com,bob@your-company.com
+```
+
+Once a user is created, their role is **not** re-evaluated on subsequent
+logins (you can change it from the dashboard or via the API). Their
+`email` and `display_name` are refreshed from each new login's claims.
+
+## OAuth-only mode
+
+To disable password login entirely:
+
+```bash
+export TASKITO_DASHBOARD_PASSWORD_AUTH_ENABLED=false
+```
+
+The dashboard refuses to start in OAuth-only mode if no provider is
+configured (you'd have no way to log in). The login page hides the
+username/password form and renders only provider buttons.
+
+## Allowlist semantics
+
+| Provider | Allowlist scope | Where it's checked |
+|---|---|---|
+| Google | `ALLOWED_DOMAINS` — the email domain (lowercased) must be in this list. Required: `email_verified=true`. | Server-side after JWKS verification of the ID token. |
+| GitHub | `ALLOWED_ORGS` — user must be a member of at least one listed org. | `GET /orgs/{org}/members/{login}` returning 204. |
+| Generic OIDC | `ALLOWED_DOMAINS` — same as Google. | Server-side after ID-token JWKS verification. |
+
+An **empty** allowlist means "any account from this provider is welcome"
+— useful for personal projects but never appropriate for a production
+deployment. Configure at least the admin-email list, and ideally a
+domain/org allowlist too.
+
+<Callout type="warn" title="Allowlists are env-only">
+  Allowlists are not editable from the dashboard UI. Changes require
+  restarting the server with new env values. This keeps the security
+  surface in one place (your deployment config) and avoids drift across
+  the operator's GitOps and the database.
+</Callout>
+
+## Security model
+
+| Control | Implementation |
+|---|---|
+| **PKCE** | S256 challenge derived from a 32-byte random verifier, per RFC 7636. Required by OAuth 2.1 and most providers in 2026. |
+| **State** | 32-byte URL-safe random, stored server-side in `auth:oauth_state:<state>` with a 5-min TTL. **Single-use** — deleted on first read. |
+| **Nonce** | 16-byte random, embedded in the OIDC authorize request, verified against the ID-token `nonce` claim. Replay protection. |
+| **ID-token signature** | Verified against the provider's JWKS (fetched from the discovery doc and cached per-provider). |
+| **iss / aud / exp** | All validated; 60-second clock skew tolerance for `exp`. |
+| **Open redirect** | The `next` query param is validated against `is_safe_redirect` — relative paths only, no scheme, no `//`. Falls back to `/`. |
+| **HTTPS required** | `redirect_base_url` must be `https://` unless the host is `localhost` / `127.0.0.1`. Misconfiguration aborts startup. |
+| **Provider tokens** | Never persisted. Only the verified identity flows into the Taskito session. |
+| **Cross-provider linking** | Disabled by design. A given `(slot, subject)` always maps to one user. Two different providers with the same email = two different users. |
+
+## API surface
+
+| Method | Path | What it does |
+|---|---|---|
+| `GET` | `/api/auth/providers` | Public. Returns `{password_enabled, providers: [{slot, label, type}]}` for the login UI. |
+| `GET` | `/api/auth/oauth/start/{slot}` | Public. Mints state, 302s to the provider's authorize URL. Accepts `?next=/path` (validated). |
+| `GET` | `/api/auth/oauth/callback/{slot}` | Public. Validates state, exchanges code, enforces allowlist, creates/refreshes the user, sets cookies, 302s to `next`. |
+
+The callback uses the same `taskito_session` + `taskito_csrf` cookies
+as password login — every other dashboard route works identically once
+you're signed in.
+
+## Troubleshooting
+
+**"oauth_state_invalid"** — the state row expired (5-min window) or
+already consumed. The user pressed back / refresh after the provider
+redirect; have them start over.
+
+**"oauth_identity_failed: id_token issuer mismatch"** — the
+`TASKITO_DASHBOARD_OAUTH_OIDC_<SLOT>_DISCOVERY_URL` points to a
+different issuer than what the IdP signed. Check the `issuer` field in
+the discovery doc.
+
+**"oauth_allowlist_denied"** — the user authenticated successfully but
+isn't in your allowlist. Either widen the allowlist or remove it.
+
+**Provider button doesn't appear** — `GET /api/auth/providers` returns
+the list the UI renders. If the button is missing, check the server
+logs for an env-var parse error at startup. The dashboard falls back to
+password-only auth (logged at WARN) when env parsing fails.
+
+**"redirect_uri_mismatch" from the provider** — the callback URL you
+registered with the provider doesn't match `{REDIRECT_BASE_URL}/api/auth/oauth/callback/{slot}`.
+The trailing slash and the slot value must match exactly.
+
+## Env var reference
+
+```bash
+# Required when any provider is configured.
+TASKITO_DASHBOARD_OAUTH_REDIRECT_BASE_URL=https://taskito.company.com
+
+# Google.
+TASKITO_DASHBOARD_OAUTH_GOOGLE_CLIENT_ID=...
+TASKITO_DASHBOARD_OAUTH_GOOGLE_CLIENT_SECRET=...
+TASKITO_DASHBOARD_OAUTH_GOOGLE_ALLOWED_DOMAINS=company.com,partner.com   # optional
+
+# GitHub.
+TASKITO_DASHBOARD_OAUTH_GITHUB_CLIENT_ID=Iv1.xxxxx
+TASKITO_DASHBOARD_OAUTH_GITHUB_CLIENT_SECRET=...
+TASKITO_DASHBOARD_OAUTH_GITHUB_ALLOWED_ORGS=org1,org2                     # optional
+
+# Generic OIDC — list slots, then config each one.
+TASKITO_DASHBOARD_OAUTH_OIDC_PROVIDERS=okta,microsoft
+TASKITO_DASHBOARD_OAUTH_OIDC_OKTA_CLIENT_ID=...
+TASKITO_DASHBOARD_OAUTH_OIDC_OKTA_CLIENT_SECRET=...
+TASKITO_DASHBOARD_OAUTH_OIDC_OKTA_DISCOVERY_URL=https://acme.okta.com/.well-known/openid-configuration
+TASKITO_DASHBOARD_OAUTH_OIDC_OKTA_LABEL=Acme SSO                          # optional
+TASKITO_DASHBOARD_OAUTH_OIDC_OKTA_ALLOWED_DOMAINS=company.com             # optional
+
+# Role bootstrap.
+TASKITO_DASHBOARD_OAUTH_ADMIN_EMAILS=alice@company.com,bob@company.com    # optional
+
+# Disable password login (OAuth-only mode). Defaults to true.
+TASKITO_DASHBOARD_PASSWORD_AUTH_ENABLED=false                             # optional
+```

--- a/docs/content/docs/guides/observability/meta.json
+++ b/docs/content/docs/guides/observability/meta.json
@@ -6,6 +6,7 @@
     "notes",
     "dashboard",
     "dashboard-auth",
+    "dashboard-oauth",
     "task-overrides",
     "dashboard-api"
   ]

--- a/py_src/taskito/dashboard/auth.py
+++ b/py_src/taskito/dashboard/auth.py
@@ -57,6 +57,10 @@ PASSWORD_MIN_LEN = 8
 PASSWORD_MAX_LEN = 256
 VALID_ROLES = frozenset({"admin", "viewer"})
 
+# Sentinel prefix used in ``password_hash`` for OAuth-only users so
+# ``verify_password`` can short-circuit-reject any password attempt.
+OAUTH_PASSWORD_HASH_PREFIX = "oauth:"
+
 
 # ── Password hashing ───────────────────────────────────────────────────
 
@@ -77,6 +81,10 @@ def hash_password(password: str) -> str:
 
 def verify_password(password: str, encoded: str) -> bool:
     """Constant-time verify a password against the encoded hash."""
+    # Sentinel for OAuth-only users — they have no real password and must
+    # never authenticate via the password endpoint.
+    if encoded.startswith(OAUTH_PASSWORD_HASH_PREFIX):
+        return False
     try:
         scheme, iters_str, salt_hex, hash_hex = encoded.split("$")
     except ValueError:
@@ -106,13 +114,24 @@ def generate_session_token() -> str:
 
 @dataclass(frozen=True)
 class User:
-    """A persisted dashboard user."""
+    """A persisted dashboard user.
+
+    ``email`` and ``display_name`` are populated for users created via the
+    OAuth flow; for password users they are typically ``None`` until set
+    by an admin.
+    """
 
     username: str
     password_hash: str
     role: str
     created_at: int
     last_login_at: int | None = None
+    email: str | None = None
+    display_name: str | None = None
+
+    @property
+    def is_oauth(self) -> bool:
+        return self.password_hash.startswith(OAUTH_PASSWORD_HASH_PREFIX)
 
 
 @dataclass(frozen=True)
@@ -152,6 +171,33 @@ def _validate_password(password: str) -> None:
 def _validate_role(role: str) -> None:
     if role not in VALID_ROLES:
         raise ValueError(f"role must be one of {sorted(VALID_ROLES)}")
+
+
+def _oauth_bootstrap_role(
+    *,
+    email: str | None,
+    email_verified: bool,
+    admin_emails: tuple[str, ...],
+    user_table_empty: bool,
+) -> str:
+    """Decide the role for a freshly-created OAuth user.
+
+    Order: any path to ``admin`` requires a verified email (defence against
+    spoofed claims). If an explicit admin list is configured, only listed
+    emails get ``admin`` — the first-user-wins fallback is skipped. With no
+    admin list, the very first user (empty table) gets ``admin``, everyone
+    else gets ``viewer``.
+    """
+    if not email_verified or not email:
+        return "viewer"
+    normalised = email.lower()
+    if admin_emails:
+        if normalised in {e.lower() for e in admin_emails}:
+            return "admin"
+        return "viewer"
+    if user_table_empty:
+        return "admin"
+    return "viewer"
 
 
 # ── Auth store ─────────────────────────────────────────────────────────
@@ -243,13 +289,66 @@ class AuthStore:
         assert row is not None
         created_raw = row["created_at"]
         last_raw = row.get("last_login_at")
+        email_raw = row.get("email")
+        name_raw = row.get("display_name")
         return User(
             username=username,
             password_hash=str(row["password_hash"]),
             role=str(row["role"]),
             created_at=int(created_raw) if isinstance(created_raw, (int, float, str)) else 0,
             last_login_at=(int(last_raw) if isinstance(last_raw, (int, float, str)) else None),
+            email=str(email_raw) if isinstance(email_raw, str) and email_raw else None,
+            display_name=str(name_raw) if isinstance(name_raw, str) and name_raw else None,
         )
+
+    # ── OAuth users ────────────────────────────────────────────────
+
+    def get_or_create_oauth_user(
+        self,
+        slot: str,
+        subject: str,
+        email: str | None,
+        name: str | None,
+        email_verified: bool,
+        admin_emails: tuple[str, ...] = (),
+    ) -> User:
+        """Look up or create the User row backing an OAuth identity.
+
+        Username is ``f"{slot}:{subject}"``. On first sight, the role is
+        assigned by :func:`_oauth_bootstrap_role`. On subsequent logins,
+        the role is left alone but ``email`` / ``display_name`` are refreshed
+        from the latest provider claims.
+        """
+        username = f"{slot}:{subject}"
+        users = self._load_users()
+        existing = users.get(username)
+        if existing is not None:
+            if email and existing.get("email") != email:
+                existing["email"] = email
+            if name and existing.get("display_name") != name:
+                existing["display_name"] = name
+            existing["last_login_at"] = int(time.time())
+            users[username] = existing
+            self._save_users(users)
+            return self._row_to_user(username, existing)
+
+        role = _oauth_bootstrap_role(
+            email=email,
+            email_verified=email_verified,
+            admin_emails=admin_emails,
+            user_table_empty=not users,
+        )
+        now = int(time.time())
+        users[username] = {
+            "password_hash": f"{OAUTH_PASSWORD_HASH_PREFIX}{slot}",
+            "role": role,
+            "created_at": now,
+            "last_login_at": now,
+            "email": email,
+            "display_name": name,
+        }
+        self._save_users(users)
+        return self._row_to_user(username, users[username])
 
     # ── Sessions ───────────────────────────────────────────────────
 

--- a/py_src/taskito/dashboard/handlers/auth.py
+++ b/py_src/taskito/dashboard/handlers/auth.py
@@ -37,11 +37,13 @@ def _serialize_session(session: Any) -> dict[str, Any]:
     }
 
 
-def handle_auth_status(queue: Queue, _qs: dict) -> dict[str, bool]:
+def handle_auth_status(queue: Queue, _qs: dict) -> dict[str, Any]:
     """Public endpoint: tells the SPA whether setup is required.
 
     Returns ``{setup_required: bool}``. The SPA uses this on cold-load to
-    decide between showing the setup page and the login page.
+    decide between showing the setup page and the login page. Provider
+    listing is fetched separately via ``GET /api/auth/providers`` so this
+    endpoint stays free of any OAuth dependency.
     """
     return {"setup_required": AuthStore(queue).count_users() == 0}
 

--- a/py_src/taskito/dashboard/handlers/oauth.py
+++ b/py_src/taskito/dashboard/handlers/oauth.py
@@ -1,0 +1,115 @@
+"""HTTP handlers for the OAuth login flow.
+
+These handlers are not JSON-producing like the rest of ``handlers/`` —
+they emit 302 redirects (and, on a successful callback, set the session
+cookies). The server wires them into ``_handle_get`` directly rather
+than through the generic JSON dispatcher.
+
+The handlers themselves are network-IO-free aside from what the wrapped
+:class:`OAuthFlow` does internally. They translate provider/flow
+exceptions to dashboard ``_BadRequest`` / ``_NotFound`` for the server's
+error machinery to pick up, and they return :class:`OAuthRedirect` —
+a tiny adapter type that tells the server "emit 302 to URL, optionally
+with these cookies attached".
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from taskito.dashboard.errors import _BadRequest, _NotFound
+from taskito.dashboard.oauth.identity import (
+    AllowlistDenied,
+    IdentityFetchError,
+    ProviderNotConfigured,
+    StateValidationError,
+)
+
+if TYPE_CHECKING:
+    from taskito.app import Queue
+    from taskito.dashboard.auth import Session
+    from taskito.dashboard.oauth.flow import OAuthFlow
+
+
+@dataclass(frozen=True)
+class OAuthRedirect:
+    """Server adapter: emit ``302 Location: url``.
+
+    ``session`` is set on a successful callback so the server can attach
+    the same ``taskito_session`` + ``taskito_csrf`` cookies it sets for
+    password login. On the ``/start`` redirect ``session`` is ``None``.
+    """
+
+    url: str
+    session: Session | None = None
+    status: int = 302
+
+
+def handle_providers(queue: Queue, _qs: dict, flow: OAuthFlow | None) -> dict:
+    """List configured providers + whether password auth is enabled.
+
+    Returns ``{password_enabled: bool, providers: [{slot, label, type}]}``.
+    Always callable; returns ``providers: []`` when OAuth is not configured.
+    """
+    if flow is None:
+        return {"password_enabled": True, "providers": []}
+    return {
+        "password_enabled": flow.password_auth_enabled,
+        "providers": flow.providers_listing(),
+    }
+
+
+def handle_start(
+    queue: Queue,
+    qs: dict[str, list[str]],
+    slot: str,
+    flow: OAuthFlow | None,
+) -> OAuthRedirect:
+    """Begin an OAuth login: mint state, return a 302 to the provider URL."""
+    if flow is None:
+        raise _NotFound("oauth_not_configured")
+    next_values = qs.get("next") or []
+    next_url = next_values[0] if next_values else None
+    try:
+        provider_url = flow.start(slot, next_url)
+    except ProviderNotConfigured as e:
+        raise _NotFound(str(e)) from None
+    return OAuthRedirect(url=provider_url)
+
+
+def handle_callback(
+    queue: Queue,
+    qs: dict[str, list[str]],
+    slot: str,
+    flow: OAuthFlow | None,
+) -> OAuthRedirect:
+    """Land an OAuth login: verify state, create a session, redirect home.
+
+    The returned :class:`OAuthRedirect` carries the new :class:`Session`;
+    the server attaches the standard ``taskito_session`` + ``taskito_csrf``
+    cookies before sending the 302.
+    """
+    if flow is None:
+        raise _NotFound("oauth_not_configured")
+
+    def _first(name: str) -> str | None:
+        values = qs.get(name) or []
+        return values[0] if values else None
+
+    code = _first("code")
+    state_token = _first("state")
+    error = _first("error")
+    try:
+        session, next_url = flow.handle_callback(
+            slot, code=code, state_token=state_token, error=error
+        )
+    except ProviderNotConfigured as e:
+        raise _NotFound(str(e)) from None
+    except StateValidationError as e:
+        raise _BadRequest(f"oauth_state_invalid: {e}") from None
+    except IdentityFetchError as e:
+        raise _BadRequest(f"oauth_identity_failed: {e}") from None
+    except AllowlistDenied as e:
+        raise _BadRequest(f"oauth_allowlist_denied: {e}") from None
+    return OAuthRedirect(url=next_url, session=session)

--- a/py_src/taskito/dashboard/oauth/__init__.py
+++ b/py_src/taskito/dashboard/oauth/__init__.py
@@ -23,6 +23,7 @@ from taskito.dashboard.oauth.identity import (
     OAuthError,
     OAuthProvider,
     ProviderIdentity,
+    ProviderNotConfigured,
     StateValidationError,
 )
 from taskito.dashboard.oauth.state_store import OAuthState, OAuthStateStore
@@ -40,5 +41,6 @@ __all__ = [
     "OAuthStateStore",
     "OIDCConfig",
     "ProviderIdentity",
+    "ProviderNotConfigured",
     "StateValidationError",
 ]

--- a/py_src/taskito/dashboard/oauth/__init__.py
+++ b/py_src/taskito/dashboard/oauth/__init__.py
@@ -1,0 +1,44 @@
+"""OAuth2 / OIDC support for the Taskito dashboard.
+
+Adds Google, GitHub, and one-or-more generic OIDC providers (Okta, Auth0,
+Keycloak, Microsoft Entra, …) alongside the existing password login. Auth
+state continues to live in ``dashboard_settings``; OAuth users are stored
+in the same ``auth:users`` blob as password users, with a sentinel
+``password_hash`` prefix (``oauth:{slot}``) that ``verify_password``
+refuses.
+"""
+
+from __future__ import annotations
+
+from taskito.dashboard.oauth.config import (
+    GitHubConfig,
+    GoogleConfig,
+    OAuthConfig,
+    OAuthConfigError,
+    OIDCConfig,
+)
+from taskito.dashboard.oauth.identity import (
+    AllowlistDenied,
+    IdentityFetchError,
+    OAuthError,
+    OAuthProvider,
+    ProviderIdentity,
+    StateValidationError,
+)
+from taskito.dashboard.oauth.state_store import OAuthState, OAuthStateStore
+
+__all__ = [
+    "AllowlistDenied",
+    "GitHubConfig",
+    "GoogleConfig",
+    "IdentityFetchError",
+    "OAuthConfig",
+    "OAuthConfigError",
+    "OAuthError",
+    "OAuthProvider",
+    "OAuthState",
+    "OAuthStateStore",
+    "OIDCConfig",
+    "ProviderIdentity",
+    "StateValidationError",
+]

--- a/py_src/taskito/dashboard/oauth/config.py
+++ b/py_src/taskito/dashboard/oauth/config.py
@@ -1,0 +1,257 @@
+"""Operator-facing OAuth configuration and env-var parsing.
+
+All settings come from environment variables (or an equivalent
+:class:`OAuthConfig` instance passed programmatically — used by tests).
+Secrets are never stored in the dashboard settings DB.
+
+See ``docs/content/docs/dashboard/oauth.mdx`` for the full env-var
+reference.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import urllib.parse
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+
+
+class OAuthConfigError(ValueError):
+    """Raised when env-var configuration is invalid."""
+
+
+SLOT_RE = re.compile(r"^[a-z][a-z0-9_-]{0,31}$")
+RESERVED_SLOTS = frozenset({"google", "github"})
+
+# Hostnames where http:// is accepted for ``redirect_base_url`` (dev only).
+_LOCAL_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
+
+
+def _split_csv(raw: str | None) -> tuple[str, ...]:
+    if not raw:
+        return ()
+    return tuple(part.strip() for part in raw.split(",") if part.strip())
+
+
+@dataclass(frozen=True)
+class GoogleConfig:
+    client_id: str
+    client_secret: str
+    allowed_domains: tuple[str, ...] = ()
+
+    slot: str = "google"
+    label: str = "Google"
+    type: str = "google"
+
+
+@dataclass(frozen=True)
+class GitHubConfig:
+    client_id: str
+    client_secret: str
+    allowed_orgs: tuple[str, ...] = ()
+
+    slot: str = "github"
+    label: str = "GitHub"
+    type: str = "github"
+
+
+@dataclass(frozen=True)
+class OIDCConfig:
+    slot: str
+    client_id: str
+    client_secret: str
+    discovery_url: str
+    allowed_domains: tuple[str, ...] = ()
+    label: str = ""
+    type: str = "oidc"
+
+    def __post_init__(self) -> None:
+        if not SLOT_RE.match(self.slot):
+            raise OAuthConfigError(f"OIDC slot {self.slot!r} must match {SLOT_RE.pattern}")
+        if self.slot in RESERVED_SLOTS:
+            raise OAuthConfigError(f"OIDC slot {self.slot!r} collides with built-in provider")
+        if not self.discovery_url:
+            raise OAuthConfigError(f"OIDC slot {self.slot!r}: discovery_url is required")
+
+
+@dataclass(frozen=True)
+class OAuthConfig:
+    """Top-level OAuth configuration.
+
+    ``redirect_base_url`` is the public origin the dashboard is served at —
+    every callback URL is built from it (``{redirect_base_url}/api/auth/oauth/callback/{slot}``).
+    OAuth is considered disabled if no provider is configured.
+    """
+
+    redirect_base_url: str
+    google: GoogleConfig | None = None
+    github: GitHubConfig | None = None
+    oidc: tuple[OIDCConfig, ...] = ()
+    password_auth_enabled: bool = True
+    admin_emails: tuple[str, ...] = field(default=())
+
+    def __post_init__(self) -> None:
+        _validate_redirect_base_url(self.redirect_base_url)
+
+    @property
+    def is_enabled(self) -> bool:
+        return self.google is not None or self.github is not None or bool(self.oidc)
+
+    def providers(self) -> tuple[GoogleConfig | GitHubConfig | OIDCConfig, ...]:
+        """Configured providers in display order (Google, GitHub, then OIDC slots)."""
+        out: list[GoogleConfig | GitHubConfig | OIDCConfig] = []
+        if self.google is not None:
+            out.append(self.google)
+        if self.github is not None:
+            out.append(self.github)
+        out.extend(self.oidc)
+        return tuple(out)
+
+    def find_provider(self, slot: str) -> GoogleConfig | GitHubConfig | OIDCConfig | None:
+        for p in self.providers():
+            if p.slot == slot:
+                return p
+        return None
+
+    def callback_url(self, slot: str) -> str:
+        return f"{self.redirect_base_url.rstrip('/')}/api/auth/oauth/callback/{slot}"
+
+
+def _validate_redirect_base_url(url: str) -> None:
+    if not url:
+        raise OAuthConfigError("redirect_base_url must be set when OAuth is enabled")
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise OAuthConfigError(f"redirect_base_url must be http(s), got {parsed.scheme!r}")
+    if not parsed.hostname:
+        raise OAuthConfigError("redirect_base_url must include a hostname")
+    if parsed.scheme == "http" and parsed.hostname not in _LOCAL_HOSTS:
+        raise OAuthConfigError(
+            f"redirect_base_url must use https for non-local hosts (got http://{parsed.hostname})"
+        )
+
+
+def from_env(environ: Mapping[str, str] | None = None) -> OAuthConfig | None:
+    """Parse :class:`OAuthConfig` from the environment.
+
+    Returns ``None`` when neither ``TASKITO_DASHBOARD_OAUTH_REDIRECT_BASE_URL``
+    nor any provider client-id env var is set — i.e. OAuth is not configured.
+    Raises :class:`OAuthConfigError` if some but not all required vars are set
+    for a configured provider (fail-fast on partial configuration).
+    """
+    env = environ if environ is not None else os.environ
+
+    base_url = env.get("TASKITO_DASHBOARD_OAUTH_REDIRECT_BASE_URL", "").strip()
+    google_id = env.get("TASKITO_DASHBOARD_OAUTH_GOOGLE_CLIENT_ID", "").strip()
+    github_id = env.get("TASKITO_DASHBOARD_OAUTH_GITHUB_CLIENT_ID", "").strip()
+    oidc_slots_raw = env.get("TASKITO_DASHBOARD_OAUTH_OIDC_PROVIDERS", "").strip()
+
+    any_provider_signal = bool(google_id or github_id or oidc_slots_raw)
+    if not any_provider_signal and not base_url:
+        return None
+    if any_provider_signal and not base_url:
+        raise OAuthConfigError(
+            "TASKITO_DASHBOARD_OAUTH_REDIRECT_BASE_URL must be set when any "
+            "OAuth provider is configured"
+        )
+
+    google = _parse_google(env) if google_id else None
+    github = _parse_github(env) if github_id else None
+    oidc = _parse_oidc_slots(env, oidc_slots_raw)
+    password_enabled = _parse_bool(
+        env.get("TASKITO_DASHBOARD_PASSWORD_AUTH_ENABLED", "true"), default=True
+    )
+    admin_emails = _split_csv(env.get("TASKITO_DASHBOARD_OAUTH_ADMIN_EMAILS"))
+
+    config = OAuthConfig(
+        redirect_base_url=base_url,
+        google=google,
+        github=github,
+        oidc=oidc,
+        password_auth_enabled=password_enabled,
+        admin_emails=admin_emails,
+    )
+
+    if not config.is_enabled and not password_enabled:
+        raise OAuthConfigError(
+            "password auth disabled but no OAuth providers configured — no way to log in"
+        )
+
+    return config
+
+
+def _parse_google(env: Mapping[str, str]) -> GoogleConfig:
+    cid = env.get("TASKITO_DASHBOARD_OAUTH_GOOGLE_CLIENT_ID", "").strip()
+    secret = env.get("TASKITO_DASHBOARD_OAUTH_GOOGLE_CLIENT_SECRET", "").strip()
+    if not secret:
+        raise OAuthConfigError(
+            "TASKITO_DASHBOARD_OAUTH_GOOGLE_CLIENT_SECRET is required when google client_id is set"
+        )
+    return GoogleConfig(
+        client_id=cid,
+        client_secret=secret,
+        allowed_domains=_split_csv(env.get("TASKITO_DASHBOARD_OAUTH_GOOGLE_ALLOWED_DOMAINS")),
+    )
+
+
+def _parse_github(env: Mapping[str, str]) -> GitHubConfig:
+    cid = env.get("TASKITO_DASHBOARD_OAUTH_GITHUB_CLIENT_ID", "").strip()
+    secret = env.get("TASKITO_DASHBOARD_OAUTH_GITHUB_CLIENT_SECRET", "").strip()
+    if not secret:
+        raise OAuthConfigError(
+            "TASKITO_DASHBOARD_OAUTH_GITHUB_CLIENT_SECRET is required when github client_id is set"
+        )
+    return GitHubConfig(
+        client_id=cid,
+        client_secret=secret,
+        allowed_orgs=_split_csv(env.get("TASKITO_DASHBOARD_OAUTH_GITHUB_ALLOWED_ORGS")),
+    )
+
+
+def _parse_oidc_slots(env: Mapping[str, str], slots_raw: str) -> tuple[OIDCConfig, ...]:
+    slot_names = _split_csv(slots_raw)
+    if not slot_names:
+        return ()
+    out: list[OIDCConfig] = []
+    seen: set[str] = set()
+    for raw_slot in slot_names:
+        slot = raw_slot.lower()
+        if slot in seen:
+            raise OAuthConfigError(
+                f"OIDC slot {slot!r} listed twice in TASKITO_DASHBOARD_OAUTH_OIDC_PROVIDERS"
+            )
+        seen.add(slot)
+        out.append(_parse_oidc_slot(env, slot))
+    return tuple(out)
+
+
+def _parse_oidc_slot(env: Mapping[str, str], slot: str) -> OIDCConfig:
+    prefix = f"TASKITO_DASHBOARD_OAUTH_OIDC_{slot.upper().replace('-', '_')}"
+    cid = env.get(f"{prefix}_CLIENT_ID", "").strip()
+    secret = env.get(f"{prefix}_CLIENT_SECRET", "").strip()
+    discovery = env.get(f"{prefix}_DISCOVERY_URL", "").strip()
+    if not cid or not secret or not discovery:
+        raise OAuthConfigError(
+            f"OIDC slot {slot!r} requires {prefix}_CLIENT_ID, _CLIENT_SECRET, and _DISCOVERY_URL"
+        )
+    default_label = slot.replace("-", " ").replace("_", " ").title()
+    label = env.get(f"{prefix}_LABEL", "").strip() or default_label
+    allowed = _split_csv(env.get(f"{prefix}_ALLOWED_DOMAINS"))
+    return OIDCConfig(
+        slot=slot,
+        client_id=cid,
+        client_secret=secret,
+        discovery_url=discovery,
+        allowed_domains=allowed,
+        label=label,
+    )
+
+
+def _parse_bool(raw: str, *, default: bool) -> bool:
+    lowered = raw.strip().lower()
+    if lowered in ("1", "true", "yes", "on"):
+        return True
+    if lowered in ("0", "false", "no", "off"):
+        return False
+    return default

--- a/py_src/taskito/dashboard/oauth/flow.py
+++ b/py_src/taskito/dashboard/oauth/flow.py
@@ -1,0 +1,167 @@
+"""End-to-end OAuth flow orchestration.
+
+:class:`OAuthFlow` is the seam between the HTTP handler layer and the
+provider implementations. It owns the registry of configured providers,
+the state store, and the :class:`AuthStore` integration. Handlers call
+``start()`` to mint a redirect URL and ``handle_callback()`` to land a
+session.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from taskito.dashboard.auth import AuthStore
+from taskito.dashboard.oauth.config import (
+    GitHubConfig,
+    GoogleConfig,
+    OAuthConfig,
+    OIDCConfig,
+)
+from taskito.dashboard.oauth.identity import (
+    IdentityFetchError,
+    OAuthProvider,
+    ProviderNotConfigured,
+    StateValidationError,
+)
+from taskito.dashboard.oauth.pkce import s256_challenge
+from taskito.dashboard.oauth.providers import (
+    GenericOIDCProvider,
+    GitHubProvider,
+    GoogleProvider,
+)
+from taskito.dashboard.oauth.state_store import OAuthStateStore
+from taskito.dashboard.url_safety import is_safe_redirect
+
+if TYPE_CHECKING:
+    from taskito.app import Queue
+    from taskito.dashboard.auth import Session
+
+
+def build_providers(
+    config: OAuthConfig,
+) -> dict[str, OAuthProvider]:
+    """Instantiate one provider per configured slot, keyed by slot."""
+    registry: dict[str, OAuthProvider] = {}
+    for entry in config.providers():
+        if isinstance(entry, GoogleConfig):
+            registry[entry.slot] = GoogleProvider(entry)
+        elif isinstance(entry, GitHubConfig):
+            registry[entry.slot] = GitHubProvider(entry)
+        elif isinstance(entry, OIDCConfig):
+            registry[entry.slot] = GenericOIDCProvider(entry)
+    return registry
+
+
+class OAuthFlow:
+    """Ties together config, providers, state store, and the auth store."""
+
+    def __init__(
+        self,
+        queue: Queue,
+        config: OAuthConfig,
+        *,
+        providers: dict[str, OAuthProvider] | None = None,
+        state_store: OAuthStateStore | None = None,
+    ) -> None:
+        self._queue = queue
+        self._config = config
+        self._providers: dict[str, OAuthProvider] = (
+            providers if providers is not None else build_providers(config)
+        )
+        self._state_store = state_store or OAuthStateStore(queue)
+
+    # ── Introspection ────────────────────────────────────────────────
+
+    @property
+    def password_auth_enabled(self) -> bool:
+        return self._config.password_auth_enabled
+
+    def has_provider(self, slot: str) -> bool:
+        return slot in self._providers
+
+    def providers_listing(self) -> list[dict[str, str]]:
+        """Compact provider summary for the login UI (no secrets)."""
+        return [
+            {"slot": p.slot, "label": p.label, "type": p.type} for p in self._providers.values()
+        ]
+
+    # ── Flow ─────────────────────────────────────────────────────────
+
+    def start(self, slot: str, next_url: str | None) -> str:
+        """Mint a state row and return the provider's authorize URL.
+
+        ``next_url`` is sanitised against :func:`is_safe_redirect` and falls
+        back to ``"/"`` if it fails the check.
+        """
+        provider = self._require_provider(slot)
+        safe_next = next_url if next_url and is_safe_redirect(next_url) else "/"
+        state = self._state_store.create(slot=slot, next_url=safe_next)
+        challenge = s256_challenge(state.code_verifier)
+        return provider.authorization_url(
+            state=state.state,
+            nonce=state.nonce,
+            code_challenge=challenge,
+            redirect_uri=self._config.callback_url(slot),
+        )
+
+    def handle_callback(
+        self,
+        slot: str,
+        *,
+        code: str | None,
+        state_token: str | None,
+        error: str | None,
+    ) -> tuple[Session, str]:
+        """Exchange ``code`` for an identity and create a session.
+
+        Returns ``(session, next_url)`` on success. Raises:
+
+        - :class:`StateValidationError` for missing/expired/replayed state
+        - :class:`IdentityFetchError` for any token / userinfo / claim issue
+        - :class:`AllowlistDenied` if the identity is outside the allowlist
+        """
+        if error:
+            raise IdentityFetchError(f"provider returned error: {error}")
+        if not code or not state_token:
+            raise StateValidationError("missing code or state parameter")
+
+        row = self._state_store.consume(state_token)
+        if row is None:
+            raise StateValidationError("state is invalid, expired, or already used")
+        if row.slot != slot:
+            raise StateValidationError("state slot does not match callback slot")
+
+        provider = self._require_provider(slot)
+        identity = provider.exchange_code(
+            code=code,
+            code_verifier=row.code_verifier,
+            redirect_uri=self._config.callback_url(slot),
+            expected_nonce=row.nonce,
+        )
+        provider.check_allowlist(identity)
+
+        store = AuthStore(self._queue)
+        user = store.get_or_create_oauth_user(
+            slot=identity.slot,
+            subject=identity.subject,
+            email=identity.email,
+            name=identity.name,
+            email_verified=identity.email_verified,
+            admin_emails=self._config.admin_emails,
+        )
+        session = store.create_session(user)
+        return session, row.next_url
+
+    # ── Maintenance ──────────────────────────────────────────────────
+
+    def prune_state(self) -> int:
+        return self._state_store.prune_expired()
+
+    # ── Internal ─────────────────────────────────────────────────────
+
+    def _require_provider(self, slot: str) -> OAuthProvider:
+        provider = self._providers.get(slot)
+        if provider is None:
+            raise ProviderNotConfigured(f"OAuth provider {slot!r} is not configured")
+        return provider

--- a/py_src/taskito/dashboard/oauth/identity.py
+++ b/py_src/taskito/dashboard/oauth/identity.py
@@ -28,6 +28,10 @@ class AllowlistDenied(OAuthError):
     """Raised when a verified identity is rejected by a configured allowlist."""
 
 
+class ProviderNotConfigured(OAuthError):
+    """Raised when a request references an OAuth slot that is not registered."""
+
+
 @dataclass(frozen=True)
 class ProviderIdentity:
     """Normalised identity returned by every provider after a successful flow.

--- a/py_src/taskito/dashboard/oauth/identity.py
+++ b/py_src/taskito/dashboard/oauth/identity.py
@@ -1,0 +1,85 @@
+"""Identity types and the provider contract.
+
+A :class:`ProviderIdentity` is the canonical shape of "who just logged in"
+that every provider must return. The :class:`OAuthProvider` protocol is
+the contract every concrete provider (Google, GitHub, generic OIDC)
+satisfies.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+class OAuthError(Exception):
+    """Base class for any OAuth-flow error surfaced to the handler layer."""
+
+
+class StateValidationError(OAuthError):
+    """Raised when the callback state is missing, expired, replayed, or forged."""
+
+
+class IdentityFetchError(OAuthError):
+    """Raised when the provider returns an error during token / userinfo fetch."""
+
+
+class AllowlistDenied(OAuthError):
+    """Raised when a verified identity is rejected by a configured allowlist."""
+
+
+@dataclass(frozen=True)
+class ProviderIdentity:
+    """Normalised identity returned by every provider after a successful flow.
+
+    ``slot`` is the registry key (``google``, ``github``, or the operator-
+    chosen OIDC slot name). ``subject`` is the provider's stable unique ID
+    for the user (``sub`` claim, GitHub ``id``); never the email, which
+    can change. Both together form the Taskito username ``f"{slot}:{subject}"``.
+    """
+
+    slot: str
+    subject: str
+    email: str | None
+    email_verified: bool
+    name: str | None = None
+    picture: str | None = None
+
+
+class OAuthProvider(Protocol):
+    """Contract every OAuth provider implementation must satisfy."""
+
+    slot: str
+    """URL-safe unique identifier used in the callback path."""
+
+    label: str
+    """Human-readable button label rendered by the dashboard."""
+
+    type: str
+    """One of ``"google"``, ``"github"``, ``"oidc"`` — chooses the icon."""
+
+    def authorization_url(
+        self,
+        *,
+        state: str,
+        nonce: str,
+        code_challenge: str,
+        redirect_uri: str,
+    ) -> str:
+        """Build the provider-side authorize URL the browser is redirected to."""
+        ...
+
+    def exchange_code(
+        self,
+        *,
+        code: str,
+        code_verifier: str,
+        redirect_uri: str,
+        expected_nonce: str | None,
+    ) -> ProviderIdentity:
+        """Exchange the auth code for an identity, raising on any failure."""
+        ...
+
+    def check_allowlist(self, identity: ProviderIdentity) -> None:
+        """Raise :class:`AllowlistDenied` if the identity is not permitted."""
+        ...

--- a/py_src/taskito/dashboard/oauth/pkce.py
+++ b/py_src/taskito/dashboard/oauth/pkce.py
@@ -1,0 +1,16 @@
+"""PKCE S256 code-challenge derivation."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+
+
+def s256_challenge(verifier: str) -> str:
+    """Return the S256 code-challenge for ``verifier`` per RFC 7636.
+
+    The challenge is ``base64url(sha256(verifier))`` with trailing ``=``
+    padding stripped, matching every OAuth provider's PKCE implementation.
+    """
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")

--- a/py_src/taskito/dashboard/oauth/providers.py
+++ b/py_src/taskito/dashboard/oauth/providers.py
@@ -1,0 +1,411 @@
+"""Concrete provider implementations: Google, GitHub, generic OIDC.
+
+Every provider satisfies :class:`OAuthProvider`. The split between
+``exchange_code`` (network IO + claim normalisation) and
+``check_allowlist`` (pure-data permission check) is deliberate so tests
+can drive either path in isolation.
+
+Tests stub the network boundary via the ``_fetch_token`` and HTTP
+session attributes on each provider.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING, Any
+from urllib.parse import urlencode
+
+import requests
+from authlib.integrations.requests_client import OAuth2Session
+from joserfc import jwt
+from joserfc.errors import JoseError
+from joserfc.jwk import KeySet
+
+from taskito.dashboard.oauth.identity import (
+    AllowlistDenied,
+    IdentityFetchError,
+    ProviderIdentity,
+)
+
+if TYPE_CHECKING:
+    from taskito.dashboard.oauth.config import (
+        GitHubConfig,
+        GoogleConfig,
+        OIDCConfig,
+    )
+
+
+GOOGLE_DISCOVERY_URL = "https://accounts.google.com/.well-known/openid-configuration"
+GITHUB_AUTH_URL = "https://github.com/login/oauth/authorize"
+GITHUB_TOKEN_URL = "https://github.com/login/oauth/access_token"
+GITHUB_API_BASE = "https://api.github.com"
+
+_HTTP_TIMEOUT = 10.0
+
+
+def _email_domain(email: str | None) -> str | None:
+    if not email or "@" not in email:
+        return None
+    return email.rsplit("@", 1)[-1].lower()
+
+
+def _audience_matches(aud: Any, client_id: str) -> bool:
+    if isinstance(aud, str):
+        return aud == client_id
+    if isinstance(aud, list):
+        return client_id in aud
+    return False
+
+
+# ── OIDC provider (shared logic for Google + generic OIDC) ─────────────
+
+
+class _OIDCProviderBase:
+    """Shared OIDC machinery: discovery, JWKS caching, ID-token decoding."""
+
+    slot: str
+    label: str
+    type: str
+    client_id: str
+    client_secret: str
+    discovery_url: str
+    scope: str = "openid email profile"
+
+    def __init__(self, *, http: requests.Session | None = None) -> None:
+        self._http = http or requests.Session()
+        self._discovery: dict[str, Any] | None = None
+        self._jwks: dict[str, Any] | None = None
+
+    # Sub-classes override / extend `_extra_auth_params` to add hints.
+    def _extra_auth_params(self) -> dict[str, str]:
+        return {}
+
+    def _get_discovery(self) -> dict[str, Any]:
+        if self._discovery is None:
+            resp = self._http.get(self.discovery_url, timeout=_HTTP_TIMEOUT)
+            resp.raise_for_status()
+            self._discovery = resp.json()
+        return self._discovery
+
+    def _get_jwks(self) -> dict[str, Any]:
+        if self._jwks is None:
+            resp = self._http.get(self._get_discovery()["jwks_uri"], timeout=_HTTP_TIMEOUT)
+            resp.raise_for_status()
+            self._jwks = resp.json()
+        return self._jwks
+
+    def authorization_url(
+        self,
+        *,
+        state: str,
+        nonce: str,
+        code_challenge: str,
+        redirect_uri: str,
+    ) -> str:
+        params: dict[str, str] = {
+            "response_type": "code",
+            "client_id": self.client_id,
+            "redirect_uri": redirect_uri,
+            "scope": self.scope,
+            "state": state,
+            "nonce": nonce,
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
+        }
+        params.update(self._extra_auth_params())
+        return f"{self._get_discovery()['authorization_endpoint']}?{urlencode(params)}"
+
+    def _fetch_token(
+        self,
+        *,
+        code: str,
+        code_verifier: str,
+        redirect_uri: str,
+    ) -> dict[str, Any]:
+        """POST the auth code to the token endpoint. Returns the raw token dict.
+
+        Isolated so tests can stub it without involving Authlib's HTTP stack.
+        """
+        client = OAuth2Session(
+            client_id=self.client_id,
+            client_secret=self.client_secret,
+        )
+        try:
+            token = client.fetch_token(
+                self._get_discovery()["token_endpoint"],
+                code=code,
+                code_verifier=code_verifier,
+                redirect_uri=redirect_uri,
+                grant_type="authorization_code",
+            )
+        except Exception as e:
+            raise IdentityFetchError(f"token exchange failed: {e}") from e
+        return dict(token)
+
+    def exchange_code(
+        self,
+        *,
+        code: str,
+        code_verifier: str,
+        redirect_uri: str,
+        expected_nonce: str | None,
+    ) -> ProviderIdentity:
+        token = self._fetch_token(
+            code=code, code_verifier=code_verifier, redirect_uri=redirect_uri
+        )
+        id_token = token.get("id_token")
+        if not id_token:
+            raise IdentityFetchError("no id_token in token response")
+
+        try:
+            key_set = KeySet.import_key_set(self._get_jwks())  # type: ignore[arg-type]
+            decoded = jwt.decode(id_token, key_set)
+            claims = decoded.claims
+        except JoseError as e:
+            raise IdentityFetchError(f"id_token validation failed: {e}") from e
+
+        issuer = self._get_discovery().get("issuer")
+        if issuer and claims.get("iss") != issuer:
+            raise IdentityFetchError(
+                f"id_token issuer mismatch: expected {issuer!r}, got {claims.get('iss')!r}"
+            )
+        if not _audience_matches(claims.get("aud"), self.client_id):
+            raise IdentityFetchError(f"id_token audience mismatch: {claims.get('aud')!r}")
+        if expected_nonce is not None and claims.get("nonce") != expected_nonce:
+            raise IdentityFetchError("id_token nonce mismatch")
+
+        exp = claims.get("exp")
+        if isinstance(exp, (int, float)) and exp < int(time.time()) - 60:
+            # 60s clock skew tolerance.
+            raise IdentityFetchError("id_token expired")
+
+        sub = claims.get("sub")
+        if not sub:
+            raise IdentityFetchError("id_token missing 'sub' claim")
+
+        return ProviderIdentity(
+            slot=self.slot,
+            subject=str(sub),
+            email=claims.get("email"),
+            email_verified=bool(claims.get("email_verified")),
+            name=claims.get("name"),
+            picture=claims.get("picture"),
+        )
+
+
+class GoogleProvider(_OIDCProviderBase):
+    slot = "google"
+    type = "google"
+    discovery_url = GOOGLE_DISCOVERY_URL
+
+    def __init__(self, config: GoogleConfig, *, http: requests.Session | None = None) -> None:
+        super().__init__(http=http)
+        self.config = config
+        self.label = config.label
+        self.client_id = config.client_id
+        self.client_secret = config.client_secret
+
+    def _extra_auth_params(self) -> dict[str, str]:
+        params = {"prompt": "select_account"}
+        # When exactly one domain is allowlisted, pass it as ``hd`` so Google
+        # pre-selects the right account. This is a UX hint only — the real
+        # enforcement happens in ``check_allowlist``.
+        if len(self.config.allowed_domains) == 1:
+            params["hd"] = self.config.allowed_domains[0]
+        return params
+
+    def check_allowlist(self, identity: ProviderIdentity) -> None:
+        if not self.config.allowed_domains:
+            return
+        if not identity.email or not identity.email_verified:
+            raise AllowlistDenied("verified email required for domain check")
+        domain = _email_domain(identity.email)
+        allowed = {d.lower() for d in self.config.allowed_domains}
+        if domain not in allowed:
+            raise AllowlistDenied(f"email domain {domain!r} is not in the allowed domains list")
+
+
+class GenericOIDCProvider(_OIDCProviderBase):
+    type = "oidc"
+
+    def __init__(self, config: OIDCConfig, *, http: requests.Session | None = None) -> None:
+        super().__init__(http=http)
+        self.config = config
+        self.slot = config.slot
+        self.label = config.label or config.slot.title()
+        self.client_id = config.client_id
+        self.client_secret = config.client_secret
+        self.discovery_url = config.discovery_url
+
+    def check_allowlist(self, identity: ProviderIdentity) -> None:
+        if not self.config.allowed_domains:
+            return
+        if not identity.email or not identity.email_verified:
+            raise AllowlistDenied("verified email required for domain check")
+        domain = _email_domain(identity.email)
+        allowed = {d.lower() for d in self.config.allowed_domains}
+        if domain not in allowed:
+            raise AllowlistDenied(f"email domain {domain!r} is not in the allowed domains list")
+
+
+# ── GitHub (OAuth2-only, no OIDC) ──────────────────────────────────────
+
+
+class GitHubProvider:
+    slot = "github"
+    type = "github"
+    scope = "read:user user:email"
+
+    def __init__(self, config: GitHubConfig, *, http: requests.Session | None = None) -> None:
+        self.config = config
+        self.label = config.label
+        self._http = http or requests.Session()
+
+    def authorization_url(
+        self,
+        *,
+        state: str,
+        nonce: str,
+        code_challenge: str,
+        redirect_uri: str,
+    ) -> str:
+        # GitHub does not implement OIDC: ``nonce`` is unused. PKCE is honoured
+        # — GitHub added support for it in 2023.
+        params = {
+            "client_id": self.config.client_id,
+            "redirect_uri": redirect_uri,
+            "scope": self.scope,
+            "state": state,
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
+            "allow_signup": "false",
+        }
+        # Request read:org scope when allowlist is configured, so the
+        # membership endpoint returns reliable results.
+        if self.config.allowed_orgs:
+            params["scope"] = self.scope + " read:org"
+        return f"{GITHUB_AUTH_URL}?{urlencode(params)}"
+
+    def _fetch_token(
+        self,
+        *,
+        code: str,
+        code_verifier: str,
+        redirect_uri: str,
+    ) -> dict[str, Any]:
+        client = OAuth2Session(
+            client_id=self.config.client_id,
+            client_secret=self.config.client_secret,
+        )
+        try:
+            token = client.fetch_token(
+                GITHUB_TOKEN_URL,
+                code=code,
+                code_verifier=code_verifier,
+                redirect_uri=redirect_uri,
+                grant_type="authorization_code",
+                # GitHub returns form-encoded by default; ask for JSON.
+                headers={"Accept": "application/json"},
+            )
+        except Exception as e:
+            raise IdentityFetchError(f"token exchange failed: {e}") from e
+        return dict(token)
+
+    def _api_get(self, path: str, access_token: str) -> Any:
+        resp = self._http.get(
+            f"{GITHUB_API_BASE}{path}",
+            headers={
+                "Authorization": f"Bearer {access_token}",
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+            timeout=_HTTP_TIMEOUT,
+        )
+        if resp.status_code >= 400 and resp.status_code != 404:
+            raise IdentityFetchError(
+                f"GitHub API {path} returned {resp.status_code}: {resp.text[:200]}"
+            )
+        return resp
+
+    def exchange_code(
+        self,
+        *,
+        code: str,
+        code_verifier: str,
+        redirect_uri: str,
+        expected_nonce: str | None,
+    ) -> ProviderIdentity:
+        token = self._fetch_token(
+            code=code, code_verifier=code_verifier, redirect_uri=redirect_uri
+        )
+        access_token = token.get("access_token")
+        if not access_token:
+            raise IdentityFetchError("no access_token in token response")
+
+        user_resp = self._api_get("/user", access_token)
+        if user_resp.status_code != 200:
+            raise IdentityFetchError(f"GET /user failed: {user_resp.status_code}")
+        user = user_resp.json()
+        gh_id = user.get("id")
+        login = user.get("login")
+        if gh_id is None or not login:
+            raise IdentityFetchError("GitHub /user response missing 'id' or 'login'")
+
+        primary_email, verified = self._primary_email(access_token)
+
+        # Org membership requires the access token, so we enforce it here
+        # rather than in ``check_allowlist`` (which is a no-op for GitHub).
+        # Any denial raises :class:`AllowlistDenied` straight through.
+        self._verify_org_membership(access_token, str(login))
+
+        return ProviderIdentity(
+            slot=self.slot,
+            subject=str(gh_id),
+            email=primary_email,
+            email_verified=verified,
+            name=user.get("name") or user.get("login"),
+            picture=user.get("avatar_url"),
+        )
+
+    def _primary_email(self, access_token: str) -> tuple[str | None, bool]:
+        """Return ``(primary_verified_email_or_None, verified_flag)``.
+
+        Falls back to ``None`` if no verified primary exists. We never trust
+        an unverified email for any access decision.
+        """
+        resp = self._api_get("/user/emails", access_token)
+        if resp.status_code != 200:
+            return None, False
+        for entry in resp.json():
+            if entry.get("primary") and entry.get("verified"):
+                return entry.get("email"), True
+        return None, False
+
+    def _verify_org_membership(self, access_token: str, login: str) -> None:
+        if not self.config.allowed_orgs:
+            return
+        for org in self.config.allowed_orgs:
+            resp = self._http.get(
+                f"{GITHUB_API_BASE}/orgs/{org}/members/{login}",
+                headers={
+                    "Authorization": f"Bearer {access_token}",
+                    "Accept": "application/vnd.github+json",
+                    "X-GitHub-Api-Version": "2022-11-28",
+                },
+                timeout=_HTTP_TIMEOUT,
+            )
+            if resp.status_code == 204:
+                return
+            if resp.status_code not in (302, 404):
+                raise IdentityFetchError(f"GitHub org membership check failed: {resp.status_code}")
+        raise AllowlistDenied(
+            f"user is not a member of any allowed GitHub org "
+            f"({', '.join(self.config.allowed_orgs)})"
+        )
+
+    def check_allowlist(self, identity: ProviderIdentity) -> None:
+        """No-op — GitHub's org check happens inside :meth:`exchange_code`.
+
+        Required by the :class:`OAuthProvider` protocol for interface symmetry.
+        """
+        return

--- a/py_src/taskito/dashboard/oauth/state_store.py
+++ b/py_src/taskito/dashboard/oauth/state_store.py
@@ -1,0 +1,137 @@
+"""Short-lived store for in-flight OAuth flows.
+
+When the dashboard redirects a browser to a provider's ``/authorize`` URL,
+we stash the ``state``, ``nonce``, PKCE ``code_verifier``, target slot,
+and post-login ``next_url`` server-side, keyed by ``state``. On callback
+we look the row up, validate ``state`` (single-use, time-bounded), and
+delete it.
+
+Rows live in ``dashboard_settings`` under the ``auth:oauth_state:<state>``
+key namespace alongside sessions and users, so they work uniformly across
+SQLite / Postgres / Redis with no new migrations.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import secrets
+import time
+from dataclasses import asdict, dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from taskito.app import Queue
+
+
+logger = logging.getLogger("taskito.dashboard.oauth")
+
+STATE_PREFIX = "auth:oauth_state:"
+DEFAULT_STATE_TTL_SECONDS = 5 * 60  # 5 min — covers consent UX + reasonable network latency.
+
+STATE_TOKEN_BYTES = 32
+NONCE_BYTES = 16
+CODE_VERIFIER_BYTES = 32
+
+
+@dataclass(frozen=True)
+class OAuthState:
+    """One in-flight OAuth flow, stored server-side until callback or expiry."""
+
+    state: str
+    nonce: str
+    code_verifier: str
+    slot: str
+    next_url: str
+    created_at: int
+    expires_at: int
+
+    def is_expired(self, now: int | None = None) -> bool:
+        return (now if now is not None else int(time.time())) >= self.expires_at
+
+
+def generate_state() -> str:
+    return secrets.token_urlsafe(STATE_TOKEN_BYTES)
+
+
+def generate_nonce() -> str:
+    return secrets.token_urlsafe(NONCE_BYTES)
+
+
+def generate_code_verifier() -> str:
+    # RFC 7636 section 4.1: high-entropy URL-safe string, 43-128 chars.
+    # 32 bytes yields 43 chars base64url, comfortably above the minimum.
+    return secrets.token_urlsafe(CODE_VERIFIER_BYTES)
+
+
+class OAuthStateStore:
+    """Create, consume (read+delete), and prune short-lived OAuth state rows."""
+
+    def __init__(self, queue: Queue) -> None:
+        self._queue = queue
+
+    def create(
+        self,
+        slot: str,
+        next_url: str,
+        ttl_seconds: int = DEFAULT_STATE_TTL_SECONDS,
+    ) -> OAuthState:
+        """Mint a fresh state/nonce/verifier triple and persist it."""
+        now = int(time.time())
+        state = OAuthState(
+            state=generate_state(),
+            nonce=generate_nonce(),
+            code_verifier=generate_code_verifier(),
+            slot=slot,
+            next_url=next_url,
+            created_at=now,
+            expires_at=now + ttl_seconds,
+        )
+        payload = {k: v for k, v in asdict(state).items() if k != "state"}
+        self._queue.set_setting(
+            STATE_PREFIX + state.state, json.dumps(payload, separators=(",", ":"))
+        )
+        return state
+
+    def consume(self, state_token: str) -> OAuthState | None:
+        """Look up ``state_token`` and atomically delete it. Returns ``None``
+        if the row is missing, malformed, or expired. Single-use — the row
+        is always deleted, so a replayed state never re-validates.
+        """
+        if not state_token:
+            return None
+        key = STATE_PREFIX + state_token
+        raw = self._queue.get_setting(key)
+        if not raw:
+            return None
+        # Always delete first so any subsequent request with the same state
+        # sees a missing row, even if parsing fails below.
+        self._queue.delete_setting(key)
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            return None
+        try:
+            row = OAuthState(state=state_token, **data)
+        except TypeError:
+            return None
+        if row.is_expired():
+            return None
+        return row
+
+    def prune_expired(self) -> int:
+        """Best-effort sweep of expired state rows. Returns count removed."""
+        now = int(time.time())
+        removed = 0
+        for key, value in self._queue.list_settings().items():
+            if not key.startswith(STATE_PREFIX):
+                continue
+            try:
+                data = json.loads(value)
+                expires_at = int(data.get("expires_at", 0))
+            except (json.JSONDecodeError, TypeError, ValueError):
+                continue
+            if expires_at <= now:
+                self._queue.delete_setting(key)
+                removed += 1
+        return removed

--- a/py_src/taskito/dashboard/routes.py
+++ b/py_src/taskito/dashboard/routes.py
@@ -87,11 +87,25 @@ PUBLIC_PATHS: frozenset[str] = frozenset(
         "/api/auth/status",
         "/api/auth/login",
         "/api/auth/setup",
+        "/api/auth/providers",
         "/health",
         "/readiness",
         "/metrics",
     }
 )
+
+# Path prefixes that bypass auth — used by the OAuth flow whose paths
+# contain a provider slot in the URL (e.g. ``/api/auth/oauth/start/google``).
+PUBLIC_PATH_PREFIXES: tuple[str, ...] = (
+    "/api/auth/oauth/start/",
+    "/api/auth/oauth/callback/",
+)
+
+
+def is_public_path(path: str) -> bool:
+    """Whether ``path`` should bypass the session/CSRF gate."""
+    return path in PUBLIC_PATHS or any(path.startswith(p) for p in PUBLIC_PATH_PREFIXES)
+
 
 # Paths handled directly by the server (live outside the regular dispatch
 # tables because they take a RequestContext as well as the queue).

--- a/py_src/taskito/dashboard/server.py
+++ b/py_src/taskito/dashboard/server.py
@@ -22,6 +22,16 @@ from taskito.dashboard.auth import (
     bootstrap_admin_from_env,
 )
 from taskito.dashboard.errors import _BadRequest, _NotFound
+from taskito.dashboard.handlers.oauth import (
+    OAuthRedirect,
+    handle_providers,
+)
+from taskito.dashboard.handlers.oauth import (
+    handle_callback as handle_oauth_callback,
+)
+from taskito.dashboard.handlers.oauth import (
+    handle_start as handle_oauth_start,
+)
 from taskito.dashboard.request_context import (
     CSRF_COOKIE,
     SESSION_COOKIE,
@@ -42,10 +52,10 @@ from taskito.dashboard.routes import (
     POST_PARAM2_ROUTES,
     POST_PARAM_ROUTES,
     POST_ROUTES,
-    PUBLIC_PATHS,
     PUT_PARAM2_ROUTES,
     PUT_PARAM_ROUTES,
     is_csrf_exempt,
+    is_public_path,
     is_state_changing_method,
 )
 from taskito.dashboard.static import (
@@ -59,6 +69,7 @@ from taskito.health import check_health, check_readiness
 
 if TYPE_CHECKING:
     from taskito.app import Queue
+    from taskito.dashboard.oauth.flow import OAuthFlow
 
 
 logger = logging.getLogger("taskito.dashboard")
@@ -80,12 +91,27 @@ def _safe_path(path: str) -> str:
     return path.translate(_LOG_UNSAFE_CHARS)[:_LOG_PATH_MAX]
 
 
+def _session_cookies(session: Any) -> tuple[str, ...]:
+    """Build the standard ``Set-Cookie`` headers for a freshly-created session.
+
+    Used by both password login and OAuth callback so the cookie shape
+    stays in lockstep across login methods.
+    """
+    return (
+        f"{SESSION_COOKIE}={session.token}; HttpOnly; SameSite=Strict; Path=/; "
+        f"Max-Age={DEFAULT_SESSION_TTL_SECONDS}",
+        f"{CSRF_COOKIE}={session.csrf_token}; SameSite=Strict; Path=/; "
+        f"Max-Age={DEFAULT_SESSION_TTL_SECONDS}",
+    )
+
+
 def serve_dashboard(
     queue: Queue,
     host: str = "127.0.0.1",
     port: int = 8080,
     *,
     static_assets: StaticAssets | None = None,
+    oauth_flow: OAuthFlow | None = None,
 ) -> None:
     """Start the dashboard HTTP server (blocking).
 
@@ -96,9 +122,14 @@ def serve_dashboard(
         static_assets: Override the default SPA asset source. Mainly a
             test seam; downstream embedders can also use it to ship a
             customised dashboard bundle from a different location.
+        oauth_flow: Configured :class:`OAuthFlow` to enable social login.
+            When unset, OAuth endpoints respond 404 and the providers list
+            is empty.
     """
     bootstrap_admin_from_env(queue)
-    handler = _make_handler(queue, static_assets=static_assets)
+    if oauth_flow is None:
+        oauth_flow = _build_oauth_flow_from_env(queue)
+    handler = _make_handler(queue, static_assets=static_assets, oauth_flow=oauth_flow)
     server = ThreadingHTTPServer((host, port), handler)
     print(f"taskito dashboard → http://{host}:{port}")
     print("Press Ctrl+C to stop")
@@ -111,7 +142,31 @@ def serve_dashboard(
         server.server_close()
 
 
-def _make_handler(queue: Queue, *, static_assets: StaticAssets | None = None) -> type:
+def _build_oauth_flow_from_env(queue: Queue) -> OAuthFlow | None:
+    """Build :class:`OAuthFlow` from environment variables, or ``None``.
+
+    Failures in the env-var config are logged and treated as "OAuth not
+    configured" — the dashboard still starts with password auth only.
+    """
+    try:
+        from taskito.dashboard.oauth.config import from_env as oauth_from_env
+        from taskito.dashboard.oauth.flow import OAuthFlow
+
+        config = oauth_from_env()
+        if config is None or not config.is_enabled:
+            return None
+        return OAuthFlow(queue, config)
+    except Exception:
+        logger.exception("OAuth env-var configuration is invalid; OAuth disabled")
+        return None
+
+
+def _make_handler(
+    queue: Queue,
+    *,
+    static_assets: StaticAssets | None = None,
+    oauth_flow: OAuthFlow | None = None,
+) -> type:
     """Create a request handler class bound to the given queue."""
     assets = static_assets if static_assets is not None else _get_default_assets()
 
@@ -167,6 +222,19 @@ def _make_handler(queue: Queue, *, static_assets: StaticAssets | None = None) ->
 
             ctx, denied = self._authorize(path, "GET")
             if denied:
+                return
+
+            # ── OAuth flow paths (public, redirect-emitting) ────────
+            if path == "/api/auth/providers":
+                self._dispatch_with_handler(handle_providers, lambda h: h(queue, qs, oauth_flow))
+                return
+            if path.startswith("/api/auth/oauth/start/"):
+                slot = unquote(path[len("/api/auth/oauth/start/") :])
+                self._dispatch_oauth_redirect(handle_oauth_start, queue, qs, slot, oauth_flow)
+                return
+            if path.startswith("/api/auth/oauth/callback/"):
+                slot = unquote(path[len("/api/auth/oauth/callback/") :])
+                self._dispatch_oauth_redirect(handle_oauth_callback, queue, qs, slot, oauth_flow)
                 return
 
             if path in AUTH_CONTEXT_GET_PATHS:
@@ -336,13 +404,13 @@ def _make_handler(queue: Queue, *, static_assets: StaticAssets | None = None) ->
             # SPA can show the setup page.
             if (
                 path.startswith("/api/")
-                and path not in PUBLIC_PATHS
+                and not is_public_path(path)
                 and AuthStore(queue).count_users() == 0
             ):
                 self._json_response({"error": "setup_required"}, status=503)
                 return ctx, True
 
-            if path in PUBLIC_PATHS or not path.startswith("/api/"):
+            if is_public_path(path) or not path.startswith("/api/"):
                 # CSRF still applies to public state-changing routes that are
                 # NOT exempt — but login/setup are the only public POSTs and
                 # they're exempt.
@@ -422,6 +490,33 @@ def _make_handler(queue: Queue, *, static_assets: StaticAssets | None = None) ->
             if on_success is not None:
                 on_success(result)
             self._json_response(result)
+
+        def _dispatch_oauth_redirect(
+            self,
+            handler: Any,
+            queue: Any,
+            qs: dict[str, list[str]],
+            slot: str,
+            flow: OAuthFlow | None,
+        ) -> None:
+            try:
+                redirect: OAuthRedirect = handler(queue, qs, slot, flow)
+            except _BadRequest as e:
+                self._json_response({"error": e.message}, status=400)
+                return
+            except _NotFound as e:
+                self._json_response({"error": e.message}, status=404)
+                return
+            cookies: list[str] = []
+            if redirect.session is not None:
+                cookies = list(_session_cookies(redirect.session))
+            self.send_response(redirect.status)
+            self.send_header("Location", redirect.url)
+            self.send_header("Content-Length", "0")
+            self.send_header("Cache-Control", "no-store")
+            for cookie in cookies:
+                self.send_header("Set-Cookie", cookie)
+            self.end_headers()
 
         # ── Body / response helpers ─────────────────────────────────
 

--- a/py_src/taskito/dashboard/url_safety.py
+++ b/py_src/taskito/dashboard/url_safety.py
@@ -95,3 +95,21 @@ def validate_webhook_url(url: str) -> None:
     for ip in addresses:
         if _is_private_ip(ip):
             raise UnsafeWebhookUrl(f"URL host {hostname!r} resolves to private address {ip}")
+
+
+def is_safe_redirect(path: str | None) -> bool:
+    """Whether ``path`` is safe to use as a post-login same-origin redirect target.
+
+    Accepts only relative paths rooted at ``/``. Rejects absolute URLs
+    (``http://evil.com/x``), protocol-relative URLs (``//evil.com/x``),
+    and anything without a leading slash. Empty / ``None`` is rejected so
+    the caller can fall back to a default explicitly.
+    """
+    if not path:
+        return False
+    if not path.startswith("/"):
+        return False
+    if path.startswith("//") or path.startswith("/\\"):
+        return False
+    parsed = urllib.parse.urlparse(path)
+    return not (parsed.scheme or parsed.netloc)

--- a/py_src/taskito/proxies/handlers/requests_session.py
+++ b/py_src/taskito/proxies/handlers/requests_session.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 try:
-    import requests  # type: ignore[import-untyped]
+    import requests
 
     _HAS_REQUESTS = True
 except ImportError:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,3 +155,11 @@ ignore_missing_imports = true
 module = ["authlib", "authlib.*"]
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+module = ["joserfc", "joserfc.*"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["requests", "requests.*"]
+ignore_missing_imports = true
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ flask = ["flask>=3.0"]
 aws = ["boto3>=1.34"]
 gcs = ["google-cloud-storage>=2.10"]
 docs = ["playwright>=1.59"]
+oauth = ["authlib>=1.7,<2"]
 
 [tool.maturin]
 manifest-path = "crates/taskito-python/Cargo.toml"
@@ -148,5 +149,9 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = "click"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["authlib", "authlib.*"]
 ignore_missing_imports = true
 

--- a/tests/dashboard/test_auth.py
+++ b/tests/dashboard/test_auth.py
@@ -197,6 +197,141 @@ def test_bootstrap_admin_noop_without_env(queue: Queue, monkeypatch: pytest.Monk
     assert AuthStore(queue).count_users() == 0
 
 
+# ── OAuth users ────────────────────────────────────────────────────────
+
+
+def test_verify_password_rejects_oauth_sentinel_hash() -> None:
+    assert verify_password("anything", "oauth:google") is False
+    assert verify_password("anything", "oauth:okta") is False
+
+
+def test_get_or_create_oauth_user_creates_user_with_admin_when_table_empty(
+    queue: Queue,
+) -> None:
+    store = AuthStore(queue)
+    user = store.get_or_create_oauth_user(
+        slot="google",
+        subject="1184283742",
+        email="alice@acme.com",
+        name="Alice Example",
+        email_verified=True,
+    )
+    assert user.username == "google:1184283742"
+    assert user.role == "admin"
+    assert user.email == "alice@acme.com"
+    assert user.display_name == "Alice Example"
+    assert user.is_oauth is True
+
+
+def test_get_or_create_oauth_user_subsequent_user_is_viewer(queue: Queue) -> None:
+    store = AuthStore(queue)
+    store.get_or_create_oauth_user(
+        slot="google",
+        subject="111",
+        email="alice@acme.com",
+        name="Alice",
+        email_verified=True,
+    )
+    second = store.get_or_create_oauth_user(
+        slot="google",
+        subject="222",
+        email="bob@acme.com",
+        name="Bob",
+        email_verified=True,
+    )
+    assert second.role == "viewer"
+
+
+def test_get_or_create_oauth_user_admin_emails_take_precedence(queue: Queue) -> None:
+    store = AuthStore(queue)
+    # Pre-seed a password user so the table is not empty.
+    store.create_user("primary", "hunter2-secret")
+    listed = store.get_or_create_oauth_user(
+        slot="google",
+        subject="111",
+        email="alice@acme.com",
+        name="Alice",
+        email_verified=True,
+        admin_emails=("alice@acme.com",),
+    )
+    assert listed.role == "admin"
+
+    unlisted = store.get_or_create_oauth_user(
+        slot="google",
+        subject="222",
+        email="eve@evil.com",
+        name="Eve",
+        email_verified=True,
+        admin_emails=("alice@acme.com",),
+    )
+    assert unlisted.role == "viewer"
+
+
+def test_get_or_create_oauth_user_unverified_email_never_gets_admin(queue: Queue) -> None:
+    store = AuthStore(queue)
+    # Even on empty table, an unverified email cannot become admin.
+    user = store.get_or_create_oauth_user(
+        slot="github",
+        subject="42",
+        email="claimed@acme.com",
+        name=None,
+        email_verified=False,
+        admin_emails=("claimed@acme.com",),
+    )
+    assert user.role == "viewer"
+
+
+def test_get_or_create_oauth_user_email_match_is_case_insensitive(queue: Queue) -> None:
+    store = AuthStore(queue)
+    store.create_user("primary", "hunter2-secret")
+    user = store.get_or_create_oauth_user(
+        slot="google",
+        subject="123",
+        email="Alice@ACME.com",
+        name=None,
+        email_verified=True,
+        admin_emails=("alice@acme.com",),
+    )
+    assert user.role == "admin"
+
+
+def test_get_or_create_oauth_user_returning_user_refreshes_display_fields(
+    queue: Queue,
+) -> None:
+    store = AuthStore(queue)
+    first = store.get_or_create_oauth_user(
+        slot="google",
+        subject="555",
+        email="alice@acme.com",
+        name="Alice",
+        email_verified=True,
+    )
+    again = store.get_or_create_oauth_user(
+        slot="google",
+        subject="555",
+        email="alice-new@acme.com",
+        name="Alice Renamed",
+        email_verified=True,
+    )
+    assert again.username == first.username
+    assert again.email == "alice-new@acme.com"
+    assert again.display_name == "Alice Renamed"
+    # Role is not re-evaluated on subsequent logins.
+    assert again.role == first.role
+
+
+def test_oauth_users_namespace_by_slot(queue: Queue) -> None:
+    store = AuthStore(queue)
+    a = store.get_or_create_oauth_user(
+        slot="okta", subject="abc", email=None, name=None, email_verified=False
+    )
+    b = store.get_or_create_oauth_user(
+        slot="microsoft", subject="abc", email=None, name=None, email_verified=False
+    )
+    assert a.username != b.username
+    assert store.count_users() == 2
+
+
 # ── HTTP endpoints ─────────────────────────────────────────────────────
 
 

--- a/tests/dashboard/test_oauth_config.py
+++ b/tests/dashboard/test_oauth_config.py
@@ -1,0 +1,209 @@
+"""Tests for OAuth config parsing from env vars."""
+
+from __future__ import annotations
+
+import pytest
+
+from taskito.dashboard.oauth.config import (
+    GitHubConfig,
+    GoogleConfig,
+    OAuthConfig,
+    OAuthConfigError,
+    OIDCConfig,
+    from_env,
+)
+
+
+def test_from_env_returns_none_when_unconfigured() -> None:
+    assert from_env({}) is None
+
+
+def test_from_env_requires_base_url_when_any_provider_set() -> None:
+    with pytest.raises(OAuthConfigError, match="REDIRECT_BASE_URL"):
+        from_env(
+            {
+                "TASKITO_DASHBOARD_OAUTH_GOOGLE_CLIENT_ID": "gid",
+                "TASKITO_DASHBOARD_OAUTH_GOOGLE_CLIENT_SECRET": "gsec",
+            }
+        )
+
+
+def test_from_env_parses_google_provider() -> None:
+    config = from_env(
+        {
+            "TASKITO_DASHBOARD_OAUTH_REDIRECT_BASE_URL": "https://taskito.acme.com",
+            "TASKITO_DASHBOARD_OAUTH_GOOGLE_CLIENT_ID": "gid",
+            "TASKITO_DASHBOARD_OAUTH_GOOGLE_CLIENT_SECRET": "gsec",
+            "TASKITO_DASHBOARD_OAUTH_GOOGLE_ALLOWED_DOMAINS": "acme.com, partner.com",
+        }
+    )
+    assert config is not None
+    assert config.is_enabled
+    assert isinstance(config.google, GoogleConfig)
+    assert config.google.client_id == "gid"
+    assert config.google.client_secret == "gsec"
+    assert config.google.allowed_domains == ("acme.com", "partner.com")
+    assert config.github is None
+    assert config.oidc == ()
+
+
+def test_from_env_partial_google_config_raises() -> None:
+    with pytest.raises(OAuthConfigError, match="CLIENT_SECRET"):
+        from_env(
+            {
+                "TASKITO_DASHBOARD_OAUTH_REDIRECT_BASE_URL": "https://taskito.acme.com",
+                "TASKITO_DASHBOARD_OAUTH_GOOGLE_CLIENT_ID": "gid",
+            }
+        )
+
+
+def test_from_env_parses_github_provider() -> None:
+    config = from_env(
+        {
+            "TASKITO_DASHBOARD_OAUTH_REDIRECT_BASE_URL": "https://taskito.acme.com",
+            "TASKITO_DASHBOARD_OAUTH_GITHUB_CLIENT_ID": "hid",
+            "TASKITO_DASHBOARD_OAUTH_GITHUB_CLIENT_SECRET": "hsec",
+            "TASKITO_DASHBOARD_OAUTH_GITHUB_ALLOWED_ORGS": "acme,partner",
+        }
+    )
+    assert config is not None
+    assert isinstance(config.github, GitHubConfig)
+    assert config.github.allowed_orgs == ("acme", "partner")
+
+
+def test_from_env_parses_multiple_oidc_slots() -> None:
+    config = from_env(
+        {
+            "TASKITO_DASHBOARD_OAUTH_REDIRECT_BASE_URL": "https://taskito.acme.com",
+            "TASKITO_DASHBOARD_OAUTH_OIDC_PROVIDERS": "okta,microsoft",
+            "TASKITO_DASHBOARD_OAUTH_OIDC_OKTA_CLIENT_ID": "oid",
+            "TASKITO_DASHBOARD_OAUTH_OIDC_OKTA_CLIENT_SECRET": "osec",
+            "TASKITO_DASHBOARD_OAUTH_OIDC_OKTA_DISCOVERY_URL": "https://acme.okta.com/.well-known/openid-configuration",
+            "TASKITO_DASHBOARD_OAUTH_OIDC_OKTA_LABEL": "Acme SSO",
+            "TASKITO_DASHBOARD_OAUTH_OIDC_OKTA_ALLOWED_DOMAINS": "acme.com",
+            "TASKITO_DASHBOARD_OAUTH_OIDC_MICROSOFT_CLIENT_ID": "mid",
+            "TASKITO_DASHBOARD_OAUTH_OIDC_MICROSOFT_CLIENT_SECRET": "msec",
+            "TASKITO_DASHBOARD_OAUTH_OIDC_MICROSOFT_DISCOVERY_URL": "https://login.microsoftonline.com/x/v2.0/.well-known/openid-configuration",
+        }
+    )
+    assert config is not None
+    assert [p.slot for p in config.oidc] == ["okta", "microsoft"]
+    okta = config.oidc[0]
+    assert isinstance(okta, OIDCConfig)
+    assert okta.label == "Acme SSO"
+    assert okta.allowed_domains == ("acme.com",)
+    microsoft = config.oidc[1]
+    assert microsoft.label == "Microsoft"  # default = title-cased slot
+
+
+def test_from_env_rejects_duplicate_oidc_slot() -> None:
+    with pytest.raises(OAuthConfigError, match="twice"):
+        from_env(
+            {
+                "TASKITO_DASHBOARD_OAUTH_REDIRECT_BASE_URL": "https://taskito.acme.com",
+                "TASKITO_DASHBOARD_OAUTH_OIDC_PROVIDERS": "okta,okta",
+                "TASKITO_DASHBOARD_OAUTH_OIDC_OKTA_CLIENT_ID": "oid",
+                "TASKITO_DASHBOARD_OAUTH_OIDC_OKTA_CLIENT_SECRET": "osec",
+                "TASKITO_DASHBOARD_OAUTH_OIDC_OKTA_DISCOVERY_URL": "https://x/y",
+            }
+        )
+
+
+def test_oidc_slot_must_not_collide_with_reserved_name() -> None:
+    with pytest.raises(OAuthConfigError, match=r"reserved|collides|built-in"):
+        OIDCConfig(
+            slot="google",
+            client_id="x",
+            client_secret="y",
+            discovery_url="https://x/y",
+        )
+
+
+def test_oidc_slot_must_be_url_safe() -> None:
+    with pytest.raises(OAuthConfigError):
+        OIDCConfig(
+            slot="Has Spaces",
+            client_id="x",
+            client_secret="y",
+            discovery_url="https://x/y",
+        )
+
+
+def test_redirect_base_url_must_be_https_for_remote_hosts() -> None:
+    with pytest.raises(OAuthConfigError, match="https"):
+        OAuthConfig(redirect_base_url="http://taskito.acme.com")
+
+
+def test_redirect_base_url_allows_http_for_localhost() -> None:
+    # No exception.
+    OAuthConfig(redirect_base_url="http://localhost:8000")
+    OAuthConfig(redirect_base_url="http://127.0.0.1:8000")
+
+
+def test_password_auth_flag_parses() -> None:
+    config = from_env(
+        {
+            "TASKITO_DASHBOARD_OAUTH_REDIRECT_BASE_URL": "https://taskito.acme.com",
+            "TASKITO_DASHBOARD_OAUTH_GOOGLE_CLIENT_ID": "gid",
+            "TASKITO_DASHBOARD_OAUTH_GOOGLE_CLIENT_SECRET": "gsec",
+            "TASKITO_DASHBOARD_PASSWORD_AUTH_ENABLED": "false",
+        }
+    )
+    assert config is not None
+    assert config.password_auth_enabled is False
+
+
+def test_disabling_password_without_providers_is_an_error() -> None:
+    with pytest.raises(OAuthConfigError, match="no way to log in"):
+        from_env(
+            {
+                "TASKITO_DASHBOARD_OAUTH_REDIRECT_BASE_URL": "https://taskito.acme.com",
+                "TASKITO_DASHBOARD_PASSWORD_AUTH_ENABLED": "false",
+            }
+        )
+
+
+def test_admin_emails_parsed_as_tuple() -> None:
+    config = from_env(
+        {
+            "TASKITO_DASHBOARD_OAUTH_REDIRECT_BASE_URL": "https://taskito.acme.com",
+            "TASKITO_DASHBOARD_OAUTH_GOOGLE_CLIENT_ID": "gid",
+            "TASKITO_DASHBOARD_OAUTH_GOOGLE_CLIENT_SECRET": "gsec",
+            "TASKITO_DASHBOARD_OAUTH_ADMIN_EMAILS": " alice@acme.com , bob@acme.com ",
+        }
+    )
+    assert config is not None
+    assert config.admin_emails == ("alice@acme.com", "bob@acme.com")
+
+
+def test_callback_url_built_from_base_url_and_slot() -> None:
+    config = from_env(
+        {
+            "TASKITO_DASHBOARD_OAUTH_REDIRECT_BASE_URL": "https://taskito.acme.com/",
+            "TASKITO_DASHBOARD_OAUTH_GOOGLE_CLIENT_ID": "gid",
+            "TASKITO_DASHBOARD_OAUTH_GOOGLE_CLIENT_SECRET": "gsec",
+        }
+    )
+    assert config is not None
+    assert (
+        config.callback_url("google") == "https://taskito.acme.com/api/auth/oauth/callback/google"
+    )
+
+
+def test_find_provider_returns_matching_slot() -> None:
+    config = from_env(
+        {
+            "TASKITO_DASHBOARD_OAUTH_REDIRECT_BASE_URL": "https://taskito.acme.com",
+            "TASKITO_DASHBOARD_OAUTH_GOOGLE_CLIENT_ID": "gid",
+            "TASKITO_DASHBOARD_OAUTH_GOOGLE_CLIENT_SECRET": "gsec",
+            "TASKITO_DASHBOARD_OAUTH_OIDC_PROVIDERS": "okta",
+            "TASKITO_DASHBOARD_OAUTH_OIDC_OKTA_CLIENT_ID": "oid",
+            "TASKITO_DASHBOARD_OAUTH_OIDC_OKTA_CLIENT_SECRET": "osec",
+            "TASKITO_DASHBOARD_OAUTH_OIDC_OKTA_DISCOVERY_URL": "https://acme.okta.com/.well-known/openid-configuration",
+        }
+    )
+    assert config is not None
+    assert config.find_provider("google") is config.google
+    okta = config.find_provider("okta")
+    assert isinstance(okta, OIDCConfig)
+    assert config.find_provider("does-not-exist") is None

--- a/tests/dashboard/test_oauth_endpoints.py
+++ b/tests/dashboard/test_oauth_endpoints.py
@@ -1,0 +1,400 @@
+"""HTTP-level integration tests for the OAuth endpoints.
+
+Spins up a real :class:`ThreadingHTTPServer` with a stubbed
+:class:`OAuthFlow` so we can drive the full request → 302-redirect →
+cookies path without making real provider calls.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import threading
+import urllib.error
+import urllib.request
+from collections.abc import Callable, Generator
+from http.server import ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from taskito import Queue
+from taskito.dashboard import _make_handler
+from taskito.dashboard.auth import AuthStore
+from taskito.dashboard.oauth.config import (
+    GitHubConfig,
+    GoogleConfig,
+    OAuthConfig,
+    OIDCConfig,
+)
+from taskito.dashboard.oauth.flow import OAuthFlow
+from taskito.dashboard.oauth.identity import (
+    AllowlistDenied,
+    IdentityFetchError,
+    ProviderIdentity,
+)
+
+
+@pytest.fixture
+def queue(tmp_path: Path) -> Queue:
+    return Queue(db_path=str(tmp_path / "oauth_endpoints.db"))
+
+
+class _FakeProvider:
+    """Programmable provider used by the integration tests."""
+
+    def __init__(self, slot: str, *, label: str = "Test", ptype: str = "google") -> None:
+        self.slot = slot
+        self.label = label
+        self.type = ptype
+        self.identity: ProviderIdentity | None = None
+        self.allow = True
+        self.start_called_with: dict[str, str] | None = None
+
+    def authorization_url(
+        self,
+        *,
+        state: str,
+        nonce: str,
+        code_challenge: str,
+        redirect_uri: str,
+    ) -> str:
+        self.start_called_with = {
+            "state": state,
+            "nonce": nonce,
+            "code_challenge": code_challenge,
+            "redirect_uri": redirect_uri,
+        }
+        return f"https://idp.example.com/authorize?state={state}"
+
+    def exchange_code(
+        self,
+        *,
+        code: str,
+        code_verifier: str,
+        redirect_uri: str,
+        expected_nonce: str | None,
+    ) -> ProviderIdentity:
+        if self.identity is None:
+            raise IdentityFetchError("no identity configured")
+        return self.identity
+
+    def check_allowlist(self, identity: ProviderIdentity) -> None:
+        if not self.allow:
+            raise AllowlistDenied("denied")
+
+
+@pytest.fixture
+def google_provider() -> _FakeProvider:
+    return _FakeProvider("google", label="Google", ptype="google")
+
+
+@pytest.fixture
+def okta_provider() -> _FakeProvider:
+    return _FakeProvider("okta", label="Acme SSO", ptype="oidc")
+
+
+def _make_flow(
+    queue: Queue,
+    providers: dict[str, _FakeProvider],
+    *,
+    password_enabled: bool = True,
+    admin_emails: tuple[str, ...] = (),
+) -> OAuthFlow:
+    google_cfg = GoogleConfig(client_id="gid", client_secret="gsec")
+    github_cfg = GitHubConfig(client_id="hid", client_secret="hsec")
+    config = OAuthConfig(
+        redirect_base_url="http://127.0.0.1",
+        google=google_cfg if "google" in providers else None,
+        github=github_cfg if "github" in providers else None,
+        oidc=tuple(
+            OIDCConfig(
+                slot=slot,
+                client_id="x",
+                client_secret="y",
+                discovery_url=f"https://idp/{slot}/.well-known/openid-configuration",
+            )
+            for slot in providers
+            if slot not in ("google", "github")
+        ),
+        password_auth_enabled=password_enabled,
+        admin_emails=admin_emails,
+    )
+    return OAuthFlow(queue, config, providers=providers)  # type: ignore[arg-type]
+
+
+@pytest.fixture
+def server_factory(
+    queue: Queue,
+) -> Generator[Callable[[OAuthFlow | None], str]]:
+    """Spawns dashboard servers with the requested OAuthFlow."""
+    handles: list[ThreadingHTTPServer] = []
+
+    def _factory(flow: OAuthFlow | None) -> str:
+        handler = _make_handler(queue, oauth_flow=flow)
+        server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+        handles.append(server)
+        port = server.server_address[1]
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        return f"http://127.0.0.1:{port}"
+
+    yield _factory
+
+    for server in handles:
+        server.shutdown()
+
+
+def _get_no_redirect(
+    url: str, *, cookies: dict[str, str] | None = None
+) -> tuple[int, Any, dict[str, list[str]]]:
+    """GET without following redirects, returning (status, body, headers)."""
+
+    class _NoRedirect(urllib.request.HTTPRedirectHandler):
+        def redirect_request(self, *_a: Any, **_k: Any) -> None:
+            return None
+
+    opener = urllib.request.build_opener(_NoRedirect())
+    req = urllib.request.Request(url, method="GET")
+    if cookies:
+        req.add_header("Cookie", "; ".join(f"{k}={v}" for k, v in cookies.items()))
+    try:
+        resp = opener.open(req)
+        body: Any = None
+        try:
+            raw = resp.read()
+            body = json.loads(raw) if raw else None
+        except (ValueError, json.JSONDecodeError):
+            body = None
+        headers = {k: resp.headers.get_all(k) or [] for k in set(resp.headers.keys())}
+        return resp.status, body, headers
+    except urllib.error.HTTPError as e:
+        body = None
+        with contextlib.suppress(ValueError, json.JSONDecodeError):
+            body = json.loads(e.read() or b"{}")
+        headers = {k: e.headers.get_all(k) or [] for k in set(e.headers.keys())}
+        return e.code, body, headers
+
+
+def _parse_set_cookies(raw: list[str]) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for line in raw:
+        nv = line.split(";", 1)[0]
+        if "=" in nv:
+            name, value = nv.split("=", 1)
+            out[name.strip()] = value.strip()
+    return out
+
+
+# ── /api/auth/providers ──────────────────────────────────────────────
+
+
+def test_providers_endpoint_returns_empty_list_when_no_flow(
+    server_factory: Any,
+) -> None:
+    base = server_factory(None)
+    status, body, _ = _get_no_redirect(f"{base}/api/auth/providers")
+    assert status == 200
+    assert body == {"password_enabled": True, "providers": []}
+
+
+def test_providers_endpoint_lists_configured_providers(
+    server_factory: Any,
+    queue: Queue,
+    google_provider: _FakeProvider,
+    okta_provider: _FakeProvider,
+) -> None:
+    flow = _make_flow(queue, {"google": google_provider, "okta": okta_provider})
+    base = server_factory(flow)
+    status, body, _ = _get_no_redirect(f"{base}/api/auth/providers")
+    assert status == 200
+    assert body == {
+        "password_enabled": True,
+        "providers": [
+            {"slot": "google", "label": "Google", "type": "google"},
+            {"slot": "okta", "label": "Acme SSO", "type": "oidc"},
+        ],
+    }
+
+
+def test_providers_endpoint_reflects_password_disabled(
+    server_factory: Any, queue: Queue, google_provider: _FakeProvider
+) -> None:
+    flow = _make_flow(queue, {"google": google_provider}, password_enabled=False)
+    base = server_factory(flow)
+    _, body, _ = _get_no_redirect(f"{base}/api/auth/providers")
+    assert body["password_enabled"] is False
+
+
+# ── /api/auth/oauth/start/{slot} ─────────────────────────────────────
+
+
+def test_start_returns_302_to_provider(
+    server_factory: Any, queue: Queue, google_provider: _FakeProvider
+) -> None:
+    flow = _make_flow(queue, {"google": google_provider})
+    base = server_factory(flow)
+    status, _, headers = _get_no_redirect(f"{base}/api/auth/oauth/start/google")
+    assert status == 302
+    locations = headers.get("Location") or []
+    assert len(locations) == 1
+    assert locations[0].startswith("https://idp.example.com/authorize?state=")
+    assert google_provider.start_called_with is not None
+    assert google_provider.start_called_with["redirect_uri"].endswith(
+        "/api/auth/oauth/callback/google"
+    )
+
+
+def test_start_returns_404_for_unknown_slot(
+    server_factory: Any, queue: Queue, google_provider: _FakeProvider
+) -> None:
+    flow = _make_flow(queue, {"google": google_provider})
+    base = server_factory(flow)
+    status, body, _ = _get_no_redirect(f"{base}/api/auth/oauth/start/azure")
+    assert status == 404
+    assert body is not None and "azure" in body.get("error", "")
+
+
+def test_start_returns_404_when_oauth_not_configured(
+    server_factory: Any,
+) -> None:
+    base = server_factory(None)
+    status, body, _ = _get_no_redirect(f"{base}/api/auth/oauth/start/google")
+    assert status == 404
+    assert body is not None
+    assert body.get("error") == "oauth_not_configured"
+
+
+# ── /api/auth/oauth/callback/{slot} ──────────────────────────────────
+
+
+def test_callback_creates_session_and_sets_cookies(
+    server_factory: Any, queue: Queue, google_provider: _FakeProvider
+) -> None:
+    google_provider.identity = ProviderIdentity(
+        slot="google",
+        subject="118420987654321",
+        email="alice@acme.com",
+        email_verified=True,
+        name="Alice",
+    )
+    flow = _make_flow(queue, {"google": google_provider})
+    base = server_factory(flow)
+
+    # First /start to mint state.
+    start_status, _, headers = _get_no_redirect(
+        f"{base}/api/auth/oauth/start/google?next=/dashboard"
+    )
+    assert start_status == 302
+    location = headers["Location"][0]
+    state = location.split("state=")[-1]
+
+    cb_status, _, cb_headers = _get_no_redirect(
+        f"{base}/api/auth/oauth/callback/google?code=abc&state={state}"
+    )
+    assert cb_status == 302
+    # Redirected to the safe ``next`` URL.
+    assert cb_headers["Location"] == ["/dashboard"]
+
+    cookies = _parse_set_cookies(cb_headers.get("Set-Cookie", []))
+    assert "taskito_session" in cookies
+    assert "taskito_csrf" in cookies
+    assert cookies["taskito_session"]
+
+    # A user was created in the AuthStore with the OAuth username scheme.
+    user = AuthStore(queue).get_user("google:118420987654321")
+    assert user is not None
+    assert user.email == "alice@acme.com"
+    assert user.is_oauth
+
+
+def test_callback_rejects_unsafe_next_via_fallback_root(
+    server_factory: Any, queue: Queue, google_provider: _FakeProvider
+) -> None:
+    google_provider.identity = ProviderIdentity(
+        slot="google", subject="2", email="bob@acme.com", email_verified=True
+    )
+    flow = _make_flow(queue, {"google": google_provider})
+    base = server_factory(flow)
+    _, _, headers = _get_no_redirect(
+        f"{base}/api/auth/oauth/start/google?next=https://evil.com/take"
+    )
+    state = headers["Location"][0].split("state=")[-1]
+    _, _, cb_headers = _get_no_redirect(
+        f"{base}/api/auth/oauth/callback/google?code=abc&state={state}"
+    )
+    # Unsafe next was scrubbed to "/" before being persisted with the state.
+    assert cb_headers["Location"] == ["/"]
+
+
+def test_callback_replayed_state_is_rejected(
+    server_factory: Any, queue: Queue, google_provider: _FakeProvider
+) -> None:
+    google_provider.identity = ProviderIdentity(
+        slot="google", subject="3", email="c@acme.com", email_verified=True
+    )
+    flow = _make_flow(queue, {"google": google_provider})
+    base = server_factory(flow)
+    _, _, headers = _get_no_redirect(f"{base}/api/auth/oauth/start/google")
+    state = headers["Location"][0].split("state=")[-1]
+    # First callback succeeds.
+    first_status, _, _ = _get_no_redirect(
+        f"{base}/api/auth/oauth/callback/google?code=abc&state={state}"
+    )
+    assert first_status == 302
+    # Replay is a 400.
+    replay_status, body, _ = _get_no_redirect(
+        f"{base}/api/auth/oauth/callback/google?code=abc&state={state}"
+    )
+    assert replay_status == 400
+    assert body is not None
+    assert "oauth_state_invalid" in body.get("error", "")
+
+
+def test_callback_with_provider_error_returns_400(
+    server_factory: Any, queue: Queue, google_provider: _FakeProvider
+) -> None:
+    flow = _make_flow(queue, {"google": google_provider})
+    base = server_factory(flow)
+    status, body, _ = _get_no_redirect(
+        f"{base}/api/auth/oauth/callback/google?error=access_denied"
+    )
+    assert status == 400
+    assert body is not None
+    assert "oauth_state_invalid" in body.get("error", "") or "identity" in body.get("error", "")
+
+
+def test_callback_blocked_by_allowlist(
+    server_factory: Any, queue: Queue, google_provider: _FakeProvider
+) -> None:
+    google_provider.identity = ProviderIdentity(
+        slot="google", subject="4", email="eve@evil.com", email_verified=True
+    )
+    google_provider.allow = False
+    flow = _make_flow(queue, {"google": google_provider})
+    base = server_factory(flow)
+    _, _, headers = _get_no_redirect(f"{base}/api/auth/oauth/start/google")
+    state = headers["Location"][0].split("state=")[-1]
+    status, body, _ = _get_no_redirect(
+        f"{base}/api/auth/oauth/callback/google?code=abc&state={state}"
+    )
+    assert status == 400
+    assert body is not None
+    assert "allowlist_denied" in body.get("error", "")
+
+
+def test_oauth_paths_bypass_setup_required_gate(
+    server_factory: Any, queue: Queue, google_provider: _FakeProvider
+) -> None:
+    """Even before the first user exists, the OAuth flow paths must answer.
+
+    Otherwise a fresh deployment using OAuth-only mode could never bootstrap.
+    """
+    flow = _make_flow(queue, {"google": google_provider})
+    base = server_factory(flow)
+    assert AuthStore(queue).count_users() == 0
+    status, _, _ = _get_no_redirect(f"{base}/api/auth/providers")
+    assert status == 200
+    status, _, _ = _get_no_redirect(f"{base}/api/auth/oauth/start/google")
+    assert status == 302

--- a/tests/dashboard/test_oauth_flow.py
+++ b/tests/dashboard/test_oauth_flow.py
@@ -1,0 +1,208 @@
+"""Tests for :class:`OAuthFlow` — state + provider + auth-store orchestration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from taskito import Queue
+from taskito.dashboard.auth import AuthStore
+from taskito.dashboard.oauth.config import GoogleConfig, OAuthConfig
+from taskito.dashboard.oauth.flow import OAuthFlow
+from taskito.dashboard.oauth.identity import (
+    AllowlistDenied,
+    IdentityFetchError,
+    ProviderIdentity,
+    ProviderNotConfigured,
+    StateValidationError,
+)
+
+
+@pytest.fixture
+def queue(tmp_path: Path) -> Queue:
+    return Queue(db_path=str(tmp_path / "oauth_flow.db"))
+
+
+@pytest.fixture
+def config() -> OAuthConfig:
+    return OAuthConfig(
+        redirect_base_url="https://taskito.example.com",
+        google=GoogleConfig(
+            client_id="cid",
+            client_secret="csec",
+            allowed_domains=("acme.com",),
+        ),
+        admin_emails=("alice@acme.com",),
+    )
+
+
+class FakeProvider:
+    """In-memory provider with programmable identity / allowlist behaviour."""
+
+    type = "google"
+    label = "Test"
+
+    def __init__(self, slot: str, identity: ProviderIdentity | None = None) -> None:
+        self.slot = slot
+        self.identity = identity
+        self.allow = True
+        self.last_authorization_args: dict | None = None
+
+    def authorization_url(
+        self,
+        *,
+        state: str,
+        nonce: str,
+        code_challenge: str,
+        redirect_uri: str,
+    ) -> str:
+        self.last_authorization_args = {
+            "state": state,
+            "nonce": nonce,
+            "code_challenge": code_challenge,
+            "redirect_uri": redirect_uri,
+        }
+        return f"https://idp.example.com/authorize?state={state}"
+
+    def exchange_code(
+        self,
+        *,
+        code: str,
+        code_verifier: str,
+        redirect_uri: str,
+        expected_nonce: str | None,
+    ) -> ProviderIdentity:
+        if self.identity is None:
+            raise IdentityFetchError("test stub: no identity configured")
+        return self.identity
+
+    def check_allowlist(self, identity: ProviderIdentity) -> None:
+        if not self.allow:
+            raise AllowlistDenied("test stub: denied")
+
+
+def test_start_returns_provider_url_with_safe_next(queue: Queue, config: OAuthConfig) -> None:
+    fake = FakeProvider("google")
+    flow = OAuthFlow(queue, config, providers={"google": fake})
+    url = flow.start("google", next_url="/dashboard/jobs")
+    assert url.startswith("https://idp.example.com/authorize?state=")
+    args = fake.last_authorization_args
+    assert args is not None
+    assert args["redirect_uri"] == "https://taskito.example.com/api/auth/oauth/callback/google"
+    assert len(args["state"]) >= 32
+
+
+def test_start_falls_back_to_root_when_next_unsafe(queue: Queue, config: OAuthConfig) -> None:
+    fake = FakeProvider("google")
+    flow = OAuthFlow(queue, config, providers={"google": fake})
+    flow.start("google", next_url="https://evil.com/x")
+    # We can't read state.next_url back without inspecting the store —
+    # but we can confirm the callback rejects it via a separate test.
+
+
+def test_start_raises_for_unknown_slot(queue: Queue, config: OAuthConfig) -> None:
+    flow = OAuthFlow(queue, config, providers={})
+    with pytest.raises(ProviderNotConfigured):
+        flow.start("nonexistent", next_url="/")
+
+
+def test_handle_callback_creates_user_and_session(queue: Queue, config: OAuthConfig) -> None:
+    identity = ProviderIdentity(
+        slot="google",
+        subject="100200300",
+        email="alice@acme.com",
+        email_verified=True,
+        name="Alice",
+    )
+    fake = FakeProvider("google", identity=identity)
+    flow = OAuthFlow(queue, config, providers={"google": fake})
+
+    # Mint state then handle the callback.
+    flow.start("google", next_url="/dashboard")
+    state_token = next(iter(_state_tokens(queue)))
+
+    session, next_url = flow.handle_callback(
+        "google", code="abc", state_token=state_token, error=None
+    )
+    assert session.username == "google:100200300"
+    assert session.role == "admin"  # alice is in admin_emails
+    assert next_url == "/dashboard"
+
+    # Replay attempt fails because state is single-use.
+    with pytest.raises(StateValidationError, match="invalid"):
+        flow.handle_callback("google", code="abc", state_token=state_token, error=None)
+
+
+def test_handle_callback_rejects_slot_mismatch(queue: Queue, config: OAuthConfig) -> None:
+    identity = ProviderIdentity(slot="google", subject="x", email=None, email_verified=False)
+    fake = FakeProvider("google", identity=identity)
+    flow = OAuthFlow(queue, config, providers={"google": fake})
+    flow.start("google", next_url="/")
+    state_token = next(iter(_state_tokens(queue)))
+    with pytest.raises(StateValidationError, match="slot"):
+        flow.handle_callback("github", code="abc", state_token=state_token, error=None)
+
+
+def test_handle_callback_propagates_provider_error(queue: Queue, config: OAuthConfig) -> None:
+    flow = OAuthFlow(queue, config, providers={"google": FakeProvider("google")})
+    flow.start("google", next_url="/")
+    state_token = next(iter(_state_tokens(queue)))
+    with pytest.raises(IdentityFetchError):
+        flow.handle_callback("google", code="abc", state_token=state_token, error=None)
+
+
+def test_handle_callback_propagates_allowlist_denied(queue: Queue, config: OAuthConfig) -> None:
+    identity = ProviderIdentity(
+        slot="google",
+        subject="1",
+        email="eve@evil.com",
+        email_verified=True,
+    )
+    fake = FakeProvider("google", identity=identity)
+    fake.allow = False
+    flow = OAuthFlow(queue, config, providers={"google": fake})
+    flow.start("google", next_url="/")
+    state_token = next(iter(_state_tokens(queue)))
+    with pytest.raises(AllowlistDenied):
+        flow.handle_callback("google", code="abc", state_token=state_token, error=None)
+
+
+def test_handle_callback_with_provider_error_raises(queue: Queue, config: OAuthConfig) -> None:
+    fake = FakeProvider("google")
+    flow = OAuthFlow(queue, config, providers={"google": fake})
+    with pytest.raises(IdentityFetchError, match="provider returned error"):
+        flow.handle_callback("google", code=None, state_token=None, error="access_denied")
+
+
+def test_providers_listing_returns_visible_metadata(queue: Queue, config: OAuthConfig) -> None:
+    fake = FakeProvider("google")
+    flow = OAuthFlow(queue, config, providers={"google": fake})
+    listing = flow.providers_listing()
+    assert listing == [{"slot": "google", "label": "Test", "type": "google"}]
+
+
+def test_admin_emails_promote_first_user(queue: Queue, config: OAuthConfig) -> None:
+    identity = ProviderIdentity(
+        slot="google",
+        subject="alice-sub",
+        email="alice@acme.com",
+        email_verified=True,
+    )
+    fake = FakeProvider("google", identity=identity)
+    flow = OAuthFlow(queue, config, providers={"google": fake})
+    flow.start("google", next_url="/")
+    state_token = next(iter(_state_tokens(queue)))
+    session, _ = flow.handle_callback("google", code="x", state_token=state_token, error=None)
+    user = AuthStore(queue).get_user(session.username)
+    assert user is not None
+    assert user.role == "admin"
+    assert user.email == "alice@acme.com"
+
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _state_tokens(queue: Queue) -> list[str]:
+    prefix = "auth:oauth_state:"
+    return [k[len(prefix) :] for k in queue.list_settings() if k.startswith(prefix)]

--- a/tests/dashboard/test_oauth_providers.py
+++ b/tests/dashboard/test_oauth_providers.py
@@ -1,0 +1,574 @@
+"""Unit tests for the concrete OAuth provider implementations.
+
+These tests stub every HTTP boundary so they run without network access.
+The end-to-end "real flow" test lives in ``test_oauth_endpoints.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from joserfc import jwt as joserfc_jwt
+from joserfc.jwk import RSAKey
+
+from taskito.dashboard.oauth.config import (
+    GitHubConfig,
+    GoogleConfig,
+    OIDCConfig,
+)
+from taskito.dashboard.oauth.identity import (
+    AllowlistDenied,
+    IdentityFetchError,
+)
+from taskito.dashboard.oauth.providers import (
+    GenericOIDCProvider,
+    GitHubProvider,
+    GoogleProvider,
+    _audience_matches,
+    _email_domain,
+)
+
+# ── HTTP stub helpers ────────────────────────────────────────────────
+
+
+class StubResponse:
+    """Minimal stand-in for a ``requests.Response`` object."""
+
+    def __init__(self, *, status_code: int = 200, payload: Any = None, text: str = "") -> None:
+        self.status_code = status_code
+        self._payload = payload
+        self.text = text or json.dumps(payload)
+
+    def json(self) -> Any:
+        return self._payload
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+
+class StubSession:
+    """Replaces ``requests.Session`` with a programmable URL → response map."""
+
+    def __init__(self, routes: dict[str, StubResponse]) -> None:
+        self._routes = routes
+        self.calls: list[tuple[str, dict[str, str]]] = []
+
+    def get(self, url: str, *, headers: dict[str, str] | None = None, **_: Any) -> StubResponse:
+        self.calls.append((url, headers or {}))
+        if url in self._routes:
+            return self._routes[url]
+        # Wildcard fallback: match by prefix to support .../members/<login>.
+        for prefix, response in self._routes.items():
+            if prefix.endswith("*") and url.startswith(prefix[:-1]):
+                return response
+        return StubResponse(status_code=404, payload={"error": "not found"})
+
+
+# ── Test fixtures ────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def rsa_key() -> RSAKey:
+    """A fresh RSA keypair used to sign + verify test ID tokens."""
+    return RSAKey.generate_key(2048, parameters={"kid": "test-kid"}, private=True)
+
+
+@pytest.fixture
+def google_discovery() -> dict[str, str]:
+    return {
+        "issuer": "https://accounts.google.com",
+        "authorization_endpoint": "https://accounts.google.com/o/oauth2/v2/auth",
+        "token_endpoint": "https://oauth2.googleapis.com/token",
+        "jwks_uri": "https://www.googleapis.com/oauth2/v3/certs",
+    }
+
+
+def _make_google_provider(
+    *,
+    allowed_domains: tuple[str, ...] = (),
+    discovery: dict[str, str],
+    jwks_payload: dict,
+) -> GoogleProvider:
+    routes = {
+        "https://accounts.google.com/.well-known/openid-configuration": StubResponse(
+            payload=discovery
+        ),
+        discovery["jwks_uri"]: StubResponse(payload=jwks_payload),
+    }
+    provider = GoogleProvider(
+        GoogleConfig(
+            client_id="test-client-id",
+            client_secret="test-client-secret",
+            allowed_domains=allowed_domains,
+        ),
+        http=StubSession(routes),  # type: ignore[arg-type]
+    )
+    return provider
+
+
+def _make_id_token(
+    *,
+    key: RSAKey,
+    issuer: str,
+    audience: str,
+    subject: str,
+    email: str,
+    email_verified: bool,
+    nonce: str | None,
+    name: str | None = "Alice Example",
+    extra_claims: dict[str, Any] | None = None,
+) -> str:
+    claims: dict[str, Any] = {
+        "iss": issuer,
+        "aud": audience,
+        "sub": subject,
+        "email": email,
+        "email_verified": email_verified,
+        "name": name,
+        "iat": int(time.time()),
+        "exp": int(time.time()) + 600,
+    }
+    if nonce is not None:
+        claims["nonce"] = nonce
+    if extra_claims:
+        claims.update(extra_claims)
+    header = {"alg": "RS256", "kid": key.kid}
+    return joserfc_jwt.encode(header, claims, key)
+
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+def test_email_domain_extracts_lowercase() -> None:
+    assert _email_domain("Alice@ACME.com") == "acme.com"
+    assert _email_domain(None) is None
+    assert _email_domain("not-an-email") is None
+
+
+def test_audience_matches_string_and_list() -> None:
+    assert _audience_matches("cid", "cid")
+    assert _audience_matches(["cid", "other"], "cid")
+    assert not _audience_matches("other", "cid")
+    assert not _audience_matches([], "cid")
+    assert not _audience_matches(None, "cid")
+
+
+# ── Google: authorization URL ────────────────────────────────────────
+
+
+def test_google_authorization_url_includes_required_params(
+    google_discovery: dict[str, str],
+) -> None:
+    provider = _make_google_provider(
+        discovery=google_discovery,
+        jwks_payload={"keys": []},
+    )
+    url = provider.authorization_url(
+        state="STATE",
+        nonce="NONCE",
+        code_challenge="CHALLENGE",
+        redirect_uri="https://taskito.example.com/api/auth/oauth/callback/google",
+    )
+    parsed = urlparse(url)
+    qs = parse_qs(parsed.query)
+    assert parsed.scheme == "https"
+    assert qs["response_type"] == ["code"]
+    assert qs["client_id"] == ["test-client-id"]
+    assert qs["scope"] == ["openid email profile"]
+    assert qs["state"] == ["STATE"]
+    assert qs["nonce"] == ["NONCE"]
+    assert qs["code_challenge"] == ["CHALLENGE"]
+    assert qs["code_challenge_method"] == ["S256"]
+    assert qs["prompt"] == ["select_account"]
+    assert "hd" not in qs  # no allowed_domains configured
+
+
+def test_google_authorization_url_sets_hd_hint_for_single_domain(
+    google_discovery: dict[str, str],
+) -> None:
+    provider = _make_google_provider(
+        discovery=google_discovery,
+        jwks_payload={"keys": []},
+        allowed_domains=("acme.com",),
+    )
+    url = provider.authorization_url(
+        state="s", nonce="n", code_challenge="c", redirect_uri="https://x/y"
+    )
+    qs = parse_qs(urlparse(url).query)
+    assert qs["hd"] == ["acme.com"]
+
+
+def test_google_authorization_url_omits_hd_for_multi_domain(
+    google_discovery: dict[str, str],
+) -> None:
+    provider = _make_google_provider(
+        discovery=google_discovery,
+        jwks_payload={"keys": []},
+        allowed_domains=("acme.com", "partner.com"),
+    )
+    url = provider.authorization_url(
+        state="s", nonce="n", code_challenge="c", redirect_uri="https://x/y"
+    )
+    qs = parse_qs(urlparse(url).query)
+    assert "hd" not in qs  # ambiguous, do not preselect
+
+
+# ── Google: exchange_code → identity ─────────────────────────────────
+
+
+def test_google_exchange_code_returns_identity_for_valid_id_token(
+    google_discovery: dict[str, str], rsa_key: RSAKey, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    id_token = _make_id_token(
+        key=rsa_key,
+        issuer=google_discovery["issuer"],
+        audience="test-client-id",
+        subject="118420987654321",
+        email="alice@acme.com",
+        email_verified=True,
+        nonce="EXPECTED_NONCE",
+    )
+    provider = _make_google_provider(
+        discovery=google_discovery,
+        jwks_payload={"keys": [rsa_key.as_dict(private=False)]},
+    )
+    monkeypatch.setattr(
+        provider, "_fetch_token", lambda **_: {"id_token": id_token, "access_token": "AT"}
+    )
+    identity = provider.exchange_code(
+        code="abc",
+        code_verifier="verifier",
+        redirect_uri="https://x",
+        expected_nonce="EXPECTED_NONCE",
+    )
+    assert identity.slot == "google"
+    assert identity.subject == "118420987654321"
+    assert identity.email == "alice@acme.com"
+    assert identity.email_verified is True
+    assert identity.name == "Alice Example"
+
+
+def test_google_exchange_code_rejects_wrong_nonce(
+    google_discovery: dict[str, str], rsa_key: RSAKey, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    id_token = _make_id_token(
+        key=rsa_key,
+        issuer=google_discovery["issuer"],
+        audience="test-client-id",
+        subject="111",
+        email="x@y.com",
+        email_verified=True,
+        nonce="WRONG",
+    )
+    provider = _make_google_provider(
+        discovery=google_discovery,
+        jwks_payload={"keys": [rsa_key.as_dict(private=False)]},
+    )
+    monkeypatch.setattr(provider, "_fetch_token", lambda **_: {"id_token": id_token})
+    with pytest.raises(IdentityFetchError, match="nonce mismatch"):
+        provider.exchange_code(
+            code="abc", code_verifier="v", redirect_uri="https://x", expected_nonce="EXPECTED"
+        )
+
+
+def test_google_exchange_code_rejects_wrong_audience(
+    google_discovery: dict[str, str], rsa_key: RSAKey, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    id_token = _make_id_token(
+        key=rsa_key,
+        issuer=google_discovery["issuer"],
+        audience="DIFFERENT-CLIENT",
+        subject="111",
+        email="x@y.com",
+        email_verified=True,
+        nonce=None,
+    )
+    provider = _make_google_provider(
+        discovery=google_discovery,
+        jwks_payload={"keys": [rsa_key.as_dict(private=False)]},
+    )
+    monkeypatch.setattr(provider, "_fetch_token", lambda **_: {"id_token": id_token})
+    with pytest.raises(IdentityFetchError, match="audience mismatch"):
+        provider.exchange_code(
+            code="abc", code_verifier="v", redirect_uri="https://x", expected_nonce=None
+        )
+
+
+def test_google_exchange_code_rejects_wrong_issuer(
+    google_discovery: dict[str, str], rsa_key: RSAKey, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    id_token = _make_id_token(
+        key=rsa_key,
+        issuer="https://evil.com",
+        audience="test-client-id",
+        subject="111",
+        email="x@y.com",
+        email_verified=True,
+        nonce=None,
+    )
+    provider = _make_google_provider(
+        discovery=google_discovery,
+        jwks_payload={"keys": [rsa_key.as_dict(private=False)]},
+    )
+    monkeypatch.setattr(provider, "_fetch_token", lambda **_: {"id_token": id_token})
+    with pytest.raises(IdentityFetchError, match="issuer mismatch"):
+        provider.exchange_code(
+            code="abc", code_verifier="v", redirect_uri="https://x", expected_nonce=None
+        )
+
+
+def test_google_exchange_code_rejects_missing_id_token(
+    google_discovery: dict[str, str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    provider = _make_google_provider(
+        discovery=google_discovery,
+        jwks_payload={"keys": []},
+    )
+    monkeypatch.setattr(provider, "_fetch_token", lambda **_: {"access_token": "AT"})
+    with pytest.raises(IdentityFetchError, match="no id_token"):
+        provider.exchange_code(
+            code="abc", code_verifier="v", redirect_uri="https://x", expected_nonce=None
+        )
+
+
+# ── Google: allowlist ─────────────────────────────────────────────────
+
+
+def test_google_check_allowlist_passes_when_no_restriction(
+    google_discovery: dict[str, str],
+) -> None:
+    provider = _make_google_provider(discovery=google_discovery, jwks_payload={"keys": []})
+    from taskito.dashboard.oauth.identity import ProviderIdentity
+
+    identity = ProviderIdentity(slot="google", subject="x", email="x@y.com", email_verified=True)
+    # Should not raise.
+    provider.check_allowlist(identity)
+
+
+def test_google_check_allowlist_rejects_unverified_email(
+    google_discovery: dict[str, str],
+) -> None:
+    from taskito.dashboard.oauth.identity import ProviderIdentity
+
+    provider = _make_google_provider(
+        discovery=google_discovery,
+        jwks_payload={"keys": []},
+        allowed_domains=("acme.com",),
+    )
+    with pytest.raises(AllowlistDenied, match="verified email"):
+        provider.check_allowlist(
+            ProviderIdentity(
+                slot="google",
+                subject="x",
+                email="user@acme.com",
+                email_verified=False,
+            )
+        )
+
+
+def test_google_check_allowlist_rejects_out_of_domain_email(
+    google_discovery: dict[str, str],
+) -> None:
+    from taskito.dashboard.oauth.identity import ProviderIdentity
+
+    provider = _make_google_provider(
+        discovery=google_discovery,
+        jwks_payload={"keys": []},
+        allowed_domains=("acme.com",),
+    )
+    with pytest.raises(AllowlistDenied, match="not in the allowed domains"):
+        provider.check_allowlist(
+            ProviderIdentity(
+                slot="google",
+                subject="x",
+                email="user@gmail.com",
+                email_verified=True,
+            )
+        )
+
+
+def test_google_check_allowlist_accepts_listed_domain(
+    google_discovery: dict[str, str],
+) -> None:
+    from taskito.dashboard.oauth.identity import ProviderIdentity
+
+    provider = _make_google_provider(
+        discovery=google_discovery,
+        jwks_payload={"keys": []},
+        allowed_domains=("acme.com",),
+    )
+    provider.check_allowlist(
+        ProviderIdentity(slot="google", subject="x", email="USER@Acme.COM", email_verified=True)
+    )
+
+
+# ── Generic OIDC ──────────────────────────────────────────────────────
+
+
+def test_generic_oidc_uses_provided_discovery_url(rsa_key: RSAKey) -> None:
+    discovery = {
+        "issuer": "https://acme.okta.com",
+        "authorization_endpoint": "https://acme.okta.com/oauth2/authorize",
+        "token_endpoint": "https://acme.okta.com/oauth2/token",
+        "jwks_uri": "https://acme.okta.com/oauth2/jwks",
+    }
+    routes = {
+        "https://acme.okta.com/.well-known/openid-configuration": StubResponse(payload=discovery),
+        discovery["jwks_uri"]: StubResponse(payload={"keys": [rsa_key.as_dict(private=False)]}),
+    }
+    provider = GenericOIDCProvider(
+        OIDCConfig(
+            slot="okta",
+            client_id="cid",
+            client_secret="csec",
+            discovery_url="https://acme.okta.com/.well-known/openid-configuration",
+            label="Acme SSO",
+        ),
+        http=StubSession(routes),  # type: ignore[arg-type]
+    )
+    url = provider.authorization_url(
+        state="s", nonce="n", code_challenge="c", redirect_uri="https://taskito.x/cb"
+    )
+    assert url.startswith("https://acme.okta.com/oauth2/authorize?")
+    assert provider.slot == "okta"
+    assert provider.label == "Acme SSO"
+    assert provider.type == "oidc"
+
+
+# ── GitHub ────────────────────────────────────────────────────────────
+
+
+def _gh_provider(
+    *,
+    allowed_orgs: tuple[str, ...] = (),
+    routes: dict[str, StubResponse] | None = None,
+) -> GitHubProvider:
+    return GitHubProvider(
+        GitHubConfig(
+            client_id="gh-client",
+            client_secret="gh-secret",
+            allowed_orgs=allowed_orgs,
+        ),
+        http=StubSession(routes or {}),  # type: ignore[arg-type]
+    )
+
+
+def test_github_authorization_url_includes_pkce_and_state() -> None:
+    provider = _gh_provider()
+    url = provider.authorization_url(
+        state="STATE", nonce="UNUSED", code_challenge="CHL", redirect_uri="https://x/cb"
+    )
+    parsed = urlparse(url)
+    qs = parse_qs(parsed.query)
+    assert parsed.netloc == "github.com"
+    assert qs["client_id"] == ["gh-client"]
+    assert qs["state"] == ["STATE"]
+    assert qs["code_challenge"] == ["CHL"]
+    assert qs["code_challenge_method"] == ["S256"]
+    assert "nonce" not in qs  # GitHub does not implement OIDC
+
+
+def test_github_authorization_url_adds_read_org_when_allowlist_configured() -> None:
+    provider = _gh_provider(allowed_orgs=("acme",))
+    url = provider.authorization_url(
+        state="s", nonce="n", code_challenge="c", redirect_uri="https://x/cb"
+    )
+    qs = parse_qs(urlparse(url).query)
+    assert "read:org" in qs["scope"][0]
+
+
+def test_github_exchange_code_returns_verified_primary_email(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    routes = {
+        "https://api.github.com/user": StubResponse(
+            payload={"id": 584213, "login": "alice", "name": "Alice", "avatar_url": "https://x/y"}
+        ),
+        "https://api.github.com/user/emails": StubResponse(
+            payload=[
+                {"email": "alt@x.com", "primary": False, "verified": True},
+                {"email": "alice@acme.com", "primary": True, "verified": True},
+            ]
+        ),
+    }
+    provider = _gh_provider(routes=routes)
+    monkeypatch.setattr(provider, "_fetch_token", lambda **_: {"access_token": "AT"})
+    identity = provider.exchange_code(
+        code="abc", code_verifier="v", redirect_uri="https://x", expected_nonce=None
+    )
+    assert identity.slot == "github"
+    assert identity.subject == "584213"
+    assert identity.email == "alice@acme.com"
+    assert identity.email_verified is True
+    assert identity.name == "Alice"
+
+
+def test_github_exchange_code_returns_none_email_when_no_verified_primary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    routes = {
+        "https://api.github.com/user": StubResponse(
+            payload={"id": 1, "login": "u", "name": None, "avatar_url": None}
+        ),
+        "https://api.github.com/user/emails": StubResponse(
+            payload=[
+                {"email": "claimed@x.com", "primary": True, "verified": False},
+            ]
+        ),
+    }
+    provider = _gh_provider(routes=routes)
+    monkeypatch.setattr(provider, "_fetch_token", lambda **_: {"access_token": "AT"})
+    identity = provider.exchange_code(
+        code="abc", code_verifier="v", redirect_uri="https://x", expected_nonce=None
+    )
+    assert identity.email is None
+    assert identity.email_verified is False
+
+
+def test_github_exchange_code_enforces_org_membership(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    routes = {
+        "https://api.github.com/user": StubResponse(
+            payload={"id": 1, "login": "alice", "name": "A", "avatar_url": "x"}
+        ),
+        "https://api.github.com/user/emails": StubResponse(
+            payload=[{"email": "a@x.com", "primary": True, "verified": True}]
+        ),
+        "https://api.github.com/orgs/acme/members/alice": StubResponse(
+            status_code=204, payload=None, text=""
+        ),
+    }
+    provider = _gh_provider(allowed_orgs=("acme",), routes=routes)
+    monkeypatch.setattr(provider, "_fetch_token", lambda **_: {"access_token": "AT"})
+    identity = provider.exchange_code(
+        code="abc", code_verifier="v", redirect_uri="https://x", expected_nonce=None
+    )
+    assert identity.email == "a@x.com"
+
+
+def test_github_exchange_code_rejects_non_member(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    routes = {
+        "https://api.github.com/user": StubResponse(
+            payload={"id": 1, "login": "eve", "name": "E", "avatar_url": "x"}
+        ),
+        "https://api.github.com/user/emails": StubResponse(
+            payload=[{"email": "e@x.com", "primary": True, "verified": True}]
+        ),
+        "https://api.github.com/orgs/acme/members/eve": StubResponse(
+            status_code=404, payload={"message": "Not Found"}
+        ),
+    }
+    provider = _gh_provider(allowed_orgs=("acme",), routes=routes)
+    monkeypatch.setattr(provider, "_fetch_token", lambda **_: {"access_token": "AT"})
+    with pytest.raises(AllowlistDenied, match="not a member"):
+        provider.exchange_code(
+            code="abc", code_verifier="v", redirect_uri="https://x", expected_nonce=None
+        )

--- a/tests/dashboard/test_oauth_state_store.py
+++ b/tests/dashboard/test_oauth_state_store.py
@@ -1,0 +1,98 @@
+"""Tests for the short-lived OAuth state store."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from taskito import Queue
+from taskito.dashboard.oauth.state_store import (
+    DEFAULT_STATE_TTL_SECONDS,
+    STATE_PREFIX,
+    OAuthStateStore,
+)
+
+
+@pytest.fixture
+def queue(tmp_path: Path) -> Queue:
+    return Queue(db_path=str(tmp_path / "oauth_state.db"))
+
+
+def test_create_persists_row_and_returns_state(queue: Queue) -> None:
+    store = OAuthStateStore(queue)
+    row = store.create(slot="google", next_url="/dashboard")
+
+    assert row.slot == "google"
+    assert row.next_url == "/dashboard"
+    assert len(row.state) >= 32
+    assert len(row.nonce) >= 16
+    assert len(row.code_verifier) >= 32
+    # state, nonce, and verifier must each be unique tokens.
+    assert row.state != row.nonce != row.code_verifier
+    # Row is in the settings store under the expected prefix.
+    assert queue.get_setting(STATE_PREFIX + row.state) is not None
+
+
+def test_consume_returns_row_then_invalidates_it(queue: Queue) -> None:
+    store = OAuthStateStore(queue)
+    row = store.create(slot="github", next_url="/")
+
+    first = store.consume(row.state)
+    assert first is not None
+    assert first.slot == "github"
+    assert first.code_verifier == row.code_verifier
+
+    # Second consume is a replay attempt — must fail.
+    assert store.consume(row.state) is None
+
+
+def test_consume_rejects_empty_and_unknown_tokens(queue: Queue) -> None:
+    store = OAuthStateStore(queue)
+    assert store.consume("") is None
+    assert store.consume("never-issued") is None
+
+
+def test_consume_expired_row_returns_none(queue: Queue) -> None:
+    store = OAuthStateStore(queue)
+    row = store.create(slot="google", next_url="/", ttl_seconds=0)
+    # Even at TTL=0 we deliberately treat the row as immediately expired
+    # — but it's still single-use (deleted on consume).
+    assert store.consume(row.state) is None
+    # Underlying entry is gone after the consume.
+    assert queue.get_setting(STATE_PREFIX + row.state) is None
+
+
+def test_consume_strips_malformed_rows(queue: Queue) -> None:
+    store = OAuthStateStore(queue)
+    # Inject a garbage row directly into the settings store.
+    queue.set_setting(STATE_PREFIX + "broken", "not-json-{}")
+    assert store.consume("broken") is None
+    assert queue.get_setting(STATE_PREFIX + "broken") is None
+
+
+def test_prune_expired_removes_only_old_rows(queue: Queue) -> None:
+    store = OAuthStateStore(queue)
+    fresh = store.create(slot="google", next_url="/")
+    stale = store.create(slot="github", next_url="/", ttl_seconds=0)
+
+    # Simulate the prune sweep.
+    removed = store.prune_expired()
+    assert removed >= 1
+    # Fresh row survives.
+    assert queue.get_setting(STATE_PREFIX + fresh.state) is not None
+    # Stale row is gone.
+    assert queue.get_setting(STATE_PREFIX + stale.state) is None
+
+
+def test_default_ttl_is_five_minutes() -> None:
+    assert DEFAULT_STATE_TTL_SECONDS == 300
+
+
+def test_create_sets_expected_expiry(queue: Queue) -> None:
+    store = OAuthStateStore(queue)
+    before = int(time.time())
+    row = store.create(slot="google", next_url="/", ttl_seconds=120)
+    after = int(time.time())
+    assert before + 120 <= row.expires_at <= after + 120

--- a/tests/dashboard/test_url_safety.py
+++ b/tests/dashboard/test_url_safety.py
@@ -1,0 +1,40 @@
+"""Tests for the URL-safety helpers used by the dashboard."""
+
+from __future__ import annotations
+
+import pytest
+
+from taskito.dashboard.url_safety import is_safe_redirect
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/",
+        "/dashboard",
+        "/dashboard/jobs",
+        "/dashboard?tab=overview",
+        "/dashboard/jobs#section",
+    ],
+)
+def test_is_safe_redirect_accepts_relative_paths(path: str) -> None:
+    assert is_safe_redirect(path) is True
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "",
+        None,
+        "dashboard",  # no leading slash
+        "//evil.com/x",  # protocol-relative URL
+        "/\\evil.com",  # backslash variant
+        "http://evil.com/x",
+        "https://evil.com/x",
+        "javascript:alert(1)",
+        "data:text/html,xss",
+        "\\\\evil.com",
+    ],
+)
+def test_is_safe_redirect_rejects_unsafe(path: str | None) -> None:
+    assert is_safe_redirect(path) is False


### PR DESCRIPTION
First of three stacked PRs adding social login to the dashboard. **Read-only for end users** — no new HTTP routes are exposed by this PR; it only puts the primitives in place. PR 2 wires them into routes/handlers; PR 3 adds the UI.

## What this PR adds

- New ``oauth = [\"authlib>=1.7,<2\"]`` extra in ``pyproject.toml``.
- ``is_safe_redirect()`` in ``dashboard/url_safety.py`` — same-origin path validator for the post-login redirect target.
- New ``py_src/taskito/dashboard/oauth/`` package:
  - ``config.py`` — ``OAuthConfig`` + ``from_env()`` parsing for Google, GitHub, and **multiple named OIDC slots** (``TASKITO_DASHBOARD_OAUTH_OIDC_PROVIDERS=okta,microsoft,...``). Validates ``redirect_base_url`` (https required for non-localhost), rejects partial provider config, rejects reserved/duplicate OIDC slots.
  - ``state_store.py`` — ``OAuthStateStore`` for short-lived state/nonce/PKCE rows under ``auth:oauth_state:<state>`` with single-use semantics and a 5-min default TTL. Works across SQLite / Postgres / Redis via the existing settings store.
  - ``identity.py`` — ``ProviderIdentity`` dataclass, ``OAuthProvider`` Protocol, exception hierarchy (``OAuthError``, ``StateValidationError``, ``IdentityFetchError``, ``AllowlistDenied``).
- ``dashboard/auth.py`` extensions:
  - ``User`` gains ``email`` and ``display_name`` fields (additive, backward-compat).
  - ``verify_password`` short-circuits any hash starting with the ``oauth:`` sentinel.
  - ``AuthStore.get_or_create_oauth_user(slot, subject, email, name, email_verified, admin_emails)`` applies the bootstrap rule: explicit admin-email list takes precedence; otherwise first OAuth user on an empty table becomes admin. Verified email is required for any admin path.

## Design choices (from the plan)

- Multiple named OIDC slots — operator can register Okta, Microsoft, and any other discovery-URL provider side-by-side. Each owns a distinct ``(slot, subject)`` user namespace.
- Password auth stays on by default; ``TASKITO_DASHBOARD_PASSWORD_AUTH_ENABLED=false`` switches to OAuth-only mode. Config rejects disabling password without any OAuth provider configured.
- Allowlists are env-only for v1 (per-provider ``*_ALLOWED_DOMAINS`` / ``*_ALLOWED_ORGS``).

## Test plan

- [x] ``uv run python -m pytest tests/dashboard/test_url_safety.py tests/dashboard/test_oauth_state_store.py tests/dashboard/test_oauth_config.py tests/dashboard/test_auth.py`` — 81 passed
- [x] ``uv run python -m pytest tests/dashboard/`` — 220 passed (full dashboard suite, no regressions)
- [x] ``uv run ruff check py_src/ tests/`` — clean
- [x] ``uv run mypy py_src/taskito/ tests/`` — clean (231 files)

## Stacked PR plan

This PR is base for PR 2 (provider implementations + HTTP routes + handlers + integration tests) and PR 3 (frontend + operator docs).