### PR TITLE
feat(workflows): postgres backend

### DIFF
--- a/crates/taskito-python/Cargo.toml
+++ b/crates/taskito-python/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [features]
 default = []
 extension-module = ["pyo3/extension-module"]
-postgres = ["taskito-core/postgres"]
+postgres = ["taskito-core/postgres", "taskito-workflows?/postgres"]
 redis = ["taskito-core/redis"]
 native-async = ["dep:taskito-async"]
 workflows = ["dep:taskito-workflows"]

--- a/crates/taskito-python/src/py_queue/workflow_ops/fan_out.rs
+++ b/crates/taskito-python/src/py_queue/workflow_ops/fan_out.rs
@@ -65,7 +65,12 @@ impl PyQueue {
                 return Ok(Vec::new());
             }
 
+            // Enqueue all child jobs first, then atomically batch-insert the
+            // matching workflow_nodes. The batch insert wraps every row in one
+            // transaction, so a crash partway through node creation no longer
+            // leaves the run with half-tracked children.
             let mut child_job_ids = Vec::with_capacity(child_names.len());
+            let mut wf_nodes = Vec::with_capacity(child_names.len());
             for (child_name, payload) in child_names.iter().zip(child_payloads.into_iter()) {
                 let new_job = NewJob {
                     queue: queue_owned.clone(),
@@ -86,7 +91,7 @@ impl PyQueue {
                 let job = self.storage.enqueue(new_job)?;
                 child_job_ids.push(job.id.clone());
 
-                let wf_node = WorkflowNode {
+                wf_nodes.push(WorkflowNode {
                     id: uuid::Uuid::now_v7().to_string(),
                     run_id: run_id_owned.clone(),
                     node_name: child_name.clone(),
@@ -98,10 +103,10 @@ impl PyQueue {
                     started_at: None,
                     completed_at: None,
                     error: None,
-                };
-                wf_storage.create_workflow_node(&wf_node)?;
+                });
             }
 
+            wf_storage.create_workflow_nodes_batch(&wf_nodes)?;
             wf_storage.set_workflow_node_fan_out_count(&run_id_owned, &parent_name_owned, count)?;
             Ok(child_job_ids)
         });

--- a/crates/taskito-python/src/py_queue/workflow_ops/mod.rs
+++ b/crates/taskito-python/src/py_queue/workflow_ops/mod.rs
@@ -19,6 +19,8 @@ use pyo3::prelude::*;
 
 use taskito_core::error::Result as CoreResult;
 use taskito_core::storage::{Storage, StorageBackend};
+#[cfg(feature = "postgres")]
+use taskito_workflows::WorkflowPostgresStorage;
 use taskito_workflows::{
     StepMetadata, WorkflowNode, WorkflowNodeStatus, WorkflowSqliteStorage, WorkflowState,
     WorkflowStorage, WorkflowStorageBackend,
@@ -41,15 +43,13 @@ pub(super) fn workflow_storage(queue: &PyQueue) -> PyResult<WorkflowStorageBacke
             .map(WorkflowStorageBackend::Sqlite)
             .map_err(|e| PyRuntimeError::new_err(e.to_string()))?,
         #[cfg(feature = "postgres")]
-        StorageBackend::Postgres(_) => {
-            return Err(PyRuntimeError::new_err(
-                "workflows are currently only supported on the SQLite backend",
-            ))
-        }
+        StorageBackend::Postgres(s) => WorkflowPostgresStorage::new(s.clone())
+            .map(WorkflowStorageBackend::Postgres)
+            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?,
         #[cfg(feature = "redis")]
         StorageBackend::Redis(_) => {
             return Err(PyRuntimeError::new_err(
-                "workflows are currently only supported on the SQLite backend",
+                "workflows are currently only supported on the SQLite and PostgreSQL backends",
             ))
         }
     };

--- a/crates/taskito-workflows/Cargo.toml
+++ b/crates/taskito-workflows/Cargo.toml
@@ -3,6 +3,10 @@ name = "taskito-workflows"
 version = "0.12.3"
 edition = "2021"
 
+[features]
+default = []
+postgres = ["taskito-core/postgres", "diesel/postgres"]
+
 [dependencies]
 taskito-core = { path = "../taskito-core" }
 dagron-core = { workspace = true }

--- a/crates/taskito-workflows/src/diesel_common.rs
+++ b/crates/taskito-workflows/src/diesel_common.rs
@@ -400,28 +400,31 @@ macro_rules! impl_workflow_diesel_ops {
                 &self,
                 nodes: &[$crate::WorkflowNode],
             ) -> ::taskito_core::error::Result<()> {
+                use ::diesel::connection::Connection;
                 let mut conn = self.inner.conn()?;
-                for node in nodes {
-                    ::diesel::sql_query(
-                        "INSERT INTO workflow_nodes
-                            (id, run_id, node_name, job_id, status, result_hash,
-                             fan_out_count, fan_in_data, started_at, completed_at, error)
-                         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                    )
-                    .bind::<::diesel::sql_types::Text, _>(&node.id)
-                    .bind::<::diesel::sql_types::Text, _>(&node.run_id)
-                    .bind::<::diesel::sql_types::Text, _>(&node.node_name)
-                    .bind::<::diesel::sql_types::Nullable<::diesel::sql_types::Text>, _>(&node.job_id)
-                    .bind::<::diesel::sql_types::Text, _>(node.status.as_str())
-                    .bind::<::diesel::sql_types::Nullable<::diesel::sql_types::Text>, _>(&node.result_hash)
-                    .bind::<::diesel::sql_types::Nullable<::diesel::sql_types::Integer>, _>(node.fan_out_count)
-                    .bind::<::diesel::sql_types::Nullable<::diesel::sql_types::Text>, _>(&node.fan_in_data)
-                    .bind::<::diesel::sql_types::Nullable<::diesel::sql_types::BigInt>, _>(node.started_at)
-                    .bind::<::diesel::sql_types::Nullable<::diesel::sql_types::BigInt>, _>(node.completed_at)
-                    .bind::<::diesel::sql_types::Nullable<::diesel::sql_types::Text>, _>(&node.error)
-                    .execute(&mut *conn)?;
-                }
-                Ok(())
+                conn.transaction::<_, ::taskito_core::error::QueueError, _>(|conn| {
+                    for node in nodes {
+                        ::diesel::sql_query(
+                            "INSERT INTO workflow_nodes
+                                (id, run_id, node_name, job_id, status, result_hash,
+                                 fan_out_count, fan_in_data, started_at, completed_at, error)
+                             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                        )
+                        .bind::<::diesel::sql_types::Text, _>(&node.id)
+                        .bind::<::diesel::sql_types::Text, _>(&node.run_id)
+                        .bind::<::diesel::sql_types::Text, _>(&node.node_name)
+                        .bind::<::diesel::sql_types::Nullable<::diesel::sql_types::Text>, _>(&node.job_id)
+                        .bind::<::diesel::sql_types::Text, _>(node.status.as_str())
+                        .bind::<::diesel::sql_types::Nullable<::diesel::sql_types::Text>, _>(&node.result_hash)
+                        .bind::<::diesel::sql_types::Nullable<::diesel::sql_types::Integer>, _>(node.fan_out_count)
+                        .bind::<::diesel::sql_types::Nullable<::diesel::sql_types::Text>, _>(&node.fan_in_data)
+                        .bind::<::diesel::sql_types::Nullable<::diesel::sql_types::BigInt>, _>(node.started_at)
+                        .bind::<::diesel::sql_types::Nullable<::diesel::sql_types::BigInt>, _>(node.completed_at)
+                        .bind::<::diesel::sql_types::Nullable<::diesel::sql_types::Text>, _>(&node.error)
+                        .execute(conn)?;
+                    }
+                    Ok(())
+                })
             }
 
             fn get_workflow_node(

--- a/crates/taskito-workflows/src/diesel_common.rs
+++ b/crates/taskito-workflows/src/diesel_common.rs
@@ -1,17 +1,21 @@
 //! Shared Diesel-based implementation for SQLite + PostgreSQL workflow stores.
 //!
-//! `impl_workflow_diesel_ops!($storage_type, $conn_type)` generates a complete
-//! `impl WorkflowStorage for $storage_type` block. The macro contract: the
-//! storage type must expose an `inner: T` field where `T` has a
+//! `impl_workflow_diesel_ops!($storage_type, $conn_type, $prep_sql)` generates
+//! a complete `impl WorkflowStorage for $storage_type` block. The macro
+//! contract: the storage type must expose an `inner: T` field where `T` has a
 //! `conn() -> Result<PooledConnection<...>>` method that derefs to a mutable
 //! `$conn_type`. SQLite and Postgres both satisfy this via their core storage
 //! handles.
 //!
-//! Diesel's `sql_query` rewrites `?` placeholders per backend automatically, so
-//! the SQL strings here are byte-identical between SQLite and Postgres. The
-//! only schema differences (`BLOB` vs `BYTEA`, `INTEGER` vs `BIGINT` for
-//! timestamps) are handled by the bound `diesel::sql_types::*` types and by
-//! the per-backend migration files — the query bodies stay unified.
+//! Diesel's `sql_query` does **not** rewrite `?` placeholders per backend — it
+//! requires `?` for SQLite and `$N` for Postgres. The `$prep_sql` macro
+//! argument names a function that converts the canonical (`?`-based) SQL into
+//! the dialect the connection expects. `sql_as_is` is a no-op for SQLite;
+//! `pg_rewrite` substitutes `?` → `$1`, `$2`, … for Postgres.
+//!
+//! Schema differences (`BLOB` vs `BYTEA`, `INTEGER` vs `BIGINT` for
+//! timestamps) are handled by the bound `diesel::sql_types::*` types and the
+//! per-backend migration files — the query bodies stay unified.
 
 use diesel::prelude::*;
 use diesel::sql_types::Text;
@@ -21,6 +25,34 @@ use taskito_core::error::{QueueError, Result};
 use crate::{
     StepMetadata, WorkflowDefinition, WorkflowNode, WorkflowNodeStatus, WorkflowRun, WorkflowState,
 };
+
+/// Pass-through SQL prep for SQLite — `?` placeholders are native.
+#[inline]
+pub(crate) fn sql_as_is(sql: &str) -> String {
+    sql.to_string()
+}
+
+/// Rewrite `?` placeholders to `$N` for Postgres in the order they appear.
+///
+/// Diesel's `sql_query` API requires dialect-correct placeholders. Postgres
+/// uses `$1`, `$2`, …; SQLite uses `?`. Doing the rewrite once at query time
+/// (a handful of µs for the short SQL bodies used here) lets the workflow
+/// crate keep a single canonical SQL string per query.
+pub(crate) fn pg_rewrite(sql: &str) -> String {
+    use std::fmt::Write;
+    let mut out = String::with_capacity(sql.len() + 8);
+    let mut n: usize = 1;
+    for c in sql.chars() {
+        if c == '?' {
+            // `write!` to String is infallible — `.unwrap()` is safe.
+            write!(out, "${n}").unwrap();
+            n += 1;
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
 
 #[derive(QueryableByName)]
 pub(crate) struct DefinitionRow {
@@ -137,11 +169,12 @@ pub(crate) fn node_from_row(row: NodeRow) -> WorkflowNode {
 
 /// Generate the full `impl WorkflowStorage for $storage_type` block.
 ///
-/// Both SQLite and Postgres implementations are byte-identical at the SQL
-/// level (Diesel rewrites `?` per backend). The macro takes the connection
-/// type so each backend's compile-time bind type-checks correctly.
+/// `$prep_sql` names a function that converts canonical (`?`-based) SQL into
+/// the dialect the connection expects. `$crate::diesel_common::sql_as_is`
+/// works for SQLite; `$crate::diesel_common::pg_rewrite` swaps `?` → `$N` for
+/// Postgres.
 macro_rules! impl_workflow_diesel_ops {
-    ($storage_type:ty, $conn_type:ty) => {
+    ($storage_type:ty, $conn_type:ty, $prep_sql:path) => {
         impl $crate::storage::WorkflowStorage for $storage_type {
             fn create_workflow_definition(
                 &self,
@@ -155,8 +188,8 @@ macro_rules! impl_workflow_diesel_ops {
                 })?;
 
                 ::diesel::sql_query(
-                    "INSERT INTO workflow_definitions (id, name, version, dag_data, step_metadata, created_at)
-                     VALUES (?, ?, ?, ?, ?, ?)",
+                    &$prep_sql("INSERT INTO workflow_definitions (id, name, version, dag_data, step_metadata, created_at)
+                     VALUES (?, ?, ?, ?, ?, ?)"),
                 )
                 .bind::<::diesel::sql_types::Text, _>(&def.id)
                 .bind::<::diesel::sql_types::Text, _>(&def.name)
@@ -178,16 +211,16 @@ macro_rules! impl_workflow_diesel_ops {
 
                 let rows: Vec<$crate::diesel_common::DefinitionRow> = if let Some(v) = version {
                     ::diesel::sql_query(
-                        "SELECT id, name, version, dag_data, step_metadata, created_at
-                         FROM workflow_definitions WHERE name = ? AND version = ?",
+                        &$prep_sql("SELECT id, name, version, dag_data, step_metadata, created_at
+                         FROM workflow_definitions WHERE name = ? AND version = ?"),
                     )
                     .bind::<::diesel::sql_types::Text, _>(name)
                     .bind::<::diesel::sql_types::Integer, _>(v)
                     .load(&mut *conn)?
                 } else {
                     ::diesel::sql_query(
-                        "SELECT id, name, version, dag_data, step_metadata, created_at
-                         FROM workflow_definitions WHERE name = ? ORDER BY version DESC LIMIT 1",
+                        &$prep_sql("SELECT id, name, version, dag_data, step_metadata, created_at
+                         FROM workflow_definitions WHERE name = ? ORDER BY version DESC LIMIT 1"),
                     )
                     .bind::<::diesel::sql_types::Text, _>(name)
                     .load(&mut *conn)?
@@ -205,8 +238,8 @@ macro_rules! impl_workflow_diesel_ops {
             ) -> ::taskito_core::error::Result<Option<$crate::WorkflowDefinition>> {
                 let mut conn = self.inner.conn()?;
                 let rows: Vec<$crate::diesel_common::DefinitionRow> = ::diesel::sql_query(
-                    "SELECT id, name, version, dag_data, step_metadata, created_at
-                     FROM workflow_definitions WHERE id = ?",
+                    &$prep_sql("SELECT id, name, version, dag_data, step_metadata, created_at
+                     FROM workflow_definitions WHERE id = ?"),
                 )
                 .bind::<::diesel::sql_types::Text, _>(id)
                 .load(&mut *conn)?;
@@ -223,10 +256,10 @@ macro_rules! impl_workflow_diesel_ops {
             ) -> ::taskito_core::error::Result<()> {
                 let mut conn = self.inner.conn()?;
                 ::diesel::sql_query(
-                    "INSERT INTO workflow_runs
+                    &$prep_sql("INSERT INTO workflow_runs
                         (id, definition_id, params, state, started_at, completed_at, error,
                          parent_run_id, parent_node_name, created_at)
-                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"),
                 )
                 .bind::<::diesel::sql_types::Text, _>(&run.id)
                 .bind::<::diesel::sql_types::Text, _>(&run.definition_id)
@@ -249,9 +282,9 @@ macro_rules! impl_workflow_diesel_ops {
             ) -> ::taskito_core::error::Result<Option<$crate::WorkflowRun>> {
                 let mut conn = self.inner.conn()?;
                 let rows: Vec<$crate::diesel_common::RunRow> = ::diesel::sql_query(
-                    "SELECT id, definition_id, params, state, started_at, completed_at, error,
+                    &$prep_sql("SELECT id, definition_id, params, state, started_at, completed_at, error,
                             parent_run_id, parent_node_name, created_at
-                     FROM workflow_runs WHERE id = ?",
+                     FROM workflow_runs WHERE id = ?"),
                 )
                 .bind::<::diesel::sql_types::Text, _>(run_id)
                 .load(&mut *conn)?;
@@ -267,7 +300,7 @@ macro_rules! impl_workflow_diesel_ops {
             ) -> ::taskito_core::error::Result<()> {
                 let mut conn = self.inner.conn()?;
                 ::diesel::sql_query(
-                    "UPDATE workflow_runs SET state = ?, error = ? WHERE id = ?",
+                    &$prep_sql("UPDATE workflow_runs SET state = ?, error = ? WHERE id = ?"),
                 )
                 .bind::<::diesel::sql_types::Text, _>(state.as_str())
                 .bind::<::diesel::sql_types::Nullable<::diesel::sql_types::Text>, _>(error)
@@ -283,7 +316,7 @@ macro_rules! impl_workflow_diesel_ops {
             ) -> ::taskito_core::error::Result<()> {
                 let mut conn = self.inner.conn()?;
                 ::diesel::sql_query(
-                    "UPDATE workflow_runs SET state = 'running', started_at = ? WHERE id = ?",
+                    &$prep_sql("UPDATE workflow_runs SET state = 'running', started_at = ? WHERE id = ?"),
                 )
                 .bind::<::diesel::sql_types::BigInt, _>(started_at)
                 .bind::<::diesel::sql_types::Text, _>(run_id)
@@ -298,7 +331,7 @@ macro_rules! impl_workflow_diesel_ops {
             ) -> ::taskito_core::error::Result<()> {
                 let mut conn = self.inner.conn()?;
                 ::diesel::sql_query(
-                    "UPDATE workflow_runs SET completed_at = ? WHERE id = ?",
+                    &$prep_sql("UPDATE workflow_runs SET completed_at = ? WHERE id = ?"),
                 )
                 .bind::<::diesel::sql_types::BigInt, _>(completed_at)
                 .bind::<::diesel::sql_types::Text, _>(run_id)
@@ -317,13 +350,13 @@ macro_rules! impl_workflow_diesel_ops {
 
                 let rows: Vec<$crate::diesel_common::RunRow> = match (definition_name, state) {
                     (Some(name), Some(st)) => ::diesel::sql_query(
-                        "SELECT r.id, r.definition_id, r.params, r.state, r.started_at,
+                        &$prep_sql("SELECT r.id, r.definition_id, r.params, r.state, r.started_at,
                                 r.completed_at, r.error, r.parent_run_id, r.parent_node_name,
                                 r.created_at
                          FROM workflow_runs r
                          JOIN workflow_definitions d ON r.definition_id = d.id
                          WHERE d.name = ? AND r.state = ?
-                         ORDER BY r.created_at DESC LIMIT ? OFFSET ?",
+                         ORDER BY r.created_at DESC LIMIT ? OFFSET ?"),
                     )
                     .bind::<::diesel::sql_types::Text, _>(name)
                     .bind::<::diesel::sql_types::Text, _>(st.as_str())
@@ -331,33 +364,33 @@ macro_rules! impl_workflow_diesel_ops {
                     .bind::<::diesel::sql_types::BigInt, _>(offset)
                     .load(&mut *conn)?,
                     (Some(name), None) => ::diesel::sql_query(
-                        "SELECT r.id, r.definition_id, r.params, r.state, r.started_at,
+                        &$prep_sql("SELECT r.id, r.definition_id, r.params, r.state, r.started_at,
                                 r.completed_at, r.error, r.parent_run_id, r.parent_node_name,
                                 r.created_at
                          FROM workflow_runs r
                          JOIN workflow_definitions d ON r.definition_id = d.id
                          WHERE d.name = ?
-                         ORDER BY r.created_at DESC LIMIT ? OFFSET ?",
+                         ORDER BY r.created_at DESC LIMIT ? OFFSET ?"),
                     )
                     .bind::<::diesel::sql_types::Text, _>(name)
                     .bind::<::diesel::sql_types::BigInt, _>(limit)
                     .bind::<::diesel::sql_types::BigInt, _>(offset)
                     .load(&mut *conn)?,
                     (None, Some(st)) => ::diesel::sql_query(
-                        "SELECT id, definition_id, params, state, started_at, completed_at,
+                        &$prep_sql("SELECT id, definition_id, params, state, started_at, completed_at,
                                 error, parent_run_id, parent_node_name, created_at
                          FROM workflow_runs WHERE state = ?
-                         ORDER BY created_at DESC LIMIT ? OFFSET ?",
+                         ORDER BY created_at DESC LIMIT ? OFFSET ?"),
                     )
                     .bind::<::diesel::sql_types::Text, _>(st.as_str())
                     .bind::<::diesel::sql_types::BigInt, _>(limit)
                     .bind::<::diesel::sql_types::BigInt, _>(offset)
                     .load(&mut *conn)?,
                     (None, None) => ::diesel::sql_query(
-                        "SELECT id, definition_id, params, state, started_at, completed_at,
+                        &$prep_sql("SELECT id, definition_id, params, state, started_at, completed_at,
                                 error, parent_run_id, parent_node_name, created_at
                          FROM workflow_runs
-                         ORDER BY created_at DESC LIMIT ? OFFSET ?",
+                         ORDER BY created_at DESC LIMIT ? OFFSET ?"),
                     )
                     .bind::<::diesel::sql_types::BigInt, _>(limit)
                     .bind::<::diesel::sql_types::BigInt, _>(offset)
@@ -376,10 +409,10 @@ macro_rules! impl_workflow_diesel_ops {
             ) -> ::taskito_core::error::Result<()> {
                 let mut conn = self.inner.conn()?;
                 ::diesel::sql_query(
-                    "INSERT INTO workflow_nodes
+                    &$prep_sql("INSERT INTO workflow_nodes
                         (id, run_id, node_name, job_id, status, result_hash,
                          fan_out_count, fan_in_data, started_at, completed_at, error)
-                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"),
                 )
                 .bind::<::diesel::sql_types::Text, _>(&node.id)
                 .bind::<::diesel::sql_types::Text, _>(&node.run_id)
@@ -405,10 +438,10 @@ macro_rules! impl_workflow_diesel_ops {
                 conn.transaction::<_, ::taskito_core::error::QueueError, _>(|conn| {
                     for node in nodes {
                         ::diesel::sql_query(
-                            "INSERT INTO workflow_nodes
+                            &$prep_sql("INSERT INTO workflow_nodes
                                 (id, run_id, node_name, job_id, status, result_hash,
                                  fan_out_count, fan_in_data, started_at, completed_at, error)
-                             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"),
                         )
                         .bind::<::diesel::sql_types::Text, _>(&node.id)
                         .bind::<::diesel::sql_types::Text, _>(&node.run_id)
@@ -434,9 +467,9 @@ macro_rules! impl_workflow_diesel_ops {
             ) -> ::taskito_core::error::Result<Option<$crate::WorkflowNode>> {
                 let mut conn = self.inner.conn()?;
                 let rows: Vec<$crate::diesel_common::NodeRow> = ::diesel::sql_query(
-                    "SELECT id, run_id, node_name, job_id, status, result_hash,
+                    &$prep_sql("SELECT id, run_id, node_name, job_id, status, result_hash,
                             fan_out_count, fan_in_data, started_at, completed_at, error
-                     FROM workflow_nodes WHERE run_id = ? AND node_name = ?",
+                     FROM workflow_nodes WHERE run_id = ? AND node_name = ?"),
                 )
                 .bind::<::diesel::sql_types::Text, _>(run_id)
                 .bind::<::diesel::sql_types::Text, _>(node_name)
@@ -454,9 +487,9 @@ macro_rules! impl_workflow_diesel_ops {
             ) -> ::taskito_core::error::Result<Vec<$crate::WorkflowNode>> {
                 let mut conn = self.inner.conn()?;
                 let rows: Vec<$crate::diesel_common::NodeRow> = ::diesel::sql_query(
-                    "SELECT id, run_id, node_name, job_id, status, result_hash,
+                    &$prep_sql("SELECT id, run_id, node_name, job_id, status, result_hash,
                             fan_out_count, fan_in_data, started_at, completed_at, error
-                     FROM workflow_nodes WHERE run_id = ?",
+                     FROM workflow_nodes WHERE run_id = ?"),
                 )
                 .bind::<::diesel::sql_types::Text, _>(run_id)
                 .load(&mut *conn)?;
@@ -475,7 +508,7 @@ macro_rules! impl_workflow_diesel_ops {
             ) -> ::taskito_core::error::Result<()> {
                 let mut conn = self.inner.conn()?;
                 ::diesel::sql_query(
-                    "UPDATE workflow_nodes SET status = ? WHERE run_id = ? AND node_name = ?",
+                    &$prep_sql("UPDATE workflow_nodes SET status = ? WHERE run_id = ? AND node_name = ?"),
                 )
                 .bind::<::diesel::sql_types::Text, _>(status.as_str())
                 .bind::<::diesel::sql_types::Text, _>(run_id)
@@ -492,7 +525,7 @@ macro_rules! impl_workflow_diesel_ops {
             ) -> ::taskito_core::error::Result<()> {
                 let mut conn = self.inner.conn()?;
                 ::diesel::sql_query(
-                    "UPDATE workflow_nodes SET job_id = ? WHERE run_id = ? AND node_name = ?",
+                    &$prep_sql("UPDATE workflow_nodes SET job_id = ? WHERE run_id = ? AND node_name = ?"),
                 )
                 .bind::<::diesel::sql_types::Text, _>(job_id)
                 .bind::<::diesel::sql_types::Text, _>(run_id)
@@ -509,8 +542,8 @@ macro_rules! impl_workflow_diesel_ops {
             ) -> ::taskito_core::error::Result<()> {
                 let mut conn = self.inner.conn()?;
                 ::diesel::sql_query(
-                    "UPDATE workflow_nodes SET status = 'running', started_at = ?
-                     WHERE run_id = ? AND node_name = ?",
+                    &$prep_sql("UPDATE workflow_nodes SET status = 'running', started_at = ?
+                     WHERE run_id = ? AND node_name = ?"),
                 )
                 .bind::<::diesel::sql_types::BigInt, _>(started_at)
                 .bind::<::diesel::sql_types::Text, _>(run_id)
@@ -528,8 +561,8 @@ macro_rules! impl_workflow_diesel_ops {
             ) -> ::taskito_core::error::Result<()> {
                 let mut conn = self.inner.conn()?;
                 ::diesel::sql_query(
-                    "UPDATE workflow_nodes SET status = 'completed', completed_at = ?, result_hash = ?
-                     WHERE run_id = ? AND node_name = ?",
+                    &$prep_sql("UPDATE workflow_nodes SET status = 'completed', completed_at = ?, result_hash = ?
+                     WHERE run_id = ? AND node_name = ?"),
                 )
                 .bind::<::diesel::sql_types::BigInt, _>(completed_at)
                 .bind::<::diesel::sql_types::Nullable<::diesel::sql_types::Text>, _>(result_hash)
@@ -547,8 +580,8 @@ macro_rules! impl_workflow_diesel_ops {
             ) -> ::taskito_core::error::Result<()> {
                 let mut conn = self.inner.conn()?;
                 ::diesel::sql_query(
-                    "UPDATE workflow_nodes SET status = 'failed', error = ?
-                     WHERE run_id = ? AND node_name = ?",
+                    &$prep_sql("UPDATE workflow_nodes SET status = 'failed', error = ?
+                     WHERE run_id = ? AND node_name = ?"),
                 )
                 .bind::<::diesel::sql_types::Text, _>(error)
                 .bind::<::diesel::sql_types::Text, _>(run_id)
@@ -565,8 +598,8 @@ macro_rules! impl_workflow_diesel_ops {
             ) -> ::taskito_core::error::Result<()> {
                 let mut conn = self.inner.conn()?;
                 ::diesel::sql_query(
-                    "UPDATE workflow_nodes SET fan_out_count = ?, status = 'running'
-                     WHERE run_id = ? AND node_name = ?",
+                    &$prep_sql("UPDATE workflow_nodes SET fan_out_count = ?, status = 'running'
+                     WHERE run_id = ? AND node_name = ?"),
                 )
                 .bind::<::diesel::sql_types::Integer, _>(count)
                 .bind::<::diesel::sql_types::Text, _>(run_id)
@@ -583,8 +616,8 @@ macro_rules! impl_workflow_diesel_ops {
             ) -> ::taskito_core::error::Result<()> {
                 let mut conn = self.inner.conn()?;
                 ::diesel::sql_query(
-                    "UPDATE workflow_nodes SET status = 'running', started_at = ?
-                     WHERE run_id = ? AND node_name = ?",
+                    &$prep_sql("UPDATE workflow_nodes SET status = 'running', started_at = ?
+                     WHERE run_id = ? AND node_name = ?"),
                 )
                 .bind::<::diesel::sql_types::BigInt, _>(started_at)
                 .bind::<::diesel::sql_types::Text, _>(run_id)
@@ -604,10 +637,10 @@ macro_rules! impl_workflow_diesel_ops {
                 let mut conn = self.inner.conn()?;
                 let affected = if succeeded {
                     ::diesel::sql_query(
-                        "UPDATE workflow_nodes
+                        &$prep_sql("UPDATE workflow_nodes
                          SET status = 'completed', completed_at = ?
                          WHERE run_id = ? AND node_name = ?
-                           AND status NOT IN ('completed', 'failed', 'skipped', 'cache_hit')",
+                           AND status NOT IN ('completed', 'failed', 'skipped', 'cache_hit')"),
                     )
                     .bind::<::diesel::sql_types::BigInt, _>(completed_at)
                     .bind::<::diesel::sql_types::Text, _>(run_id)
@@ -615,10 +648,10 @@ macro_rules! impl_workflow_diesel_ops {
                     .execute(&mut *conn)?
                 } else {
                     ::diesel::sql_query(
-                        "UPDATE workflow_nodes
+                        &$prep_sql("UPDATE workflow_nodes
                          SET status = 'failed', error = ?
                          WHERE run_id = ? AND node_name = ?
-                           AND status NOT IN ('completed', 'failed', 'skipped', 'cache_hit')",
+                           AND status NOT IN ('completed', 'failed', 'skipped', 'cache_hit')"),
                     )
                     .bind::<::diesel::sql_types::Text, _>(error.unwrap_or("fan-out child failed"))
                     .bind::<::diesel::sql_types::Text, _>(run_id)
@@ -636,9 +669,9 @@ macro_rules! impl_workflow_diesel_ops {
                 let mut conn = self.inner.conn()?;
                 let pattern = format!("{prefix}%");
                 let rows: Vec<$crate::diesel_common::NodeRow> = ::diesel::sql_query(
-                    "SELECT id, run_id, node_name, job_id, status, result_hash,
+                    &$prep_sql("SELECT id, run_id, node_name, job_id, status, result_hash,
                             fan_out_count, fan_in_data, started_at, completed_at, error
-                     FROM workflow_nodes WHERE run_id = ? AND node_name LIKE ?",
+                     FROM workflow_nodes WHERE run_id = ? AND node_name LIKE ?"),
                 )
                 .bind::<::diesel::sql_types::Text, _>(run_id)
                 .bind::<::diesel::sql_types::Text, _>(&pattern)
@@ -666,9 +699,9 @@ macro_rules! impl_workflow_diesel_ops {
             ) -> ::taskito_core::error::Result<Vec<$crate::WorkflowRun>> {
                 let mut conn = self.inner.conn()?;
                 let rows: Vec<$crate::diesel_common::RunRow> = ::diesel::sql_query(
-                    "SELECT id, definition_id, params, state, started_at, completed_at,
+                    &$prep_sql("SELECT id, definition_id, params, state, started_at, completed_at,
                             error, parent_run_id, parent_node_name, created_at
-                     FROM workflow_runs WHERE parent_run_id = ?",
+                     FROM workflow_runs WHERE parent_run_id = ?"),
                 )
                 .bind::<::diesel::sql_types::Text, _>(parent_run_id)
                 .load(&mut *conn)?;

--- a/crates/taskito-workflows/src/lib.rs
+++ b/crates/taskito-workflows/src/lib.rs
@@ -3,6 +3,8 @@ mod definition;
 pub(crate) mod diesel_common;
 mod error;
 mod node;
+#[cfg(feature = "postgres")]
+pub mod postgres_store;
 mod run;
 pub mod sqlite_store;
 mod state;
@@ -15,6 +17,8 @@ pub use dagron_core;
 pub use definition::{StepMetadata, WorkflowDefinition};
 pub use error::WorkflowError;
 pub use node::{WorkflowNode, WorkflowNodeStatus};
+#[cfg(feature = "postgres")]
+pub use postgres_store::WorkflowPostgresStorage;
 pub use run::WorkflowRun;
 pub use sqlite_store::WorkflowSqliteStorage;
 pub use state::WorkflowState;
@@ -34,13 +38,27 @@ use taskito_core::error::Result;
 #[derive(Clone)]
 pub enum WorkflowStorageBackend {
     Sqlite(WorkflowSqliteStorage),
+    #[cfg(feature = "postgres")]
+    Postgres(WorkflowPostgresStorage),
+}
+
+/// Dispatch a `WorkflowStorage` method across every enum variant.
+///
+/// Each variant arm forwards `$method($($arg),*)` to the inner backend handle.
+/// Variants behind `#[cfg(feature = ...)]` are conditionally compiled in.
+macro_rules! delegate {
+    ($self:ident, $method:ident $(, $arg:expr)* $(,)?) => {
+        match $self {
+            Self::Sqlite(s) => s.$method($($arg),*),
+            #[cfg(feature = "postgres")]
+            Self::Postgres(s) => s.$method($($arg),*),
+        }
+    };
 }
 
 impl WorkflowStorage for WorkflowStorageBackend {
     fn create_workflow_definition(&self, def: &WorkflowDefinition) -> Result<()> {
-        match self {
-            Self::Sqlite(s) => s.create_workflow_definition(def),
-        }
+        delegate!(self, create_workflow_definition, def)
     }
 
     fn get_workflow_definition(
@@ -48,27 +66,19 @@ impl WorkflowStorage for WorkflowStorageBackend {
         name: &str,
         version: Option<i32>,
     ) -> Result<Option<WorkflowDefinition>> {
-        match self {
-            Self::Sqlite(s) => s.get_workflow_definition(name, version),
-        }
+        delegate!(self, get_workflow_definition, name, version)
     }
 
     fn get_workflow_definition_by_id(&self, id: &str) -> Result<Option<WorkflowDefinition>> {
-        match self {
-            Self::Sqlite(s) => s.get_workflow_definition_by_id(id),
-        }
+        delegate!(self, get_workflow_definition_by_id, id)
     }
 
     fn create_workflow_run(&self, run: &WorkflowRun) -> Result<()> {
-        match self {
-            Self::Sqlite(s) => s.create_workflow_run(run),
-        }
+        delegate!(self, create_workflow_run, run)
     }
 
     fn get_workflow_run(&self, run_id: &str) -> Result<Option<WorkflowRun>> {
-        match self {
-            Self::Sqlite(s) => s.get_workflow_run(run_id),
-        }
+        delegate!(self, get_workflow_run, run_id)
     }
 
     fn update_workflow_run_state(
@@ -77,21 +87,15 @@ impl WorkflowStorage for WorkflowStorageBackend {
         state: WorkflowState,
         error: Option<&str>,
     ) -> Result<()> {
-        match self {
-            Self::Sqlite(s) => s.update_workflow_run_state(run_id, state, error),
-        }
+        delegate!(self, update_workflow_run_state, run_id, state, error)
     }
 
     fn set_workflow_run_started(&self, run_id: &str, started_at: i64) -> Result<()> {
-        match self {
-            Self::Sqlite(s) => s.set_workflow_run_started(run_id, started_at),
-        }
+        delegate!(self, set_workflow_run_started, run_id, started_at)
     }
 
     fn set_workflow_run_completed(&self, run_id: &str, completed_at: i64) -> Result<()> {
-        match self {
-            Self::Sqlite(s) => s.set_workflow_run_completed(run_id, completed_at),
-        }
+        delegate!(self, set_workflow_run_completed, run_id, completed_at)
     }
 
     fn list_workflow_runs(
@@ -101,33 +105,30 @@ impl WorkflowStorage for WorkflowStorageBackend {
         limit: i64,
         offset: i64,
     ) -> Result<Vec<WorkflowRun>> {
-        match self {
-            Self::Sqlite(s) => s.list_workflow_runs(definition_name, state, limit, offset),
-        }
+        delegate!(
+            self,
+            list_workflow_runs,
+            definition_name,
+            state,
+            limit,
+            offset
+        )
     }
 
     fn create_workflow_node(&self, node: &WorkflowNode) -> Result<()> {
-        match self {
-            Self::Sqlite(s) => s.create_workflow_node(node),
-        }
+        delegate!(self, create_workflow_node, node)
     }
 
     fn create_workflow_nodes_batch(&self, nodes: &[WorkflowNode]) -> Result<()> {
-        match self {
-            Self::Sqlite(s) => s.create_workflow_nodes_batch(nodes),
-        }
+        delegate!(self, create_workflow_nodes_batch, nodes)
     }
 
     fn get_workflow_node(&self, run_id: &str, node_name: &str) -> Result<Option<WorkflowNode>> {
-        match self {
-            Self::Sqlite(s) => s.get_workflow_node(run_id, node_name),
-        }
+        delegate!(self, get_workflow_node, run_id, node_name)
     }
 
     fn get_workflow_nodes(&self, run_id: &str) -> Result<Vec<WorkflowNode>> {
-        match self {
-            Self::Sqlite(s) => s.get_workflow_nodes(run_id),
-        }
+        delegate!(self, get_workflow_nodes, run_id)
     }
 
     fn update_workflow_node_status(
@@ -136,15 +137,11 @@ impl WorkflowStorage for WorkflowStorageBackend {
         node_name: &str,
         status: WorkflowNodeStatus,
     ) -> Result<()> {
-        match self {
-            Self::Sqlite(s) => s.update_workflow_node_status(run_id, node_name, status),
-        }
+        delegate!(self, update_workflow_node_status, run_id, node_name, status)
     }
 
     fn set_workflow_node_job(&self, run_id: &str, node_name: &str, job_id: &str) -> Result<()> {
-        match self {
-            Self::Sqlite(s) => s.set_workflow_node_job(run_id, node_name, job_id),
-        }
+        delegate!(self, set_workflow_node_job, run_id, node_name, job_id)
     }
 
     fn set_workflow_node_started(
@@ -153,9 +150,13 @@ impl WorkflowStorage for WorkflowStorageBackend {
         node_name: &str,
         started_at: i64,
     ) -> Result<()> {
-        match self {
-            Self::Sqlite(s) => s.set_workflow_node_started(run_id, node_name, started_at),
-        }
+        delegate!(
+            self,
+            set_workflow_node_started,
+            run_id,
+            node_name,
+            started_at
+        )
     }
 
     fn set_workflow_node_completed(
@@ -165,23 +166,22 @@ impl WorkflowStorage for WorkflowStorageBackend {
         completed_at: i64,
         result_hash: Option<&str>,
     ) -> Result<()> {
-        match self {
-            Self::Sqlite(s) => {
-                s.set_workflow_node_completed(run_id, node_name, completed_at, result_hash)
-            }
-        }
+        delegate!(
+            self,
+            set_workflow_node_completed,
+            run_id,
+            node_name,
+            completed_at,
+            result_hash
+        )
     }
 
     fn set_workflow_node_error(&self, run_id: &str, node_name: &str, error: &str) -> Result<()> {
-        match self {
-            Self::Sqlite(s) => s.set_workflow_node_error(run_id, node_name, error),
-        }
+        delegate!(self, set_workflow_node_error, run_id, node_name, error)
     }
 
     fn get_ready_workflow_nodes(&self, run_id: &str, dag_json: &str) -> Result<Vec<WorkflowNode>> {
-        match self {
-            Self::Sqlite(s) => s.get_ready_workflow_nodes(run_id, dag_json),
-        }
+        delegate!(self, get_ready_workflow_nodes, run_id, dag_json)
     }
 
     fn set_workflow_node_fan_out_count(
@@ -190,9 +190,13 @@ impl WorkflowStorage for WorkflowStorageBackend {
         node_name: &str,
         count: i32,
     ) -> Result<()> {
-        match self {
-            Self::Sqlite(s) => s.set_workflow_node_fan_out_count(run_id, node_name, count),
-        }
+        delegate!(
+            self,
+            set_workflow_node_fan_out_count,
+            run_id,
+            node_name,
+            count
+        )
     }
 
     fn set_workflow_node_running(
@@ -201,9 +205,13 @@ impl WorkflowStorage for WorkflowStorageBackend {
         node_name: &str,
         started_at: i64,
     ) -> Result<()> {
-        match self {
-            Self::Sqlite(s) => s.set_workflow_node_running(run_id, node_name, started_at),
-        }
+        delegate!(
+            self,
+            set_workflow_node_running,
+            run_id,
+            node_name,
+            started_at
+        )
     }
 
     fn finalize_fan_out_parent(
@@ -214,11 +222,15 @@ impl WorkflowStorage for WorkflowStorageBackend {
         error: Option<&str>,
         completed_at: i64,
     ) -> Result<bool> {
-        match self {
-            Self::Sqlite(s) => {
-                s.finalize_fan_out_parent(run_id, node_name, succeeded, error, completed_at)
-            }
-        }
+        delegate!(
+            self,
+            finalize_fan_out_parent,
+            run_id,
+            node_name,
+            succeeded,
+            error,
+            completed_at
+        )
     }
 
     fn get_workflow_nodes_by_prefix(
@@ -226,14 +238,10 @@ impl WorkflowStorage for WorkflowStorageBackend {
         run_id: &str,
         prefix: &str,
     ) -> Result<Vec<WorkflowNode>> {
-        match self {
-            Self::Sqlite(s) => s.get_workflow_nodes_by_prefix(run_id, prefix),
-        }
+        delegate!(self, get_workflow_nodes_by_prefix, run_id, prefix)
     }
 
     fn get_child_workflow_runs(&self, parent_run_id: &str) -> Result<Vec<WorkflowRun>> {
-        match self {
-            Self::Sqlite(s) => s.get_child_workflow_runs(parent_run_id),
-        }
+        delegate!(self, get_child_workflow_runs, parent_run_id)
     }
 }

--- a/crates/taskito-workflows/src/postgres_store.rs
+++ b/crates/taskito-workflows/src/postgres_store.rs
@@ -107,4 +107,8 @@ impl WorkflowPostgresStorage {
     }
 }
 
-impl_workflow_diesel_ops!(WorkflowPostgresStorage, PgConnection);
+impl_workflow_diesel_ops!(
+    WorkflowPostgresStorage,
+    PgConnection,
+    crate::diesel_common::pg_rewrite
+);

--- a/crates/taskito-workflows/src/postgres_store.rs
+++ b/crates/taskito-workflows/src/postgres_store.rs
@@ -1,0 +1,110 @@
+//! PostgreSQL implementation of `WorkflowStorage`.
+//!
+//! Construction runs the workflow-table migrations once and caches a pool
+//! handle to the underlying `PostgresStorage`. Every trait method is generated
+//! by the `impl_workflow_diesel_ops!` macro in `diesel_common.rs` — the SQL
+//! bodies are byte-identical to SQLite (Diesel rewrites `?` to `$N` per
+//! backend), only the DDL differs (`BYTEA` for `BLOB`, `BIGINT` for `INTEGER`
+//! timestamps).
+
+use diesel::pg::PgConnection;
+use diesel::prelude::*;
+
+use taskito_core::error::Result;
+use taskito_core::storage::postgres::PostgresStorage;
+
+use crate::diesel_common::impl_workflow_diesel_ops;
+
+fn run_workflow_migrations(conn: &mut PgConnection) -> Result<()> {
+    diesel::sql_query(
+        "CREATE TABLE IF NOT EXISTS workflow_definitions (
+            id             TEXT PRIMARY KEY,
+            name           TEXT NOT NULL,
+            version        INTEGER NOT NULL DEFAULT 1,
+            dag_data       BYTEA NOT NULL,
+            step_metadata  TEXT NOT NULL,
+            created_at     BIGINT NOT NULL,
+            UNIQUE(name, version)
+        )",
+    )
+    .execute(conn)?;
+
+    diesel::sql_query("CREATE INDEX IF NOT EXISTS idx_wf_def_name ON workflow_definitions(name)")
+        .execute(conn)?;
+
+    diesel::sql_query(
+        "CREATE TABLE IF NOT EXISTS workflow_runs (
+            id               TEXT PRIMARY KEY,
+            definition_id    TEXT NOT NULL,
+            params           TEXT,
+            state            TEXT NOT NULL DEFAULT 'pending',
+            started_at       BIGINT,
+            completed_at     BIGINT,
+            error            TEXT,
+            parent_run_id    TEXT,
+            parent_node_name TEXT,
+            created_at       BIGINT NOT NULL
+        )",
+    )
+    .execute(conn)?;
+
+    diesel::sql_query("CREATE INDEX IF NOT EXISTS idx_wf_run_def ON workflow_runs(definition_id)")
+        .execute(conn)?;
+
+    diesel::sql_query("CREATE INDEX IF NOT EXISTS idx_wf_run_state ON workflow_runs(state)")
+        .execute(conn)?;
+
+    diesel::sql_query(
+        "CREATE TABLE IF NOT EXISTS workflow_nodes (
+            id             TEXT PRIMARY KEY,
+            run_id         TEXT NOT NULL,
+            node_name      TEXT NOT NULL,
+            job_id         TEXT,
+            status         TEXT NOT NULL DEFAULT 'pending',
+            result_hash    TEXT,
+            fan_out_count  INTEGER,
+            fan_in_data    TEXT,
+            started_at     BIGINT,
+            completed_at   BIGINT,
+            error          TEXT,
+            UNIQUE(run_id, node_name)
+        )",
+    )
+    .execute(conn)?;
+
+    diesel::sql_query("CREATE INDEX IF NOT EXISTS idx_wf_node_run ON workflow_nodes(run_id)")
+        .execute(conn)?;
+
+    diesel::sql_query(
+        "CREATE INDEX IF NOT EXISTS idx_wf_node_status ON workflow_nodes(run_id, status)",
+    )
+    .execute(conn)?;
+
+    Ok(())
+}
+
+/// Workflow-aware wrapper around `PostgresStorage`.
+///
+/// Runs workflow table migrations on construction, then delegates all
+/// `WorkflowStorage` operations through the shared diesel macro. The wrapped
+/// `PostgresStorage` owns the pool; clones share it.
+#[derive(Clone)]
+pub struct WorkflowPostgresStorage {
+    pub(crate) inner: PostgresStorage,
+}
+
+impl WorkflowPostgresStorage {
+    /// Wrap an existing `PostgresStorage` and ensure workflow tables exist.
+    pub fn new(storage: PostgresStorage) -> Result<Self> {
+        let mut conn = storage.conn()?;
+        run_workflow_migrations(&mut conn)?;
+        Ok(Self { inner: storage })
+    }
+
+    /// Access the underlying `PostgresStorage`.
+    pub fn inner(&self) -> &PostgresStorage {
+        &self.inner
+    }
+}
+
+impl_workflow_diesel_ops!(WorkflowPostgresStorage, PgConnection);

--- a/crates/taskito-workflows/src/sqlite_store.rs
+++ b/crates/taskito-workflows/src/sqlite_store.rs
@@ -104,4 +104,8 @@ impl WorkflowSqliteStorage {
     }
 }
 
-impl_workflow_diesel_ops!(WorkflowSqliteStorage, SqliteConnection);
+impl_workflow_diesel_ops!(
+    WorkflowSqliteStorage,
+    SqliteConnection,
+    crate::diesel_common::sql_as_is
+);


### PR DESCRIPTION
## Summary

Enables the workflow engine on PostgreSQL. Audit P1 step 1 of 3 (parity work — Redis + contract tests follow in subsequent PRs).

- New `WorkflowPostgresStorage` mirrors `WorkflowSqliteStorage`, reuses the shared diesel macro for the 25-method `WorkflowStorage` impl.
- `WorkflowStorageBackend` enum gets a `Postgres` variant; the 25 manual match arms collapse behind a new `delegate!` macro (−75 LOC, fully clean).
- `crates/taskito-python/src/py_queue/workflow_ops/mod.rs` no longer raises `PyRuntimeError` for postgres-backed queues.
- Latent fan-out bug fixed: `expand_fan_out` now builds the child-node list and calls `create_workflow_nodes_batch` once, which wraps every INSERT in one transaction. No more partial node-state on crash mid-expansion.
- Found and fixed a Diesel correctness bug while testing: `sql_query` does **not** rewrite `?` to `$N` per backend. Added `sql_as_is` / `pg_rewrite` SQL prep functions and threaded a `$prep_sql:path` arg through `impl_workflow_diesel_ops!`. SQLite stays on canonical `?`; Postgres rewrites once per query.

## Test plan

- [x] `cargo test --workspace` — all 91 tests pass (incl. 29 workflow)
- [x] `cargo check --workspace --features workflows,postgres`
- [x] `cargo clippy --workspace --features workflows,postgres -- -D warnings`
- [x] `uv run python -m pytest tests/workflows/ tests/core/` — 210 passed
- [x] End-to-end smoke: linear 4-step workflow on Postgres runs in order
- [x] End-to-end smoke: fan-out workflow on Postgres runs to completion

Backend parity machine-verification (contract suite running against PG in CI) lands in PR 3.