### PR TITLE
test(workflows): multi-backend storage contract suite + CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,7 @@ jobs:
           prefix-key: v1-rust-bin-fix
 
       - name: Run Rust test suite (PostgreSQL backend)
-        run: cargo test --workspace --features postgres
+        run: cargo test --workspace --features postgres,workflows
         env:
           LD_LIBRARY_PATH: ${{ env.pythonLocation }}/lib
           TASKITO_POSTGRES_TEST_URL: postgres://postgres:test@localhost:5432/taskito_test
@@ -206,7 +206,7 @@ jobs:
           prefix-key: v1-rust-bin-fix
 
       - name: Run Rust test suite (Redis backend)
-        run: cargo test --workspace --features redis
+        run: cargo test --workspace --features redis,workflows
         env:
           LD_LIBRARY_PATH: ${{ env.pythonLocation }}/lib
           TASKITO_REDIS_TEST_URL: redis://localhost:6379/15

--- a/crates/taskito-core/src/storage/redis_backend/mod.rs
+++ b/crates/taskito-core/src/storage/redis_backend/mod.rs
@@ -64,6 +64,14 @@ impl RedisStorage {
             .get_connection()
             .map_err(|e| QueueError::Other(format!("Redis connection error: {e}")))
     }
+
+    /// The key prefix used for every Redis key this storage writes.
+    ///
+    /// Exposed so adjacent stores (e.g. the workflow store) can namespace
+    /// their own keys under the same prefix without re-parsing the URL.
+    pub fn prefix(&self) -> &str {
+        &self.prefix
+    }
 }
 
 fn map_err(e: redis::RedisError) -> QueueError {

--- a/crates/taskito-python/Cargo.toml
+++ b/crates/taskito-python/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [features]
 default = []
 extension-module = ["pyo3/extension-module"]
-postgres = ["taskito-core/postgres"]
+postgres = ["taskito-core/postgres", "taskito-workflows?/postgres"]
 redis = ["taskito-core/redis"]
 native-async = ["dep:taskito-async"]
 workflows = ["dep:taskito-workflows"]

--- a/crates/taskito-python/Cargo.toml
+++ b/crates/taskito-python/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 default = []
 extension-module = ["pyo3/extension-module"]
 postgres = ["taskito-core/postgres", "taskito-workflows?/postgres"]
-redis = ["taskito-core/redis"]
+redis = ["taskito-core/redis", "taskito-workflows?/redis"]
 native-async = ["dep:taskito-async"]
 workflows = ["dep:taskito-workflows"]
 

--- a/crates/taskito-python/src/py_queue/workflow_ops/fan_out.rs
+++ b/crates/taskito-python/src/py_queue/workflow_ops/fan_out.rs
@@ -65,7 +65,12 @@ impl PyQueue {
                 return Ok(Vec::new());
             }
 
+            // Enqueue all child jobs first, then atomically batch-insert the
+            // matching workflow_nodes. The batch insert wraps every row in one
+            // transaction, so a crash partway through node creation no longer
+            // leaves the run with half-tracked children.
             let mut child_job_ids = Vec::with_capacity(child_names.len());
+            let mut wf_nodes = Vec::with_capacity(child_names.len());
             for (child_name, payload) in child_names.iter().zip(child_payloads.into_iter()) {
                 let new_job = NewJob {
                     queue: queue_owned.clone(),
@@ -86,7 +91,7 @@ impl PyQueue {
                 let job = self.storage.enqueue(new_job)?;
                 child_job_ids.push(job.id.clone());
 
-                let wf_node = WorkflowNode {
+                wf_nodes.push(WorkflowNode {
                     id: uuid::Uuid::now_v7().to_string(),
                     run_id: run_id_owned.clone(),
                     node_name: child_name.clone(),
@@ -98,10 +103,10 @@ impl PyQueue {
                     started_at: None,
                     completed_at: None,
                     error: None,
-                };
-                wf_storage.create_workflow_node(&wf_node)?;
+                });
             }
 
+            wf_storage.create_workflow_nodes_batch(&wf_nodes)?;
             wf_storage.set_workflow_node_fan_out_count(&run_id_owned, &parent_name_owned, count)?;
             Ok(child_job_ids)
         });

--- a/crates/taskito-python/src/py_queue/workflow_ops/mod.rs
+++ b/crates/taskito-python/src/py_queue/workflow_ops/mod.rs
@@ -21,6 +21,8 @@ use taskito_core::error::Result as CoreResult;
 use taskito_core::storage::{Storage, StorageBackend};
 #[cfg(feature = "postgres")]
 use taskito_workflows::WorkflowPostgresStorage;
+#[cfg(feature = "redis")]
+use taskito_workflows::WorkflowRedisStorage;
 use taskito_workflows::{
     StepMetadata, WorkflowNode, WorkflowNodeStatus, WorkflowSqliteStorage, WorkflowState,
     WorkflowStorage, WorkflowStorageBackend,
@@ -47,11 +49,9 @@ pub(super) fn workflow_storage(queue: &PyQueue) -> PyResult<WorkflowStorageBacke
             .map(WorkflowStorageBackend::Postgres)
             .map_err(|e| PyRuntimeError::new_err(e.to_string()))?,
         #[cfg(feature = "redis")]
-        StorageBackend::Redis(_) => {
-            return Err(PyRuntimeError::new_err(
-                "workflows are currently only supported on the SQLite and PostgreSQL backends",
-            ))
-        }
+        StorageBackend::Redis(s) => WorkflowRedisStorage::new(s.clone())
+            .map(WorkflowStorageBackend::Redis)
+            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?,
     };
     // If another thread raced us to initialize, our value is ignored — either
     // handle is equivalent because the underlying pool is shared.

--- a/crates/taskito-python/src/py_queue/workflow_ops/mod.rs
+++ b/crates/taskito-python/src/py_queue/workflow_ops/mod.rs
@@ -19,6 +19,8 @@ use pyo3::prelude::*;
 
 use taskito_core::error::Result as CoreResult;
 use taskito_core::storage::{Storage, StorageBackend};
+#[cfg(feature = "postgres")]
+use taskito_workflows::WorkflowPostgresStorage;
 use taskito_workflows::{
     StepMetadata, WorkflowNode, WorkflowNodeStatus, WorkflowSqliteStorage, WorkflowState,
     WorkflowStorage, WorkflowStorageBackend,
@@ -41,15 +43,13 @@ pub(super) fn workflow_storage(queue: &PyQueue) -> PyResult<WorkflowStorageBacke
             .map(WorkflowStorageBackend::Sqlite)
             .map_err(|e| PyRuntimeError::new_err(e.to_string()))?,
         #[cfg(feature = "postgres")]
-        StorageBackend::Postgres(_) => {
-            return Err(PyRuntimeError::new_err(
-                "workflows are currently only supported on the SQLite backend",
-            ))
-        }
+        StorageBackend::Postgres(s) => WorkflowPostgresStorage::new(s.clone())
+            .map(WorkflowStorageBackend::Postgres)
+            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?,
         #[cfg(feature = "redis")]
         StorageBackend::Redis(_) => {
             return Err(PyRuntimeError::new_err(
-                "workflows are currently only supported on the SQLite backend",
+                "workflows are currently only supported on the SQLite and PostgreSQL backends",
             ))
         }
     };

--- a/crates/taskito-workflows/Cargo.toml
+++ b/crates/taskito-workflows/Cargo.toml
@@ -17,3 +17,7 @@ uuid = { workspace = true }
 diesel = { workspace = true }
 log = { workspace = true }
 redis = { workspace = true, optional = true }
+
+[dev-dependencies]
+uuid = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/taskito-workflows/Cargo.toml
+++ b/crates/taskito-workflows/Cargo.toml
@@ -3,6 +3,10 @@ name = "taskito-workflows"
 version = "0.12.3"
 edition = "2021"
 
+[features]
+default = []
+postgres = ["taskito-core/postgres", "diesel/postgres"]
+
 [dependencies]
 taskito-core = { path = "../taskito-core" }
 dagron-core = { workspace = true }

--- a/crates/taskito-workflows/Cargo.toml
+++ b/crates/taskito-workflows/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [features]
 default = []
 postgres = ["taskito-core/postgres", "diesel/postgres"]
+redis = ["taskito-core/redis", "dep:redis"]
 
 [dependencies]
 taskito-core = { path = "../taskito-core" }
@@ -15,3 +16,4 @@ serde_json = { workspace = true }
 uuid = { workspace = true }
 diesel = { workspace = true }
 log = { workspace = true }
+redis = { workspace = true, optional = true }

--- a/crates/taskito-workflows/src/diesel_common.rs
+++ b/crates/taskito-workflows/src/diesel_common.rs
@@ -38,6 +38,7 @@ pub(crate) fn sql_as_is(sql: &str) -> String {
 /// uses `$1`, `$2`, …; SQLite uses `?`. Doing the rewrite once at query time
 /// (a handful of µs for the short SQL bodies used here) lets the workflow
 /// crate keep a single canonical SQL string per query.
+#[cfg(feature = "postgres")]
 pub(crate) fn pg_rewrite(sql: &str) -> String {
     use std::fmt::Write;
     let mut out = String::with_capacity(sql.len() + 8);

--- a/crates/taskito-workflows/src/diesel_common.rs
+++ b/crates/taskito-workflows/src/diesel_common.rs
@@ -400,28 +400,31 @@ macro_rules! impl_workflow_diesel_ops {
                 &self,
                 nodes: &[$crate::WorkflowNode],
             ) -> ::taskito_core::error::Result<()> {
+                use ::diesel::connection::Connection;
                 let mut conn = self.inner.conn()?;
-                for node in nodes {
-                    ::diesel::sql_query(
-                        "INSERT INTO workflow_nodes
-                            (id, run_id, node_name, job_id, status, result_hash,
-                             fan_out_count, fan_in_data, started_at, completed_at, error)
-                         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                    )
-                    .bind::<::diesel::sql_types::Text, _>(&node.id)
-                    .bind::<::diesel::sql_types::Text, _>(&node.run_id)
-                    .bind::<::diesel::sql_types::Text, _>(&node.node_name)
-                    .bind::<::diesel::sql_types::Nullable<::diesel::sql_types::Text>, _>(&node.job_id)
-                    .bind::<::diesel::sql_types::Text, _>(node.status.as_str())
-                    .bind::<::diesel::sql_types::Nullable<::diesel::sql_types::Text>, _>(&node.result_hash)
-                    .bind::<::diesel::sql_types::Nullable<::diesel::sql_types::Integer>, _>(node.fan_out_count)
-                    .bind::<::diesel::sql_types::Nullable<::diesel::sql_types::Text>, _>(&node.fan_in_data)
-                    .bind::<::diesel::sql_types::Nullable<::diesel::sql_types::BigInt>, _>(node.started_at)
-                    .bind::<::diesel::sql_types::Nullable<::diesel::sql_types::BigInt>, _>(node.completed_at)
-                    .bind::<::diesel::sql_types::Nullable<::diesel::sql_types::Text>, _>(&node.error)
-                    .execute(&mut *conn)?;
-                }
-                Ok(())
+                conn.transaction::<_, ::taskito_core::error::QueueError, _>(|conn| {
+                    for node in nodes {
+                        ::diesel::sql_query(
+                            "INSERT INTO workflow_nodes
+                                (id, run_id, node_name, job_id, status, result_hash,
+                                 fan_out_count, fan_in_data, started_at, completed_at, error)
+                             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                        )
+                        .bind::<::diesel::sql_types::Text, _>(&node.id)
+                        .bind::<::diesel::sql_types::Text, _>(&node.run_id)
+                        .bind::<::diesel::sql_types::Text, _>(&node.node_name)
+                        .bind::<::diesel::sql_types::Nullable<::diesel::sql_types::Text>, _>(&node.job_id)
+                        .bind::<::diesel::sql_types::Text, _>(node.status.as_str())
+                        .bind::<::diesel::sql_types::Nullable<::diesel::sql_types::Text>, _>(&node.result_hash)
+                        .bind::<::diesel::sql_types::Nullable<::diesel::sql_types::Integer>, _>(node.fan_out_count)
+                        .bind::<::diesel::sql_types::Nullable<::diesel::sql_types::Text>, _>(&node.fan_in_data)
+                        .bind::<::diesel::sql_types::Nullable<::diesel::sql_types::BigInt>, _>(node.started_at)
+                        .bind::<::diesel::sql_types::Nullable<::diesel::sql_types::BigInt>, _>(node.completed_at)
+                        .bind::<::diesel::sql_types::Nullable<::diesel::sql_types::Text>, _>(&node.error)
+                        .execute(conn)?;
+                    }
+                    Ok(())
+                })
             }
 
             fn get_workflow_node(

--- a/crates/taskito-workflows/src/diesel_common.rs
+++ b/crates/taskito-workflows/src/diesel_common.rs
@@ -1,17 +1,21 @@
 //! Shared Diesel-based implementation for SQLite + PostgreSQL workflow stores.
 //!
-//! `impl_workflow_diesel_ops!($storage_type, $conn_type)` generates a complete
-//! `impl WorkflowStorage for $storage_type` block. The macro contract: the
-//! storage type must expose an `inner: T` field where `T` has a
+//! `impl_workflow_diesel_ops!($storage_type, $conn_type, $prep_sql)` generates
+//! a complete `impl WorkflowStorage for $storage_type` block. The macro
+//! contract: the storage type must expose an `inner: T` field where `T` has a
 //! `conn() -> Result<PooledConnection<...>>` method that derefs to a mutable
 //! `$conn_type`. SQLite and Postgres both satisfy this via their core storage
 //! handles.
 //!
-//! Diesel's `sql_query` rewrites `?` placeholders per backend automatically, so
-//! the SQL strings here are byte-identical between SQLite and Postgres. The
-//! only schema differences (`BLOB` vs `BYTEA`, `INTEGER` vs `BIGINT` for
-//! timestamps) are handled by the bound `diesel::sql_types::*` types and by
-//! the per-backend migration files — the query bodies stay unified.
+//! Diesel's `sql_query` does **not** rewrite `?` placeholders per backend — it
+//! requires `?` for SQLite and `$N` for Postgres. The `$prep_sql` macro
+//! argument names a function that converts the canonical (`?`-based) SQL into
+//! the dialect the connection expects. `sql_as_is` is a no-op for SQLite;
+//! `pg_rewrite` substitutes `?` → `$1`, `$2`, … for Postgres.
+//!
+//! Schema differences (`BLOB` vs `BYTEA`, `INTEGER` vs `BIGINT` for
+//! timestamps) are handled by the bound `diesel::sql_types::*` types and the
+//! per-backend migration files — the query bodies stay unified.
 
 use diesel::prelude::*;
 use diesel::sql_types::Text;
@@ -21,6 +25,34 @@ use taskito_core::error::{QueueError, Result};
 use crate::{
     StepMetadata, WorkflowDefinition, WorkflowNode, WorkflowNodeStatus, WorkflowRun, WorkflowState,
 };
+
+/// Pass-through SQL prep for SQLite — `?` placeholders are native.
+#[inline]
+pub(crate) fn sql_as_is(sql: &str) -> String {
+    sql.to_string()
+}
+
+/// Rewrite `?` placeholders to `$N` for Postgres in the order they appear.
+///
+/// Diesel's `sql_query` API requires dialect-correct placeholders. Postgres
+/// uses `$1`, `$2`, …; SQLite uses `?`. Doing the rewrite once at query time
+/// (a handful of µs for the short SQL bodies used here) lets the workflow
+/// crate keep a single canonical SQL string per query.
+pub(crate) fn pg_rewrite(sql: &str) -> String {
+    use std::fmt::Write;
+    let mut out = String::with_capacity(sql.len() + 8);
+    let mut n: usize = 1;
+    for c in sql.chars() {
+        if c == '?' {
+            // `write!` to String is infallible — `.unwrap()` is safe.
+            write!(out, "${n}").unwrap();
+            n += 1;
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
 
 #[derive(QueryableByName)]
 pub(crate) struct DefinitionRow {
@@ -137,11 +169,12 @@ pub(crate) fn node_from_row(row: NodeRow) -> WorkflowNode {
 
 /// Generate the full `impl WorkflowStorage for $storage_type` block.
 ///
-/// Both SQLite and Postgres implementations are byte-identical at the SQL
-/// level (Diesel rewrites `?` per backend). The macro takes the connection
-/// type so each backend's compile-time bind type-checks correctly.
+/// `$prep_sql` names a function that converts canonical (`?`-based) SQL into
+/// the dialect the connection expects. `$crate::diesel_common::sql_as_is`
+/// works for SQLite; `$crate::diesel_common::pg_rewrite` swaps `?` → `$N` for
+/// Postgres.
 macro_rules! impl_workflow_diesel_ops {
-    ($storage_type:ty, $conn_type:ty) => {
+    ($storage_type:ty, $conn_type:ty, $prep_sql:path) => {
         impl $crate::storage::WorkflowStorage for $storage_type {
             fn create_workflow_definition(
                 &self,
@@ -155,8 +188,8 @@ macro_rules! impl_workflow_diesel_ops {
                 })?;
 
                 ::diesel::sql_query(
-                    "INSERT INTO workflow_definitions (id, name, version, dag_data, step_metadata, created_at)
-                     VALUES (?, ?, ?, ?, ?, ?)",
+                    &$prep_sql("INSERT INTO workflow_definitions (id, name, version, dag_data, step_metadata, created_at)
+                     VALUES (?, ?, ?, ?, ?, ?)"),
                 )
                 .bind::<::diesel::sql_types::Text, _>(&def.id)
                 .bind::<::diesel::sql_types::Text, _>(&def.name)
@@ -178,16 +211,16 @@ macro_rules! impl_workflow_diesel_ops {
 
                 let rows: Vec<$crate::diesel_common::DefinitionRow> = if let Some(v) = version {
                     ::diesel::sql_query(
-                        "SELECT id, name, version, dag_data, step_metadata, created_at
-                         FROM workflow_definitions WHERE name = ? AND version = ?",
+                        &$prep_sql("SELECT id, name, version, dag_data, step_metadata, created_at
+                         FROM workflow_definitions WHERE name = ? AND version = ?"),
                     )
                     .bind::<::diesel::sql_types::Text, _>(name)
                     .bind::<::diesel::sql_types::Integer, _>(v)
                     .load(&mut *conn)?
                 } else {
                     ::diesel::sql_query(
-                        "SELECT id, name, version, dag_data, step_metadata, created_at
-                         FROM workflow_definitions WHERE name = ? ORDER BY version DESC LIMIT 1",
+                        &$prep_sql("SELECT id, name, version, dag_data, step_metadata, created_at
+                         FROM workflow_definitions WHERE name = ? ORDER BY version DESC LIMIT 1"),
                     )
                     .bind::<::diesel::sql_types::Text, _>(name)
                     .load(&mut *conn)?
@@ -205,8 +238,8 @@ macro_rules! impl_workflow_diesel_ops {
             ) -> ::taskito_core::error::Result<Option<$crate::WorkflowDefinition>> {
                 let mut conn = self.inner.conn()?;
                 let rows: Vec<$crate::diesel_common::DefinitionRow> = ::diesel::sql_query(
-                    "SELECT id, name, version, dag_data, step_metadata, created_at
-                     FROM workflow_definitions WHERE id = ?",
+                    &$prep_sql("SELECT id, name, version, dag_data, step_metadata, created_at
+                     FROM workflow_definitions WHERE id = ?"),
                 )
                 .bind::<::diesel::sql_types::Text, _>(id)
                 .load(&mut *conn)?;
@@ -223,10 +256,10 @@ macro_rules! impl_workflow_diesel_ops {
             ) -> ::taskito_core::error::Result<()> {
                 let mut conn = self.inner.conn()?;
                 ::diesel::sql_query(
-                    "INSERT INTO workflow_runs
+                    &$prep_sql("INSERT INTO workflow_runs
                         (id, definition_id, params, state, started_at, completed_at, error,
                          parent_run_id, parent_node_name, created_at)
-                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"),
                 )
                 .bind::<::diesel::sql_types::Text, _>(&run.id)
                 .bind::<::diesel::sql_types::Text, _>(&run.definition_id)
@@ -249,9 +282,9 @@ macro_rules! impl_workflow_diesel_ops {
             ) -> ::taskito_core::error::Result<Option<$crate::WorkflowRun>> {
                 let mut conn = self.inner.conn()?;
                 let rows: Vec<$crate::diesel_common::RunRow> = ::diesel::sql_query(
-                    "SELECT id, definition_id, params, state, started_at, completed_at, error,
+                    &$prep_sql("SELECT id, definition_id, params, state, started_at, completed_at, error,
                             parent_run_id, parent_node_name, created_at
-                     FROM workflow_runs WHERE id = ?",
+                     FROM workflow_runs WHERE id = ?"),
                 )
                 .bind::<::diesel::sql_types::Text, _>(run_id)
                 .load(&mut *conn)?;
@@ -267,7 +300,7 @@ macro_rules! impl_workflow_diesel_ops {
             ) -> ::taskito_core::error::Result<()> {
                 let mut conn = self.inner.conn()?;
                 ::diesel::sql_query(
-                    "UPDATE workflow_runs SET state = ?, error = ? WHERE id = ?",
+                    &$prep_sql("UPDATE workflow_runs SET state = ?, error = ? WHERE id = ?"),
                 )
                 .bind::<::diesel::sql_types::Text, _>(state.as_str())
                 .bind::<::diesel::sql_types::Nullable<::diesel::sql_types::Text>, _>(error)
@@ -283,7 +316,7 @@ macro_rules! impl_workflow_diesel_ops {
             ) -> ::taskito_core::error::Result<()> {
                 let mut conn = self.inner.conn()?;
                 ::diesel::sql_query(
-                    "UPDATE workflow_runs SET state = 'running', started_at = ? WHERE id = ?",
+                    &$prep_sql("UPDATE workflow_runs SET state = 'running', started_at = ? WHERE id = ?"),
                 )
                 .bind::<::diesel::sql_types::BigInt, _>(started_at)
                 .bind::<::diesel::sql_types::Text, _>(run_id)
@@ -298,7 +331,7 @@ macro_rules! impl_workflow_diesel_ops {
             ) -> ::taskito_core::error::Result<()> {
                 let mut conn = self.inner.conn()?;
                 ::diesel::sql_query(
-                    "UPDATE workflow_runs SET completed_at = ? WHERE id = ?",
+                    &$prep_sql("UPDATE workflow_runs SET completed_at = ? WHERE id = ?"),
                 )
                 .bind::<::diesel::sql_types::BigInt, _>(completed_at)
                 .bind::<::diesel::sql_types::Text, _>(run_id)
@@ -317,13 +350,13 @@ macro_rules! impl_workflow_diesel_ops {
 
                 let rows: Vec<$crate::diesel_common::RunRow> = match (definition_name, state) {
                     (Some(name), Some(st)) => ::diesel::sql_query(
-                        "SELECT r.id, r.definition_id, r.params, r.state, r.started_at,
+                        &$prep_sql("SELECT r.id, r.definition_id, r.params, r.state, r.started_at,
                                 r.completed_at, r.error, r.parent_run_id, r.parent_node_name,
                                 r.created_at
                          FROM workflow_runs r
                          JOIN workflow_definitions d ON r.definition_id = d.id
                          WHERE d.name = ? AND r.state = ?
-                         ORDER BY r.created_at DESC LIMIT ? OFFSET ?",
+                         ORDER BY r.created_at DESC LIMIT ? OFFSET ?"),
                     )
                     .bind::<::diesel::sql_types::Text, _>(name)
                     .bind::<::diesel::sql_types::Text, _>(st.as_str())
@@ -331,33 +364,33 @@ macro_rules! impl_workflow_diesel_ops {
                     .bind::<::diesel::sql_types::BigInt, _>(offset)
                     .load(&mut *conn)?,
                     (Some(name), None) => ::diesel::sql_query(
-                        "SELECT r.id, r.definition_id, r.params, r.state, r.started_at,
+                        &$prep_sql("SELECT r.id, r.definition_id, r.params, r.state, r.started_at,
                                 r.completed_at, r.error, r.parent_run_id, r.parent_node_name,
                                 r.created_at
                          FROM workflow_runs r
                          JOIN workflow_definitions d ON r.definition_id = d.id
                          WHERE d.name = ?
-                         ORDER BY r.created_at DESC LIMIT ? OFFSET ?",
+                         ORDER BY r.created_at DESC LIMIT ? OFFSET ?"),
                     )
                     .bind::<::diesel::sql_types::Text, _>(name)
                     .bind::<::diesel::sql_types::BigInt, _>(limit)
                     .bind::<::diesel::sql_types::BigInt, _>(offset)
                     .load(&mut *conn)?,
                     (None, Some(st)) => ::diesel::sql_query(
-                        "SELECT id, definition_id, params, state, started_at, completed_at,
+                        &$prep_sql("SELECT id, definition_id, params, state, started_at, completed_at,
                                 error, parent_run_id, parent_node_name, created_at
                          FROM workflow_runs WHERE state = ?
-                         ORDER BY created_at DESC LIMIT ? OFFSET ?",
+                         ORDER BY created_at DESC LIMIT ? OFFSET ?"),
                     )
                     .bind::<::diesel::sql_types::Text, _>(st.as_str())
                     .bind::<::diesel::sql_types::BigInt, _>(limit)
                     .bind::<::diesel::sql_types::BigInt, _>(offset)
                     .load(&mut *conn)?,
                     (None, None) => ::diesel::sql_query(
-                        "SELECT id, definition_id, params, state, started_at, completed_at,
+                        &$prep_sql("SELECT id, definition_id, params, state, started_at, completed_at,
                                 error, parent_run_id, parent_node_name, created_at
                          FROM workflow_runs
-                         ORDER BY created_at DESC LIMIT ? OFFSET ?",
+                         ORDER BY created_at DESC LIMIT ? OFFSET ?"),
                     )
                     .bind::<::diesel::sql_types::BigInt, _>(limit)
                     .bind::<::diesel::sql_types::BigInt, _>(offset)
@@ -376,10 +409,10 @@ macro_rules! impl_workflow_diesel_ops {
             ) -> ::taskito_core::error::Result<()> {
                 let mut conn = self.inner.conn()?;
                 ::diesel::sql_query(
-                    "INSERT INTO workflow_nodes
+                    &$prep_sql("INSERT INTO workflow_nodes
                         (id, run_id, node_name, job_id, status, result_hash,
                          fan_out_count, fan_in_data, started_at, completed_at, error)
-                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"),
                 )
                 .bind::<::diesel::sql_types::Text, _>(&node.id)
                 .bind::<::diesel::sql_types::Text, _>(&node.run_id)
@@ -405,10 +438,10 @@ macro_rules! impl_workflow_diesel_ops {
                 conn.transaction::<_, ::taskito_core::error::QueueError, _>(|conn| {
                     for node in nodes {
                         ::diesel::sql_query(
-                            "INSERT INTO workflow_nodes
+                            &$prep_sql("INSERT INTO workflow_nodes
                                 (id, run_id, node_name, job_id, status, result_hash,
                                  fan_out_count, fan_in_data, started_at, completed_at, error)
-                             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"),
                         )
                         .bind::<::diesel::sql_types::Text, _>(&node.id)
                         .bind::<::diesel::sql_types::Text, _>(&node.run_id)
@@ -434,9 +467,9 @@ macro_rules! impl_workflow_diesel_ops {
             ) -> ::taskito_core::error::Result<Option<$crate::WorkflowNode>> {
                 let mut conn = self.inner.conn()?;
                 let rows: Vec<$crate::diesel_common::NodeRow> = ::diesel::sql_query(
-                    "SELECT id, run_id, node_name, job_id, status, result_hash,
+                    &$prep_sql("SELECT id, run_id, node_name, job_id, status, result_hash,
                             fan_out_count, fan_in_data, started_at, completed_at, error
-                     FROM workflow_nodes WHERE run_id = ? AND node_name = ?",
+                     FROM workflow_nodes WHERE run_id = ? AND node_name = ?"),
                 )
                 .bind::<::diesel::sql_types::Text, _>(run_id)
                 .bind::<::diesel::sql_types::Text, _>(node_name)
@@ -454,9 +487,9 @@ macro_rules! impl_workflow_diesel_ops {
             ) -> ::taskito_core::error::Result<Vec<$crate::WorkflowNode>> {
                 let mut conn = self.inner.conn()?;
                 let rows: Vec<$crate::diesel_common::NodeRow> = ::diesel::sql_query(
-                    "SELECT id, run_id, node_name, job_id, status, result_hash,
+                    &$prep_sql("SELECT id, run_id, node_name, job_id, status, result_hash,
                             fan_out_count, fan_in_data, started_at, completed_at, error
-                     FROM workflow_nodes WHERE run_id = ?",
+                     FROM workflow_nodes WHERE run_id = ?"),
                 )
                 .bind::<::diesel::sql_types::Text, _>(run_id)
                 .load(&mut *conn)?;
@@ -475,7 +508,7 @@ macro_rules! impl_workflow_diesel_ops {
             ) -> ::taskito_core::error::Result<()> {
                 let mut conn = self.inner.conn()?;
                 ::diesel::sql_query(
-                    "UPDATE workflow_nodes SET status = ? WHERE run_id = ? AND node_name = ?",
+                    &$prep_sql("UPDATE workflow_nodes SET status = ? WHERE run_id = ? AND node_name = ?"),
                 )
                 .bind::<::diesel::sql_types::Text, _>(status.as_str())
                 .bind::<::diesel::sql_types::Text, _>(run_id)
@@ -492,7 +525,7 @@ macro_rules! impl_workflow_diesel_ops {
             ) -> ::taskito_core::error::Result<()> {
                 let mut conn = self.inner.conn()?;
                 ::diesel::sql_query(
-                    "UPDATE workflow_nodes SET job_id = ? WHERE run_id = ? AND node_name = ?",
+                    &$prep_sql("UPDATE workflow_nodes SET job_id = ? WHERE run_id = ? AND node_name = ?"),
                 )
                 .bind::<::diesel::sql_types::Text, _>(job_id)
                 .bind::<::diesel::sql_types::Text, _>(run_id)
@@ -509,8 +542,8 @@ macro_rules! impl_workflow_diesel_ops {
             ) -> ::taskito_core::error::Result<()> {
                 let mut conn = self.inner.conn()?;
                 ::diesel::sql_query(
-                    "UPDATE workflow_nodes SET status = 'running', started_at = ?
-                     WHERE run_id = ? AND node_name = ?",
+                    &$prep_sql("UPDATE workflow_nodes SET status = 'running', started_at = ?
+                     WHERE run_id = ? AND node_name = ?"),
                 )
                 .bind::<::diesel::sql_types::BigInt, _>(started_at)
                 .bind::<::diesel::sql_types::Text, _>(run_id)
@@ -528,8 +561,8 @@ macro_rules! impl_workflow_diesel_ops {
             ) -> ::taskito_core::error::Result<()> {
                 let mut conn = self.inner.conn()?;
                 ::diesel::sql_query(
-                    "UPDATE workflow_nodes SET status = 'completed', completed_at = ?, result_hash = ?
-                     WHERE run_id = ? AND node_name = ?",
+                    &$prep_sql("UPDATE workflow_nodes SET status = 'completed', completed_at = ?, result_hash = ?
+                     WHERE run_id = ? AND node_name = ?"),
                 )
                 .bind::<::diesel::sql_types::BigInt, _>(completed_at)
                 .bind::<::diesel::sql_types::Nullable<::diesel::sql_types::Text>, _>(result_hash)
@@ -547,8 +580,8 @@ macro_rules! impl_workflow_diesel_ops {
             ) -> ::taskito_core::error::Result<()> {
                 let mut conn = self.inner.conn()?;
                 ::diesel::sql_query(
-                    "UPDATE workflow_nodes SET status = 'failed', error = ?
-                     WHERE run_id = ? AND node_name = ?",
+                    &$prep_sql("UPDATE workflow_nodes SET status = 'failed', error = ?
+                     WHERE run_id = ? AND node_name = ?"),
                 )
                 .bind::<::diesel::sql_types::Text, _>(error)
                 .bind::<::diesel::sql_types::Text, _>(run_id)
@@ -565,8 +598,8 @@ macro_rules! impl_workflow_diesel_ops {
             ) -> ::taskito_core::error::Result<()> {
                 let mut conn = self.inner.conn()?;
                 ::diesel::sql_query(
-                    "UPDATE workflow_nodes SET fan_out_count = ?, status = 'running'
-                     WHERE run_id = ? AND node_name = ?",
+                    &$prep_sql("UPDATE workflow_nodes SET fan_out_count = ?, status = 'running'
+                     WHERE run_id = ? AND node_name = ?"),
                 )
                 .bind::<::diesel::sql_types::Integer, _>(count)
                 .bind::<::diesel::sql_types::Text, _>(run_id)
@@ -583,8 +616,8 @@ macro_rules! impl_workflow_diesel_ops {
             ) -> ::taskito_core::error::Result<()> {
                 let mut conn = self.inner.conn()?;
                 ::diesel::sql_query(
-                    "UPDATE workflow_nodes SET status = 'running', started_at = ?
-                     WHERE run_id = ? AND node_name = ?",
+                    &$prep_sql("UPDATE workflow_nodes SET status = 'running', started_at = ?
+                     WHERE run_id = ? AND node_name = ?"),
                 )
                 .bind::<::diesel::sql_types::BigInt, _>(started_at)
                 .bind::<::diesel::sql_types::Text, _>(run_id)
@@ -604,10 +637,10 @@ macro_rules! impl_workflow_diesel_ops {
                 let mut conn = self.inner.conn()?;
                 let affected = if succeeded {
                     ::diesel::sql_query(
-                        "UPDATE workflow_nodes
+                        &$prep_sql("UPDATE workflow_nodes
                          SET status = 'completed', completed_at = ?
                          WHERE run_id = ? AND node_name = ?
-                           AND status NOT IN ('completed', 'failed', 'skipped', 'cache_hit')",
+                           AND status NOT IN ('completed', 'failed', 'skipped', 'cache_hit')"),
                     )
                     .bind::<::diesel::sql_types::BigInt, _>(completed_at)
                     .bind::<::diesel::sql_types::Text, _>(run_id)
@@ -615,10 +648,10 @@ macro_rules! impl_workflow_diesel_ops {
                     .execute(&mut *conn)?
                 } else {
                     ::diesel::sql_query(
-                        "UPDATE workflow_nodes
+                        &$prep_sql("UPDATE workflow_nodes
                          SET status = 'failed', error = ?
                          WHERE run_id = ? AND node_name = ?
-                           AND status NOT IN ('completed', 'failed', 'skipped', 'cache_hit')",
+                           AND status NOT IN ('completed', 'failed', 'skipped', 'cache_hit')"),
                     )
                     .bind::<::diesel::sql_types::Text, _>(error.unwrap_or("fan-out child failed"))
                     .bind::<::diesel::sql_types::Text, _>(run_id)
@@ -636,9 +669,9 @@ macro_rules! impl_workflow_diesel_ops {
                 let mut conn = self.inner.conn()?;
                 let pattern = format!("{prefix}%");
                 let rows: Vec<$crate::diesel_common::NodeRow> = ::diesel::sql_query(
-                    "SELECT id, run_id, node_name, job_id, status, result_hash,
+                    &$prep_sql("SELECT id, run_id, node_name, job_id, status, result_hash,
                             fan_out_count, fan_in_data, started_at, completed_at, error
-                     FROM workflow_nodes WHERE run_id = ? AND node_name LIKE ?",
+                     FROM workflow_nodes WHERE run_id = ? AND node_name LIKE ?"),
                 )
                 .bind::<::diesel::sql_types::Text, _>(run_id)
                 .bind::<::diesel::sql_types::Text, _>(&pattern)
@@ -666,9 +699,9 @@ macro_rules! impl_workflow_diesel_ops {
             ) -> ::taskito_core::error::Result<Vec<$crate::WorkflowRun>> {
                 let mut conn = self.inner.conn()?;
                 let rows: Vec<$crate::diesel_common::RunRow> = ::diesel::sql_query(
-                    "SELECT id, definition_id, params, state, started_at, completed_at,
+                    &$prep_sql("SELECT id, definition_id, params, state, started_at, completed_at,
                             error, parent_run_id, parent_node_name, created_at
-                     FROM workflow_runs WHERE parent_run_id = ?",
+                     FROM workflow_runs WHERE parent_run_id = ?"),
                 )
                 .bind::<::diesel::sql_types::Text, _>(parent_run_id)
                 .load(&mut *conn)?;

--- a/crates/taskito-workflows/src/lib.rs
+++ b/crates/taskito-workflows/src/lib.rs
@@ -3,6 +3,8 @@ mod definition;
 pub(crate) mod diesel_common;
 mod error;
 mod node;
+#[cfg(feature = "postgres")]
+pub mod postgres_store;
 mod run;
 pub mod sqlite_store;
 mod state;
@@ -15,6 +17,8 @@ pub use dagron_core;
 pub use definition::{StepMetadata, WorkflowDefinition};
 pub use error::WorkflowError;
 pub use node::{WorkflowNode, WorkflowNodeStatus};
+#[cfg(feature = "postgres")]
+pub use postgres_store::WorkflowPostgresStorage;
 pub use run::WorkflowRun;
 pub use sqlite_store::WorkflowSqliteStorage;
 pub use state::WorkflowState;
@@ -34,13 +38,27 @@ use taskito_core::error::Result;
 #[derive(Clone)]
 pub enum WorkflowStorageBackend {
     Sqlite(WorkflowSqliteStorage),
+    #[cfg(feature = "postgres")]
+    Postgres(WorkflowPostgresStorage),
+}
+
+/// Dispatch a `WorkflowStorage` method across every enum variant.
+///
+/// Each variant arm forwards `$method($($arg),*)` to the inner backend handle.
+/// Variants behind `#[cfg(feature = ...)]` are conditionally compiled in.
+macro_rules! delegate {
+    ($self:ident, $method:ident $(, $arg:expr)* $(,)?) => {
+        match $self {
+            Self::Sqlite(s) => s.$method($($arg),*),
+            #[cfg(feature = "postgres")]
+            Self::Postgres(s) => s.$method($($arg),*),
+        }
+    };
 }
 
 impl WorkflowStorage for WorkflowStorageBackend {
     fn create_workflow_definition(&self, def: &WorkflowDefinition) -> Result<()> {
-        match self {
-            Self::Sqlite(s) => s.create_workflow_definition(def),
-        }
+        delegate!(self, create_workflow_definition, def)
     }
 
     fn get_workflow_definition(
@@ -48,27 +66,19 @@ impl WorkflowStorage for WorkflowStorageBackend {
         name: &str,
         version: Option<i32>,
     ) -> Result<Option<WorkflowDefinition>> {
-        match self {
-            Self::Sqlite(s) => s.get_workflow_definition(name, version),
-        }
+        delegate!(self, get_workflow_definition, name, version)
     }
 
     fn get_workflow_definition_by_id(&self, id: &str) -> Result<Option<WorkflowDefinition>> {
-        match self {
-            Self::Sqlite(s) => s.get_workflow_definition_by_id(id),
-        }
+        delegate!(self, get_workflow_definition_by_id, id)
     }
 
     fn create_workflow_run(&self, run: &WorkflowRun) -> Result<()> {
-        match self {
-            Self::Sqlite(s) => s.create_workflow_run(run),
-        }
+        delegate!(self, create_workflow_run, run)
     }
 
     fn get_workflow_run(&self, run_id: &str) -> Result<Option<WorkflowRun>> {
-        match self {
-            Self::Sqlite(s) => s.get_workflow_run(run_id),
-        }
+        delegate!(self, get_workflow_run, run_id)
     }
 
     fn update_workflow_run_state(
@@ -77,21 +87,15 @@ impl WorkflowStorage for WorkflowStorageBackend {
         state: WorkflowState,
         error: Option<&str>,
     ) -> Result<()> {
-        match self {
-            Self::Sqlite(s) => s.update_workflow_run_state(run_id, state, error),
-        }
+        delegate!(self, update_workflow_run_state, run_id, state, error)
     }
 
     fn set_workflow_run_started(&self, run_id: &str, started_at: i64) -> Result<()> {
-        match self {
-            Self::Sqlite(s) => s.set_workflow_run_started(run_id, started_at),
-        }
+        delegate!(self, set_workflow_run_started, run_id, started_at)
     }
 
     fn set_workflow_run_completed(&self, run_id: &str, completed_at: i64) -> Result<()> {
-        match self {
-            Self::Sqlite(s) => s.set_workflow_run_completed(run_id, completed_at),
-        }
+        delegate!(self, set_workflow_run_completed, run_id, completed_at)
     }
 
     fn list_workflow_runs(
@@ -101,33 +105,30 @@ impl WorkflowStorage for WorkflowStorageBackend {
         limit: i64,
         offset: i64,
     ) -> Result<Vec<WorkflowRun>> {
-        match self {
-            Self::Sqlite(s) => s.list_workflow_runs(definition_name, state, limit, offset),
-        }
+        delegate!(
+            self,
+            list_workflow_runs,
+            definition_name,
+            state,
+            limit,
+            offset
+        )
     }
 
     fn create_workflow_node(&self, node: &WorkflowNode) -> Result<()> {
-        match self {
-            Self::Sqlite(s) => s.create_workflow_node(node),
-        }
+        delegate!(self, create_workflow_node, node)
     }
 
     fn create_workflow_nodes_batch(&self, nodes: &[WorkflowNode]) -> Result<()> {
-        match self {
-            Self::Sqlite(s) => s.create_workflow_nodes_batch(nodes),
-        }
+        delegate!(self, create_workflow_nodes_batch, nodes)
     }
 
     fn get_workflow_node(&self, run_id: &str, node_name: &str) -> Result<Option<WorkflowNode>> {
-        match self {
-            Self::Sqlite(s) => s.get_workflow_node(run_id, node_name),
-        }
+        delegate!(self, get_workflow_node, run_id, node_name)
     }
 
     fn get_workflow_nodes(&self, run_id: &str) -> Result<Vec<WorkflowNode>> {
-        match self {
-            Self::Sqlite(s) => s.get_workflow_nodes(run_id),
-        }
+        delegate!(self, get_workflow_nodes, run_id)
     }
 
     fn update_workflow_node_status(
@@ -136,15 +137,11 @@ impl WorkflowStorage for WorkflowStorageBackend {
         node_name: &str,
         status: WorkflowNodeStatus,
     ) -> Result<()> {
-        match self {
-            Self::Sqlite(s) => s.update_workflow_node_status(run_id, node_name, status),
-        }
+        delegate!(self, update_workflow_node_status, run_id, node_name, status)
     }
 
     fn set_workflow_node_job(&self, run_id: &str, node_name: &str, job_id: &str) -> Result<()> {
-        match self {
-            Self::Sqlite(s) => s.set_workflow_node_job(run_id, node_name, job_id),
-        }
+        delegate!(self, set_workflow_node_job, run_id, node_name, job_id)
     }
 
     fn set_workflow_node_started(
@@ -153,9 +150,13 @@ impl WorkflowStorage for WorkflowStorageBackend {
         node_name: &str,
         started_at: i64,
     ) -> Result<()> {
-        match self {
-            Self::Sqlite(s) => s.set_workflow_node_started(run_id, node_name, started_at),
-        }
+        delegate!(
+            self,
+            set_workflow_node_started,
+            run_id,
+            node_name,
+            started_at
+        )
     }
 
     fn set_workflow_node_completed(
@@ -165,23 +166,22 @@ impl WorkflowStorage for WorkflowStorageBackend {
         completed_at: i64,
         result_hash: Option<&str>,
     ) -> Result<()> {
-        match self {
-            Self::Sqlite(s) => {
-                s.set_workflow_node_completed(run_id, node_name, completed_at, result_hash)
-            }
-        }
+        delegate!(
+            self,
+            set_workflow_node_completed,
+            run_id,
+            node_name,
+            completed_at,
+            result_hash
+        )
     }
 
     fn set_workflow_node_error(&self, run_id: &str, node_name: &str, error: &str) -> Result<()> {
-        match self {
-            Self::Sqlite(s) => s.set_workflow_node_error(run_id, node_name, error),
-        }
+        delegate!(self, set_workflow_node_error, run_id, node_name, error)
     }
 
     fn get_ready_workflow_nodes(&self, run_id: &str, dag_json: &str) -> Result<Vec<WorkflowNode>> {
-        match self {
-            Self::Sqlite(s) => s.get_ready_workflow_nodes(run_id, dag_json),
-        }
+        delegate!(self, get_ready_workflow_nodes, run_id, dag_json)
     }
 
     fn set_workflow_node_fan_out_count(
@@ -190,9 +190,13 @@ impl WorkflowStorage for WorkflowStorageBackend {
         node_name: &str,
         count: i32,
     ) -> Result<()> {
-        match self {
-            Self::Sqlite(s) => s.set_workflow_node_fan_out_count(run_id, node_name, count),
-        }
+        delegate!(
+            self,
+            set_workflow_node_fan_out_count,
+            run_id,
+            node_name,
+            count
+        )
     }
 
     fn set_workflow_node_running(
@@ -201,9 +205,13 @@ impl WorkflowStorage for WorkflowStorageBackend {
         node_name: &str,
         started_at: i64,
     ) -> Result<()> {
-        match self {
-            Self::Sqlite(s) => s.set_workflow_node_running(run_id, node_name, started_at),
-        }
+        delegate!(
+            self,
+            set_workflow_node_running,
+            run_id,
+            node_name,
+            started_at
+        )
     }
 
     fn finalize_fan_out_parent(
@@ -214,11 +222,15 @@ impl WorkflowStorage for WorkflowStorageBackend {
         error: Option<&str>,
         completed_at: i64,
     ) -> Result<bool> {
-        match self {
-            Self::Sqlite(s) => {
-                s.finalize_fan_out_parent(run_id, node_name, succeeded, error, completed_at)
-            }
-        }
+        delegate!(
+            self,
+            finalize_fan_out_parent,
+            run_id,
+            node_name,
+            succeeded,
+            error,
+            completed_at
+        )
     }
 
     fn get_workflow_nodes_by_prefix(
@@ -226,14 +238,10 @@ impl WorkflowStorage for WorkflowStorageBackend {
         run_id: &str,
         prefix: &str,
     ) -> Result<Vec<WorkflowNode>> {
-        match self {
-            Self::Sqlite(s) => s.get_workflow_nodes_by_prefix(run_id, prefix),
-        }
+        delegate!(self, get_workflow_nodes_by_prefix, run_id, prefix)
     }
 
     fn get_child_workflow_runs(&self, parent_run_id: &str) -> Result<Vec<WorkflowRun>> {
-        match self {
-            Self::Sqlite(s) => s.get_child_workflow_runs(parent_run_id),
-        }
+        delegate!(self, get_child_workflow_runs, parent_run_id)
     }
 }

--- a/crates/taskito-workflows/src/lib.rs
+++ b/crates/taskito-workflows/src/lib.rs
@@ -5,6 +5,8 @@ mod error;
 mod node;
 #[cfg(feature = "postgres")]
 pub mod postgres_store;
+#[cfg(feature = "redis")]
+pub mod redis_store;
 mod run;
 pub mod sqlite_store;
 mod state;
@@ -19,6 +21,8 @@ pub use error::WorkflowError;
 pub use node::{WorkflowNode, WorkflowNodeStatus};
 #[cfg(feature = "postgres")]
 pub use postgres_store::WorkflowPostgresStorage;
+#[cfg(feature = "redis")]
+pub use redis_store::WorkflowRedisStorage;
 pub use run::WorkflowRun;
 pub use sqlite_store::WorkflowSqliteStorage;
 pub use state::WorkflowState;
@@ -40,6 +44,8 @@ pub enum WorkflowStorageBackend {
     Sqlite(WorkflowSqliteStorage),
     #[cfg(feature = "postgres")]
     Postgres(WorkflowPostgresStorage),
+    #[cfg(feature = "redis")]
+    Redis(WorkflowRedisStorage),
 }
 
 /// Dispatch a `WorkflowStorage` method across every enum variant.
@@ -52,6 +58,8 @@ macro_rules! delegate {
             Self::Sqlite(s) => s.$method($($arg),*),
             #[cfg(feature = "postgres")]
             Self::Postgres(s) => s.$method($($arg),*),
+            #[cfg(feature = "redis")]
+            Self::Redis(s) => s.$method($($arg),*),
         }
     };
 }

--- a/crates/taskito-workflows/src/postgres_store.rs
+++ b/crates/taskito-workflows/src/postgres_store.rs
@@ -107,4 +107,8 @@ impl WorkflowPostgresStorage {
     }
 }
 
-impl_workflow_diesel_ops!(WorkflowPostgresStorage, PgConnection);
+impl_workflow_diesel_ops!(
+    WorkflowPostgresStorage,
+    PgConnection,
+    crate::diesel_common::pg_rewrite
+);

--- a/crates/taskito-workflows/src/postgres_store.rs
+++ b/crates/taskito-workflows/src/postgres_store.rs
@@ -1,0 +1,110 @@
+//! PostgreSQL implementation of `WorkflowStorage`.
+//!
+//! Construction runs the workflow-table migrations once and caches a pool
+//! handle to the underlying `PostgresStorage`. Every trait method is generated
+//! by the `impl_workflow_diesel_ops!` macro in `diesel_common.rs` — the SQL
+//! bodies are byte-identical to SQLite (Diesel rewrites `?` to `$N` per
+//! backend), only the DDL differs (`BYTEA` for `BLOB`, `BIGINT` for `INTEGER`
+//! timestamps).
+
+use diesel::pg::PgConnection;
+use diesel::prelude::*;
+
+use taskito_core::error::Result;
+use taskito_core::storage::postgres::PostgresStorage;
+
+use crate::diesel_common::impl_workflow_diesel_ops;
+
+fn run_workflow_migrations(conn: &mut PgConnection) -> Result<()> {
+    diesel::sql_query(
+        "CREATE TABLE IF NOT EXISTS workflow_definitions (
+            id             TEXT PRIMARY KEY,
+            name           TEXT NOT NULL,
+            version        INTEGER NOT NULL DEFAULT 1,
+            dag_data       BYTEA NOT NULL,
+            step_metadata  TEXT NOT NULL,
+            created_at     BIGINT NOT NULL,
+            UNIQUE(name, version)
+        )",
+    )
+    .execute(conn)?;
+
+    diesel::sql_query("CREATE INDEX IF NOT EXISTS idx_wf_def_name ON workflow_definitions(name)")
+        .execute(conn)?;
+
+    diesel::sql_query(
+        "CREATE TABLE IF NOT EXISTS workflow_runs (
+            id               TEXT PRIMARY KEY,
+            definition_id    TEXT NOT NULL,
+            params           TEXT,
+            state            TEXT NOT NULL DEFAULT 'pending',
+            started_at       BIGINT,
+            completed_at     BIGINT,
+            error            TEXT,
+            parent_run_id    TEXT,
+            parent_node_name TEXT,
+            created_at       BIGINT NOT NULL
+        )",
+    )
+    .execute(conn)?;
+
+    diesel::sql_query("CREATE INDEX IF NOT EXISTS idx_wf_run_def ON workflow_runs(definition_id)")
+        .execute(conn)?;
+
+    diesel::sql_query("CREATE INDEX IF NOT EXISTS idx_wf_run_state ON workflow_runs(state)")
+        .execute(conn)?;
+
+    diesel::sql_query(
+        "CREATE TABLE IF NOT EXISTS workflow_nodes (
+            id             TEXT PRIMARY KEY,
+            run_id         TEXT NOT NULL,
+            node_name      TEXT NOT NULL,
+            job_id         TEXT,
+            status         TEXT NOT NULL DEFAULT 'pending',
+            result_hash    TEXT,
+            fan_out_count  INTEGER,
+            fan_in_data    TEXT,
+            started_at     BIGINT,
+            completed_at   BIGINT,
+            error          TEXT,
+            UNIQUE(run_id, node_name)
+        )",
+    )
+    .execute(conn)?;
+
+    diesel::sql_query("CREATE INDEX IF NOT EXISTS idx_wf_node_run ON workflow_nodes(run_id)")
+        .execute(conn)?;
+
+    diesel::sql_query(
+        "CREATE INDEX IF NOT EXISTS idx_wf_node_status ON workflow_nodes(run_id, status)",
+    )
+    .execute(conn)?;
+
+    Ok(())
+}
+
+/// Workflow-aware wrapper around `PostgresStorage`.
+///
+/// Runs workflow table migrations on construction, then delegates all
+/// `WorkflowStorage` operations through the shared diesel macro. The wrapped
+/// `PostgresStorage` owns the pool; clones share it.
+#[derive(Clone)]
+pub struct WorkflowPostgresStorage {
+    pub(crate) inner: PostgresStorage,
+}
+
+impl WorkflowPostgresStorage {
+    /// Wrap an existing `PostgresStorage` and ensure workflow tables exist.
+    pub fn new(storage: PostgresStorage) -> Result<Self> {
+        let mut conn = storage.conn()?;
+        run_workflow_migrations(&mut conn)?;
+        Ok(Self { inner: storage })
+    }
+
+    /// Access the underlying `PostgresStorage`.
+    pub fn inner(&self) -> &PostgresStorage {
+        &self.inner
+    }
+}
+
+impl_workflow_diesel_ops!(WorkflowPostgresStorage, PgConnection);

--- a/crates/taskito-workflows/src/redis_store.rs
+++ b/crates/taskito-workflows/src/redis_store.rs
@@ -1,0 +1,791 @@
+//! Redis implementation of `WorkflowStorage`.
+//!
+//! ## Key layout (all keys are namespaced by `RedisStorage.prefix + "wf:"`)
+//!
+//! - `wf:def:{id}` (HASH) — definition fields (`id`, `name`, `version`,
+//!   `dag_data` (binary), `step_metadata` (JSON), `created_at`).
+//! - `wf:def:by_name:{name}` (ZSET, score=version, member=id) — index for
+//!   `get_workflow_definition(name, version=None)` (highest version wins).
+//! - `wf:run:{id}` (HASH) — run fields.
+//! - `wf:runs:all` (ZSET, score=created_at, member=id) — unfiltered list.
+//! - `wf:runs:by_state:{state}` (ZSET, score=created_at, member=id) — state filter.
+//! - `wf:runs:by_def:{definition_id}` (ZSET, score=created_at, member=id).
+//! - `wf:node:{run_id}:{node_name}` (HASH) — node fields.
+//! - `wf:run_nodes:{run_id}` (SET, members=node_name) — enumeration index.
+//! - `wf:children:{parent_run_id}` (SET, members=child_run_id) — sub-workflow
+//!   index for `get_child_workflow_runs`.
+//!
+//! ## Atomicity
+//!
+//! Multi-write operations use `redis::pipe().atomic()` (a `MULTI`/`EXEC`
+//! pipeline) so insertions of a run/node and its index entries are committed
+//! together. `finalize_fan_out_parent` uses a Lua script (`FINALIZE_FAN_OUT`)
+//! so the read-current-status-then-conditional-write happens atomically in
+//! one round trip. `compute_ready_nodes` runs in Rust on the fetched nodes —
+//! same backend-agnostic helper SQLite + Postgres use.
+
+use std::collections::HashMap;
+
+use redis::{Commands, FromRedisValue, Value};
+
+use taskito_core::error::{QueueError, Result};
+use taskito_core::storage::redis_backend::RedisStorage;
+
+use crate::common::compute_ready_nodes;
+use crate::storage::WorkflowStorage;
+use crate::{
+    StepMetadata, WorkflowDefinition, WorkflowNode, WorkflowNodeStatus, WorkflowRun, WorkflowState,
+};
+
+// ─── Key formatters ────────────────────────────────────────────────────────
+
+fn k_def(prefix: &str, id: &str) -> String {
+    format!("{prefix}wf:def:{id}")
+}
+fn k_def_by_name(prefix: &str, name: &str) -> String {
+    format!("{prefix}wf:def:by_name:{name}")
+}
+fn k_run(prefix: &str, id: &str) -> String {
+    format!("{prefix}wf:run:{id}")
+}
+fn k_runs_all(prefix: &str) -> String {
+    format!("{prefix}wf:runs:all")
+}
+fn k_runs_by_state(prefix: &str, state: &str) -> String {
+    format!("{prefix}wf:runs:by_state:{state}")
+}
+fn k_runs_by_def(prefix: &str, definition_id: &str) -> String {
+    format!("{prefix}wf:runs:by_def:{definition_id}")
+}
+fn k_node(prefix: &str, run_id: &str, node_name: &str) -> String {
+    format!("{prefix}wf:node:{run_id}:{node_name}")
+}
+fn k_run_nodes(prefix: &str, run_id: &str) -> String {
+    format!("{prefix}wf:run_nodes:{run_id}")
+}
+fn k_children(prefix: &str, parent_run_id: &str) -> String {
+    format!("{prefix}wf:children:{parent_run_id}")
+}
+
+// ─── Lua scripts ───────────────────────────────────────────────────────────
+
+/// Atomic compare-and-swap to finalize a fan-out parent node exactly once.
+///
+/// `KEYS[1]` = `wf:node:{run_id}:{node_name}`
+/// `ARGV[1]` = `"1"` for success, `"0"` for failure
+/// `ARGV[2]` = `completed_at` (decimal string of i64)
+/// `ARGV[3]` = error message (only used when `ARGV[1] == "0"`)
+///
+/// Returns `1` if this caller transitioned the node, `0` if it was already
+/// in a terminal state.
+const FINALIZE_FAN_OUT: &str = r#"
+local status = redis.call('HGET', KEYS[1], 'status')
+if status == 'completed' or status == 'failed' or status == 'skipped' or status == 'cache_hit' then
+    return 0
+end
+if ARGV[1] == '1' then
+    redis.call('HSET', KEYS[1], 'status', 'completed', 'completed_at', ARGV[2])
+    redis.call('HDEL', KEYS[1], 'error')
+else
+    redis.call('HSET', KEYS[1], 'status', 'failed', 'error', ARGV[3])
+end
+return 1
+"#;
+
+// ─── Redis storage handle ─────────────────────────────────────────────────
+
+/// Workflow-aware wrapper around `RedisStorage`.
+///
+/// Clones share the same `redis::Client`; opening a connection per operation
+/// is how the core `RedisStorage` works today, so we follow the same pattern.
+#[derive(Clone)]
+pub struct WorkflowRedisStorage {
+    pub(crate) inner: RedisStorage,
+    /// Full prefix used by core, ending with `':'`. We add `"wf:"` on top.
+    prefix: String,
+}
+
+impl WorkflowRedisStorage {
+    /// Wrap an existing `RedisStorage`.
+    ///
+    /// Redis has no "schema" or "migrations" — the key layout is implicit.
+    /// A round-trip `PING` happens inside `RedisStorage::new`, so by the time
+    /// we receive it the connection is known good.
+    pub fn new(inner: RedisStorage) -> Result<Self> {
+        let prefix = inner.prefix().to_string();
+        Ok(Self { inner, prefix })
+    }
+
+    /// Access the underlying `RedisStorage`.
+    pub fn inner(&self) -> &RedisStorage {
+        &self.inner
+    }
+
+    fn conn(&self) -> Result<redis::Connection> {
+        self.inner
+            .conn()
+            .map_err(|e| QueueError::Other(format!("redis conn: {e}")))
+    }
+}
+
+// ─── Serialization helpers ─────────────────────────────────────────────────
+
+fn into_other(e: impl std::fmt::Display) -> QueueError {
+    QueueError::Other(e.to_string())
+}
+
+fn opt_i64(v: Option<i64>) -> Option<String> {
+    v.map(|n| n.to_string())
+}
+
+fn parse_i64(s: &str) -> Result<i64> {
+    s.parse::<i64>()
+        .map_err(|e| QueueError::Serialization(format!("invalid i64 '{s}': {e}")))
+}
+
+fn parse_i32(s: &str) -> Result<i32> {
+    s.parse::<i32>()
+        .map_err(|e| QueueError::Serialization(format!("invalid i32 '{s}': {e}")))
+}
+
+fn hash_get<'a>(map: &'a HashMap<String, Value>, key: &str) -> Result<&'a Value> {
+    map.get(key)
+        .ok_or_else(|| QueueError::Serialization(format!("missing field '{key}'")))
+}
+
+fn val_to_string(v: &Value) -> Result<String> {
+    String::from_redis_value(v.clone()).map_err(into_other)
+}
+
+fn val_to_bytes(v: &Value) -> Result<Vec<u8>> {
+    Vec::<u8>::from_redis_value(v.clone()).map_err(into_other)
+}
+
+fn val_to_opt_string(v: &Value) -> Result<Option<String>> {
+    match v {
+        Value::Nil => Ok(None),
+        other => Ok(Some(
+            String::from_redis_value(other.clone()).map_err(into_other)?,
+        )),
+    }
+}
+
+/// Decode a Redis HASH (returned as a flat `[key, value, key, value, …]` bulk
+/// reply or already as a map) into a `HashMap<String, Value>`.
+fn hash_to_map(v: Value) -> Result<HashMap<String, Value>> {
+    let mut out = HashMap::new();
+    match v {
+        Value::Array(items) => {
+            let mut it = items.into_iter();
+            while let (Some(k), Some(v)) = (it.next(), it.next()) {
+                let key = String::from_redis_value(k).map_err(into_other)?;
+                out.insert(key, v);
+            }
+        }
+        Value::Map(entries) => {
+            for (k, v) in entries {
+                let key = String::from_redis_value(k).map_err(into_other)?;
+                out.insert(key, v);
+            }
+        }
+        Value::Nil => {}
+        other => {
+            return Err(QueueError::Serialization(format!(
+                "unexpected HASH reply: {other:?}"
+            )))
+        }
+    }
+    Ok(out)
+}
+
+fn map_to_definition(map: HashMap<String, Value>) -> Result<WorkflowDefinition> {
+    let id = val_to_string(hash_get(&map, "id")?)?;
+    let name = val_to_string(hash_get(&map, "name")?)?;
+    let version = parse_i32(&val_to_string(hash_get(&map, "version")?)?)?;
+    let dag_data = val_to_bytes(hash_get(&map, "dag_data")?)?;
+    let step_meta_json = val_to_string(hash_get(&map, "step_metadata")?)?;
+    let created_at = parse_i64(&val_to_string(hash_get(&map, "created_at")?)?)?;
+    let step_metadata: HashMap<String, StepMetadata> = serde_json::from_str(&step_meta_json)
+        .map_err(|e| {
+            QueueError::Serialization(format!("invalid workflow_definitions.step_metadata: {e}"))
+        })?;
+    Ok(WorkflowDefinition {
+        id,
+        name,
+        version,
+        dag_data,
+        step_metadata,
+        created_at,
+    })
+}
+
+fn map_to_run(map: HashMap<String, Value>) -> Result<WorkflowRun> {
+    let id = val_to_string(hash_get(&map, "id")?)?;
+    let definition_id = val_to_string(hash_get(&map, "definition_id")?)?;
+    let params = val_to_opt_string(map.get("params").unwrap_or(&Value::Nil))?;
+    let state_str = val_to_string(hash_get(&map, "state")?)?;
+    let state = WorkflowState::from_str_val(&state_str).unwrap_or(WorkflowState::Pending);
+    let started_at = match map.get("started_at") {
+        Some(v) if !matches!(v, Value::Nil) => Some(parse_i64(&val_to_string(v)?)?),
+        _ => None,
+    };
+    let completed_at = match map.get("completed_at") {
+        Some(v) if !matches!(v, Value::Nil) => Some(parse_i64(&val_to_string(v)?)?),
+        _ => None,
+    };
+    let error = val_to_opt_string(map.get("error").unwrap_or(&Value::Nil))?;
+    let parent_run_id = val_to_opt_string(map.get("parent_run_id").unwrap_or(&Value::Nil))?;
+    let parent_node_name = val_to_opt_string(map.get("parent_node_name").unwrap_or(&Value::Nil))?;
+    let created_at = parse_i64(&val_to_string(hash_get(&map, "created_at")?)?)?;
+    Ok(WorkflowRun {
+        id,
+        definition_id,
+        params,
+        state,
+        started_at,
+        completed_at,
+        error,
+        parent_run_id,
+        parent_node_name,
+        created_at,
+    })
+}
+
+fn map_to_node(map: HashMap<String, Value>) -> Result<WorkflowNode> {
+    let id = val_to_string(hash_get(&map, "id")?)?;
+    let run_id = val_to_string(hash_get(&map, "run_id")?)?;
+    let node_name = val_to_string(hash_get(&map, "node_name")?)?;
+    let job_id = val_to_opt_string(map.get("job_id").unwrap_or(&Value::Nil))?;
+    let status_str = val_to_string(hash_get(&map, "status")?)?;
+    let status =
+        WorkflowNodeStatus::from_str_val(&status_str).unwrap_or(WorkflowNodeStatus::Pending);
+    let result_hash = val_to_opt_string(map.get("result_hash").unwrap_or(&Value::Nil))?;
+    let fan_out_count = match map.get("fan_out_count") {
+        Some(v) if !matches!(v, Value::Nil) => Some(parse_i32(&val_to_string(v)?)?),
+        _ => None,
+    };
+    let fan_in_data = val_to_opt_string(map.get("fan_in_data").unwrap_or(&Value::Nil))?;
+    let started_at = match map.get("started_at") {
+        Some(v) if !matches!(v, Value::Nil) => Some(parse_i64(&val_to_string(v)?)?),
+        _ => None,
+    };
+    let completed_at = match map.get("completed_at") {
+        Some(v) if !matches!(v, Value::Nil) => Some(parse_i64(&val_to_string(v)?)?),
+        _ => None,
+    };
+    let error = val_to_opt_string(map.get("error").unwrap_or(&Value::Nil))?;
+    Ok(WorkflowNode {
+        id,
+        run_id,
+        node_name,
+        job_id,
+        status,
+        result_hash,
+        fan_out_count,
+        fan_in_data,
+        started_at,
+        completed_at,
+        error,
+    })
+}
+
+// ─── WorkflowStorage impl ──────────────────────────────────────────────────
+
+impl WorkflowStorage for WorkflowRedisStorage {
+    fn create_workflow_definition(&self, def: &WorkflowDefinition) -> Result<()> {
+        let mut conn = self.conn()?;
+        let meta_json = serde_json::to_string(&def.step_metadata).map_err(|e| {
+            QueueError::Serialization(format!("failed to serialize step_metadata: {e}"))
+        })?;
+        let key = k_def(&self.prefix, &def.id);
+        let by_name = k_def_by_name(&self.prefix, &def.name);
+
+        redis::pipe()
+            .atomic()
+            .hset(&key, "id", &def.id)
+            .hset(&key, "name", &def.name)
+            .hset(&key, "version", def.version)
+            .hset(&key, "dag_data", &def.dag_data)
+            .hset(&key, "step_metadata", meta_json)
+            .hset(&key, "created_at", def.created_at)
+            .zadd(&by_name, &def.id, def.version)
+            .query::<()>(&mut conn)
+            .map_err(into_other)?;
+        Ok(())
+    }
+
+    fn get_workflow_definition(
+        &self,
+        name: &str,
+        version: Option<i32>,
+    ) -> Result<Option<WorkflowDefinition>> {
+        let mut conn = self.conn()?;
+        let by_name = k_def_by_name(&self.prefix, name);
+
+        let id: Option<String> = match version {
+            Some(v) => {
+                // Find the def id whose score equals `v`.
+                let ids: Vec<String> = conn
+                    .zrangebyscore(&by_name, v as f64, v as f64)
+                    .map_err(into_other)?;
+                ids.into_iter().next()
+            }
+            None => {
+                // Highest version = highest score.
+                let ids: Vec<String> = conn.zrevrange(&by_name, 0, 0).map_err(into_other)?;
+                ids.into_iter().next()
+            }
+        };
+
+        match id {
+            Some(id) => self.get_workflow_definition_by_id(&id),
+            None => Ok(None),
+        }
+    }
+
+    fn get_workflow_definition_by_id(&self, id: &str) -> Result<Option<WorkflowDefinition>> {
+        let mut conn = self.conn()?;
+        let key = k_def(&self.prefix, id);
+        let raw: Value = conn.hgetall(&key).map_err(into_other)?;
+        let map = hash_to_map(raw)?;
+        if map.is_empty() {
+            return Ok(None);
+        }
+        Ok(Some(map_to_definition(map)?))
+    }
+
+    fn create_workflow_run(&self, run: &WorkflowRun) -> Result<()> {
+        let mut conn = self.conn()?;
+        let key = k_run(&self.prefix, &run.id);
+        let all = k_runs_all(&self.prefix);
+        let by_state = k_runs_by_state(&self.prefix, run.state.as_str());
+        let by_def = k_runs_by_def(&self.prefix, &run.definition_id);
+
+        let mut pipe = redis::pipe();
+        let pipe = pipe.atomic();
+        pipe.hset(&key, "id", &run.id);
+        pipe.hset(&key, "definition_id", &run.definition_id);
+        if let Some(p) = &run.params {
+            pipe.hset(&key, "params", p);
+        }
+        pipe.hset(&key, "state", run.state.as_str());
+        if let Some(s) = opt_i64(run.started_at) {
+            pipe.hset(&key, "started_at", s);
+        }
+        if let Some(s) = opt_i64(run.completed_at) {
+            pipe.hset(&key, "completed_at", s);
+        }
+        if let Some(e) = &run.error {
+            pipe.hset(&key, "error", e);
+        }
+        if let Some(p) = &run.parent_run_id {
+            pipe.hset(&key, "parent_run_id", p);
+            // Track this run as a child for parent lookups.
+            pipe.sadd(k_children(&self.prefix, p), &run.id);
+        }
+        if let Some(n) = &run.parent_node_name {
+            pipe.hset(&key, "parent_node_name", n);
+        }
+        pipe.hset(&key, "created_at", run.created_at);
+        pipe.zadd(&all, &run.id, run.created_at);
+        pipe.zadd(&by_state, &run.id, run.created_at);
+        pipe.zadd(&by_def, &run.id, run.created_at);
+
+        pipe.query::<()>(&mut conn).map_err(into_other)?;
+        Ok(())
+    }
+
+    fn get_workflow_run(&self, run_id: &str) -> Result<Option<WorkflowRun>> {
+        let mut conn = self.conn()?;
+        let key = k_run(&self.prefix, run_id);
+        let raw: Value = conn.hgetall(&key).map_err(into_other)?;
+        let map = hash_to_map(raw)?;
+        if map.is_empty() {
+            return Ok(None);
+        }
+        Ok(Some(map_to_run(map)?))
+    }
+
+    fn update_workflow_run_state(
+        &self,
+        run_id: &str,
+        state: WorkflowState,
+        error: Option<&str>,
+    ) -> Result<()> {
+        let mut conn = self.conn()?;
+        let key = k_run(&self.prefix, run_id);
+
+        // Read the current state + created_at to maintain the state index.
+        let current_state: Option<String> = conn.hget(&key, "state").map_err(into_other)?;
+        let created_at: Option<i64> = conn.hget(&key, "created_at").map_err(into_other)?;
+
+        let mut pipe = redis::pipe();
+        let pipe = pipe.atomic();
+        pipe.hset(&key, "state", state.as_str());
+        match error {
+            Some(e) => {
+                pipe.hset(&key, "error", e);
+            }
+            None => {
+                pipe.hdel(&key, "error");
+            }
+        }
+        if let (Some(old), Some(ts)) = (current_state, created_at) {
+            if old != state.as_str() {
+                pipe.zrem(k_runs_by_state(&self.prefix, &old), run_id);
+                pipe.zadd(k_runs_by_state(&self.prefix, state.as_str()), run_id, ts);
+            }
+        }
+        pipe.query::<()>(&mut conn).map_err(into_other)?;
+        Ok(())
+    }
+
+    fn set_workflow_run_started(&self, run_id: &str, started_at: i64) -> Result<()> {
+        let mut conn = self.conn()?;
+        let key = k_run(&self.prefix, run_id);
+        let created_at: Option<i64> = conn.hget(&key, "created_at").map_err(into_other)?;
+        let prev_state: Option<String> = conn.hget(&key, "state").map_err(into_other)?;
+
+        let mut pipe = redis::pipe();
+        let pipe = pipe.atomic();
+        pipe.hset(&key, "state", "running");
+        pipe.hset(&key, "started_at", started_at);
+        if let (Some(old), Some(ts)) = (prev_state, created_at) {
+            if old != "running" {
+                pipe.zrem(k_runs_by_state(&self.prefix, &old), run_id);
+                pipe.zadd(k_runs_by_state(&self.prefix, "running"), run_id, ts);
+            }
+        }
+        pipe.query::<()>(&mut conn).map_err(into_other)?;
+        Ok(())
+    }
+
+    fn set_workflow_run_completed(&self, run_id: &str, completed_at: i64) -> Result<()> {
+        let mut conn = self.conn()?;
+        let key = k_run(&self.prefix, run_id);
+        conn.hset::<_, _, _, ()>(&key, "completed_at", completed_at)
+            .map_err(into_other)?;
+        Ok(())
+    }
+
+    fn list_workflow_runs(
+        &self,
+        definition_name: Option<&str>,
+        state: Option<WorkflowState>,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Vec<WorkflowRun>> {
+        let mut conn = self.conn()?;
+
+        // Resolve the definition_id set if filtering by definition name.
+        let def_id_for_filter: Option<String> = match definition_name {
+            Some(name) => {
+                let by_name = k_def_by_name(&self.prefix, name);
+                // Use the highest-version definition for the name.
+                let ids: Vec<String> = conn.zrevrange(&by_name, 0, 0).map_err(into_other)?;
+                match ids.into_iter().next() {
+                    Some(id) => Some(id),
+                    None => return Ok(Vec::new()),
+                }
+            }
+            None => None,
+        };
+
+        // Pick the most selective index.
+        let index_key = match (def_id_for_filter.as_deref(), state) {
+            (Some(def_id), _) => k_runs_by_def(&self.prefix, def_id),
+            (None, Some(st)) => k_runs_by_state(&self.prefix, st.as_str()),
+            (None, None) => k_runs_all(&self.prefix),
+        };
+
+        // ZREVRANGE for newest-first ordering (matches Diesel impl).
+        let start = offset;
+        let stop = if limit <= 0 { -1 } else { offset + limit - 1 };
+        let candidate_ids: Vec<String> = conn
+            .zrevrange(&index_key, start as isize, stop as isize)
+            .map_err(into_other)?;
+
+        let mut runs = Vec::with_capacity(candidate_ids.len());
+        for id in candidate_ids {
+            if let Some(run) = self.get_workflow_run(&id)? {
+                // If both filters set, the definition index already constrained
+                // the candidates; apply state filter in-memory.
+                if let Some(st) = state {
+                    if run.state != st {
+                        continue;
+                    }
+                }
+                runs.push(run);
+            }
+        }
+        Ok(runs)
+    }
+
+    fn create_workflow_node(&self, node: &WorkflowNode) -> Result<()> {
+        let mut conn = self.conn()?;
+        write_node_pipeline(&self.prefix, node, &mut conn)
+    }
+
+    fn create_workflow_nodes_batch(&self, nodes: &[WorkflowNode]) -> Result<()> {
+        if nodes.is_empty() {
+            return Ok(());
+        }
+        let mut conn = self.conn()?;
+        let mut pipe = redis::pipe();
+        let pipe = pipe.atomic();
+        for node in nodes {
+            let key = k_node(&self.prefix, &node.run_id, &node.node_name);
+            pipe.hset(&key, "id", &node.id);
+            pipe.hset(&key, "run_id", &node.run_id);
+            pipe.hset(&key, "node_name", &node.node_name);
+            if let Some(j) = &node.job_id {
+                pipe.hset(&key, "job_id", j);
+            }
+            pipe.hset(&key, "status", node.status.as_str());
+            if let Some(r) = &node.result_hash {
+                pipe.hset(&key, "result_hash", r);
+            }
+            if let Some(c) = node.fan_out_count {
+                pipe.hset(&key, "fan_out_count", c);
+            }
+            if let Some(f) = &node.fan_in_data {
+                pipe.hset(&key, "fan_in_data", f);
+            }
+            if let Some(s) = opt_i64(node.started_at) {
+                pipe.hset(&key, "started_at", s);
+            }
+            if let Some(c) = opt_i64(node.completed_at) {
+                pipe.hset(&key, "completed_at", c);
+            }
+            if let Some(e) = &node.error {
+                pipe.hset(&key, "error", e);
+            }
+            pipe.sadd(k_run_nodes(&self.prefix, &node.run_id), &node.node_name);
+        }
+        pipe.query::<()>(&mut conn).map_err(into_other)?;
+        Ok(())
+    }
+
+    fn get_workflow_node(&self, run_id: &str, node_name: &str) -> Result<Option<WorkflowNode>> {
+        let mut conn = self.conn()?;
+        let key = k_node(&self.prefix, run_id, node_name);
+        let raw: Value = conn.hgetall(&key).map_err(into_other)?;
+        let map = hash_to_map(raw)?;
+        if map.is_empty() {
+            return Ok(None);
+        }
+        Ok(Some(map_to_node(map)?))
+    }
+
+    fn get_workflow_nodes(&self, run_id: &str) -> Result<Vec<WorkflowNode>> {
+        let mut conn = self.conn()?;
+        let names: Vec<String> = conn
+            .smembers(k_run_nodes(&self.prefix, run_id))
+            .map_err(into_other)?;
+        if names.is_empty() {
+            return Ok(Vec::new());
+        }
+        let mut pipe = redis::pipe();
+        for name in &names {
+            pipe.hgetall(k_node(&self.prefix, run_id, name));
+        }
+        let raws: Vec<Value> = pipe.query(&mut conn).map_err(into_other)?;
+        let mut nodes = Vec::with_capacity(raws.len());
+        for raw in raws {
+            let map = hash_to_map(raw)?;
+            if !map.is_empty() {
+                nodes.push(map_to_node(map)?);
+            }
+        }
+        Ok(nodes)
+    }
+
+    fn update_workflow_node_status(
+        &self,
+        run_id: &str,
+        node_name: &str,
+        status: WorkflowNodeStatus,
+    ) -> Result<()> {
+        let mut conn = self.conn()?;
+        let key = k_node(&self.prefix, run_id, node_name);
+        conn.hset::<_, _, _, ()>(&key, "status", status.as_str())
+            .map_err(into_other)?;
+        Ok(())
+    }
+
+    fn set_workflow_node_job(&self, run_id: &str, node_name: &str, job_id: &str) -> Result<()> {
+        let mut conn = self.conn()?;
+        let key = k_node(&self.prefix, run_id, node_name);
+        conn.hset::<_, _, _, ()>(&key, "job_id", job_id)
+            .map_err(into_other)?;
+        Ok(())
+    }
+
+    fn set_workflow_node_started(
+        &self,
+        run_id: &str,
+        node_name: &str,
+        started_at: i64,
+    ) -> Result<()> {
+        let mut conn = self.conn()?;
+        let key = k_node(&self.prefix, run_id, node_name);
+        redis::pipe()
+            .atomic()
+            .hset(&key, "status", "running")
+            .hset(&key, "started_at", started_at)
+            .query::<()>(&mut conn)
+            .map_err(into_other)?;
+        Ok(())
+    }
+
+    fn set_workflow_node_completed(
+        &self,
+        run_id: &str,
+        node_name: &str,
+        completed_at: i64,
+        result_hash: Option<&str>,
+    ) -> Result<()> {
+        let mut conn = self.conn()?;
+        let key = k_node(&self.prefix, run_id, node_name);
+        let mut pipe = redis::pipe();
+        let pipe = pipe.atomic();
+        pipe.hset(&key, "status", "completed");
+        pipe.hset(&key, "completed_at", completed_at);
+        if let Some(rh) = result_hash {
+            pipe.hset(&key, "result_hash", rh);
+        }
+        pipe.query::<()>(&mut conn).map_err(into_other)?;
+        Ok(())
+    }
+
+    fn set_workflow_node_error(&self, run_id: &str, node_name: &str, error: &str) -> Result<()> {
+        let mut conn = self.conn()?;
+        let key = k_node(&self.prefix, run_id, node_name);
+        redis::pipe()
+            .atomic()
+            .hset(&key, "status", "failed")
+            .hset(&key, "error", error)
+            .query::<()>(&mut conn)
+            .map_err(into_other)?;
+        Ok(())
+    }
+
+    fn get_ready_workflow_nodes(&self, run_id: &str, dag_json: &str) -> Result<Vec<WorkflowNode>> {
+        let nodes = self.get_workflow_nodes(run_id)?;
+        compute_ready_nodes(nodes, dag_json)
+    }
+
+    fn set_workflow_node_fan_out_count(
+        &self,
+        run_id: &str,
+        node_name: &str,
+        count: i32,
+    ) -> Result<()> {
+        let mut conn = self.conn()?;
+        let key = k_node(&self.prefix, run_id, node_name);
+        redis::pipe()
+            .atomic()
+            .hset(&key, "fan_out_count", count)
+            .hset(&key, "status", "running")
+            .query::<()>(&mut conn)
+            .map_err(into_other)?;
+        Ok(())
+    }
+
+    fn set_workflow_node_running(
+        &self,
+        run_id: &str,
+        node_name: &str,
+        started_at: i64,
+    ) -> Result<()> {
+        // Same wire effect as set_workflow_node_started for the Redis backend.
+        self.set_workflow_node_started(run_id, node_name, started_at)
+    }
+
+    fn finalize_fan_out_parent(
+        &self,
+        run_id: &str,
+        node_name: &str,
+        succeeded: bool,
+        error: Option<&str>,
+        completed_at: i64,
+    ) -> Result<bool> {
+        let mut conn = self.conn()?;
+        let key = k_node(&self.prefix, run_id, node_name);
+        let succeeded_arg = if succeeded { "1" } else { "0" };
+        let error_arg = error.unwrap_or("fan-out child failed");
+
+        let res: i32 = redis::Script::new(FINALIZE_FAN_OUT)
+            .key(key)
+            .arg(succeeded_arg)
+            .arg(completed_at)
+            .arg(error_arg)
+            .invoke(&mut conn)
+            .map_err(into_other)?;
+        Ok(res == 1)
+    }
+
+    fn get_workflow_nodes_by_prefix(
+        &self,
+        run_id: &str,
+        prefix: &str,
+    ) -> Result<Vec<WorkflowNode>> {
+        let all = self.get_workflow_nodes(run_id)?;
+        Ok(all
+            .into_iter()
+            .filter(|n| n.node_name.starts_with(prefix))
+            .collect())
+    }
+
+    fn get_child_workflow_runs(&self, parent_run_id: &str) -> Result<Vec<WorkflowRun>> {
+        let mut conn = self.conn()?;
+        let child_ids: Vec<String> = conn
+            .smembers(k_children(&self.prefix, parent_run_id))
+            .map_err(into_other)?;
+        let mut runs = Vec::with_capacity(child_ids.len());
+        for id in child_ids {
+            if let Some(run) = self.get_workflow_run(&id)? {
+                runs.push(run);
+            }
+        }
+        Ok(runs)
+    }
+}
+
+fn write_node_pipeline(
+    prefix: &str,
+    node: &WorkflowNode,
+    conn: &mut redis::Connection,
+) -> Result<()> {
+    let key = k_node(prefix, &node.run_id, &node.node_name);
+    let mut pipe = redis::pipe();
+    let pipe = pipe.atomic();
+    pipe.hset(&key, "id", &node.id);
+    pipe.hset(&key, "run_id", &node.run_id);
+    pipe.hset(&key, "node_name", &node.node_name);
+    if let Some(j) = &node.job_id {
+        pipe.hset(&key, "job_id", j);
+    }
+    pipe.hset(&key, "status", node.status.as_str());
+    if let Some(r) = &node.result_hash {
+        pipe.hset(&key, "result_hash", r);
+    }
+    if let Some(c) = node.fan_out_count {
+        pipe.hset(&key, "fan_out_count", c);
+    }
+    if let Some(f) = &node.fan_in_data {
+        pipe.hset(&key, "fan_in_data", f);
+    }
+    if let Some(s) = opt_i64(node.started_at) {
+        pipe.hset(&key, "started_at", s);
+    }
+    if let Some(c) = opt_i64(node.completed_at) {
+        pipe.hset(&key, "completed_at", c);
+    }
+    if let Some(e) = &node.error {
+        pipe.hset(&key, "error", e);
+    }
+    pipe.sadd(k_run_nodes(prefix, &node.run_id), &node.node_name);
+    pipe.query::<()>(conn).map_err(into_other)?;
+    Ok(())
+}

--- a/crates/taskito-workflows/src/sqlite_store.rs
+++ b/crates/taskito-workflows/src/sqlite_store.rs
@@ -104,4 +104,8 @@ impl WorkflowSqliteStorage {
     }
 }
 
-impl_workflow_diesel_ops!(WorkflowSqliteStorage, SqliteConnection);
+impl_workflow_diesel_ops!(
+    WorkflowSqliteStorage,
+    SqliteConnection,
+    crate::diesel_common::sql_as_is
+);

--- a/crates/taskito-workflows/src/tests.rs
+++ b/crates/taskito-workflows/src/tests.rs
@@ -1,100 +1,19 @@
+//! Unit tests for backend-agnostic helpers.
+//!
+//! Cross-backend storage scenarios live in the integration suite at
+//! `tests/storage_contract.rs` so they can run against every backend
+//! (SQLite, Postgres, Redis) without duplication. The tests here exercise
+//! pure-Rust state-machine logic and the diamond-DAG ready-nodes case,
+//! which has too much setup to be worth porting to the contract format.
+
+use std::collections::HashMap;
+
 use taskito_core::job::now_millis;
 use taskito_core::storage::sqlite::SqliteStorage;
 
 use crate::sqlite_store::WorkflowSqliteStorage;
 use crate::storage::WorkflowStorage;
 use crate::*;
-
-fn test_storage() -> WorkflowSqliteStorage {
-    let base = SqliteStorage::in_memory().unwrap();
-    WorkflowSqliteStorage::new(base).unwrap()
-}
-
-fn make_definition(name: &str) -> WorkflowDefinition {
-    let mut step_metadata = std::collections::HashMap::new();
-    step_metadata.insert(
-        "a".to_string(),
-        StepMetadata {
-            task_name: "task_a".to_string(),
-            queue: None,
-            args_template: None,
-            kwargs_template: None,
-            max_retries: None,
-            timeout_ms: None,
-            priority: None,
-            fan_out: None,
-            fan_in: None,
-            condition: None,
-        },
-    );
-    step_metadata.insert(
-        "b".to_string(),
-        StepMetadata {
-            task_name: "task_b".to_string(),
-            queue: None,
-            args_template: None,
-            kwargs_template: None,
-            max_retries: None,
-            timeout_ms: None,
-            priority: None,
-            fan_out: None,
-            fan_in: None,
-            condition: None,
-        },
-    );
-    step_metadata.insert(
-        "c".to_string(),
-        StepMetadata {
-            task_name: "task_c".to_string(),
-            queue: None,
-            args_template: None,
-            kwargs_template: None,
-            max_retries: None,
-            timeout_ms: None,
-            priority: None,
-            fan_out: None,
-            fan_in: None,
-            condition: None,
-        },
-    );
-
-    // Simple DAG: a → b → c
-    let dag_json = serde_json::json!({
-        "nodes": [
-            {"name": "a"},
-            {"name": "b"},
-            {"name": "c"}
-        ],
-        "edges": [
-            {"from": "a", "to": "b", "weight": 1.0},
-            {"from": "b", "to": "c", "weight": 1.0}
-        ]
-    });
-
-    WorkflowDefinition {
-        id: uuid::Uuid::now_v7().to_string(),
-        name: name.to_string(),
-        version: 1,
-        dag_data: serde_json::to_vec(&dag_json).unwrap(),
-        step_metadata,
-        created_at: now_millis(),
-    }
-}
-
-fn make_run(definition_id: &str) -> WorkflowRun {
-    WorkflowRun {
-        id: uuid::Uuid::now_v7().to_string(),
-        definition_id: definition_id.to_string(),
-        params: Some(r#"{"region":"eu"}"#.to_string()),
-        state: WorkflowState::Pending,
-        started_at: None,
-        completed_at: None,
-        error: None,
-        parent_run_id: None,
-        parent_node_name: None,
-        created_at: now_millis(),
-    }
-}
 
 fn make_node(run_id: &str, name: &str) -> WorkflowNode {
     WorkflowNode {
@@ -112,406 +31,55 @@ fn make_node(run_id: &str, name: &str) -> WorkflowNode {
     }
 }
 
-// ── Definition tests ─────────────────────────────────────────
-
-#[test]
-fn test_create_and_get_definition() {
-    let storage = test_storage();
-    let def = make_definition("my_pipeline");
-
-    storage.create_workflow_definition(&def).unwrap();
-
-    let fetched = storage
-        .get_workflow_definition("my_pipeline", None)
-        .unwrap()
-        .unwrap();
-    assert_eq!(fetched.name, "my_pipeline");
-    assert_eq!(fetched.version, 1);
-    assert_eq!(fetched.step_metadata.len(), 3);
-    assert!(fetched.step_metadata.contains_key("a"));
-}
-
-#[test]
-fn test_get_definition_by_version() {
-    let storage = test_storage();
-
-    let mut def_v1 = make_definition("versioned");
-    def_v1.version = 1;
-    storage.create_workflow_definition(&def_v1).unwrap();
-
-    let mut def_v2 = make_definition("versioned");
-    def_v2.id = uuid::Uuid::now_v7().to_string();
-    def_v2.version = 2;
-    storage.create_workflow_definition(&def_v2).unwrap();
-
-    // Latest version (no version specified) returns v2
-    let latest = storage
-        .get_workflow_definition("versioned", None)
-        .unwrap()
-        .unwrap();
-    assert_eq!(latest.version, 2);
-
-    // Specific version
-    let v1 = storage
-        .get_workflow_definition("versioned", Some(1))
-        .unwrap()
-        .unwrap();
-    assert_eq!(v1.version, 1);
-}
-
-#[test]
-fn test_get_definition_by_id() {
-    let storage = test_storage();
-    let def = make_definition("by_id_test");
-    let def_id = def.id.clone();
-    storage.create_workflow_definition(&def).unwrap();
-
-    let fetched = storage
-        .get_workflow_definition_by_id(&def_id)
-        .unwrap()
-        .unwrap();
-    assert_eq!(fetched.id, def_id);
-}
-
-#[test]
-fn test_definition_not_found() {
-    let storage = test_storage();
-    let result = storage
-        .get_workflow_definition("nonexistent", None)
-        .unwrap();
-    assert!(result.is_none());
-}
-
-// ── Run tests ────────────────────────────────────────────────
-
-#[test]
-fn test_create_and_get_run() {
-    let storage = test_storage();
-    let def = make_definition("run_test");
-    storage.create_workflow_definition(&def).unwrap();
-
-    let run = make_run(&def.id);
-    let run_id = run.id.clone();
-    storage.create_workflow_run(&run).unwrap();
-
-    let fetched = storage.get_workflow_run(&run_id).unwrap().unwrap();
-    assert_eq!(fetched.id, run_id);
-    assert_eq!(fetched.state, WorkflowState::Pending);
-    assert_eq!(fetched.params, Some(r#"{"region":"eu"}"#.to_string()));
-}
-
-#[test]
-fn test_update_run_state() {
-    let storage = test_storage();
-    let def = make_definition("state_test");
-    storage.create_workflow_definition(&def).unwrap();
-
-    let run = make_run(&def.id);
-    let run_id = run.id.clone();
-    storage.create_workflow_run(&run).unwrap();
-
-    // Pending → Running
-    storage
-        .update_workflow_run_state(&run_id, WorkflowState::Running, None)
-        .unwrap();
-    let fetched = storage.get_workflow_run(&run_id).unwrap().unwrap();
-    assert_eq!(fetched.state, WorkflowState::Running);
-
-    // Running → Failed with error
-    storage
-        .update_workflow_run_state(&run_id, WorkflowState::Failed, Some("node X blew up"))
-        .unwrap();
-    let fetched = storage.get_workflow_run(&run_id).unwrap().unwrap();
-    assert_eq!(fetched.state, WorkflowState::Failed);
-    assert_eq!(fetched.error, Some("node X blew up".to_string()));
-}
-
-#[test]
-fn test_set_run_started_and_completed() {
-    let storage = test_storage();
-    let def = make_definition("timing_test");
-    storage.create_workflow_definition(&def).unwrap();
-
-    let run = make_run(&def.id);
-    let run_id = run.id.clone();
-    storage.create_workflow_run(&run).unwrap();
-
-    let start_time = now_millis();
-    storage
-        .set_workflow_run_started(&run_id, start_time)
-        .unwrap();
-    let fetched = storage.get_workflow_run(&run_id).unwrap().unwrap();
-    assert_eq!(fetched.state, WorkflowState::Running);
-    assert_eq!(fetched.started_at, Some(start_time));
-
-    let end_time = now_millis();
-    storage
-        .set_workflow_run_completed(&run_id, end_time)
-        .unwrap();
-    let fetched = storage.get_workflow_run(&run_id).unwrap().unwrap();
-    assert_eq!(fetched.completed_at, Some(end_time));
-}
-
-#[test]
-fn test_list_runs() {
-    let storage = test_storage();
-    let def = make_definition("list_test");
-    storage.create_workflow_definition(&def).unwrap();
-
-    for _ in 0..5 {
-        storage.create_workflow_run(&make_run(&def.id)).unwrap();
+fn make_run(definition_id: &str) -> WorkflowRun {
+    WorkflowRun {
+        id: uuid::Uuid::now_v7().to_string(),
+        definition_id: definition_id.to_string(),
+        params: None,
+        state: WorkflowState::Pending,
+        started_at: None,
+        completed_at: None,
+        error: None,
+        parent_run_id: None,
+        parent_node_name: None,
+        created_at: now_millis(),
     }
-
-    let all = storage.list_workflow_runs(None, None, 100, 0).unwrap();
-    assert_eq!(all.len(), 5);
-
-    let limited = storage.list_workflow_runs(None, None, 2, 0).unwrap();
-    assert_eq!(limited.len(), 2);
-
-    let offset = storage.list_workflow_runs(None, None, 100, 3).unwrap();
-    assert_eq!(offset.len(), 2);
 }
 
 #[test]
-fn test_list_runs_by_state() {
-    let storage = test_storage();
-    let def = make_definition("state_filter");
-    storage.create_workflow_definition(&def).unwrap();
+fn test_state_transitions() {
+    assert!(WorkflowState::Pending.can_transition_to(WorkflowState::Running));
+    assert!(WorkflowState::Running.can_transition_to(WorkflowState::Completed));
+    assert!(WorkflowState::Running.can_transition_to(WorkflowState::Failed));
+    assert!(WorkflowState::Running.can_transition_to(WorkflowState::Cancelled));
+    assert!(WorkflowState::Running.can_transition_to(WorkflowState::Paused));
+    assert!(WorkflowState::Paused.can_transition_to(WorkflowState::Running));
+    assert!(WorkflowState::Paused.can_transition_to(WorkflowState::Cancelled));
 
-    let run1 = make_run(&def.id);
-    let run1_id = run1.id.clone();
-    storage.create_workflow_run(&run1).unwrap();
-
-    let run2 = make_run(&def.id);
-    storage.create_workflow_run(&run2).unwrap();
-
-    storage
-        .update_workflow_run_state(&run1_id, WorkflowState::Running, None)
-        .unwrap();
-
-    let running = storage
-        .list_workflow_runs(None, Some(WorkflowState::Running), 100, 0)
-        .unwrap();
-    assert_eq!(running.len(), 1);
-    assert_eq!(running[0].id, run1_id);
-
-    let pending = storage
-        .list_workflow_runs(None, Some(WorkflowState::Pending), 100, 0)
-        .unwrap();
-    assert_eq!(pending.len(), 1);
-}
-
-// ── Node tests ───────────────────────────────────────────────
-
-#[test]
-fn test_create_and_get_node() {
-    let storage = test_storage();
-    let def = make_definition("node_test");
-    storage.create_workflow_definition(&def).unwrap();
-    let run = make_run(&def.id);
-    let run_id = run.id.clone();
-    storage.create_workflow_run(&run).unwrap();
-
-    let node = make_node(&run_id, "a");
-    storage.create_workflow_node(&node).unwrap();
-
-    let fetched = storage.get_workflow_node(&run_id, "a").unwrap().unwrap();
-    assert_eq!(fetched.node_name, "a");
-    assert_eq!(fetched.status, WorkflowNodeStatus::Pending);
-    assert!(fetched.job_id.is_none());
+    assert!(!WorkflowState::Pending.can_transition_to(WorkflowState::Completed));
+    assert!(!WorkflowState::Completed.can_transition_to(WorkflowState::Running));
+    assert!(!WorkflowState::Failed.can_transition_to(WorkflowState::Running));
 }
 
 #[test]
-fn test_create_nodes_batch() {
-    let storage = test_storage();
-    let def = make_definition("batch_test");
-    storage.create_workflow_definition(&def).unwrap();
-    let run = make_run(&def.id);
-    let run_id = run.id.clone();
-    storage.create_workflow_run(&run).unwrap();
-
-    let nodes = vec![
-        make_node(&run_id, "a"),
-        make_node(&run_id, "b"),
-        make_node(&run_id, "c"),
-    ];
-    storage.create_workflow_nodes_batch(&nodes).unwrap();
-
-    let all = storage.get_workflow_nodes(&run_id).unwrap();
-    assert_eq!(all.len(), 3);
+fn test_state_is_terminal() {
+    assert!(WorkflowState::Completed.is_terminal());
+    assert!(WorkflowState::Failed.is_terminal());
+    assert!(WorkflowState::Cancelled.is_terminal());
+    assert!(!WorkflowState::Pending.is_terminal());
+    assert!(!WorkflowState::Running.is_terminal());
+    assert!(!WorkflowState::Paused.is_terminal());
 }
 
-#[test]
-fn test_update_node_status() {
-    let storage = test_storage();
-    let def = make_definition("status_test");
-    storage.create_workflow_definition(&def).unwrap();
-    let run = make_run(&def.id);
-    let run_id = run.id.clone();
-    storage.create_workflow_run(&run).unwrap();
-    storage
-        .create_workflow_node(&make_node(&run_id, "a"))
-        .unwrap();
-
-    storage
-        .update_workflow_node_status(&run_id, "a", WorkflowNodeStatus::Running)
-        .unwrap();
-    let fetched = storage.get_workflow_node(&run_id, "a").unwrap().unwrap();
-    assert_eq!(fetched.status, WorkflowNodeStatus::Running);
-}
-
-#[test]
-fn test_set_node_job_and_timing() {
-    let storage = test_storage();
-    let def = make_definition("job_test");
-    storage.create_workflow_definition(&def).unwrap();
-    let run = make_run(&def.id);
-    let run_id = run.id.clone();
-    storage.create_workflow_run(&run).unwrap();
-    storage
-        .create_workflow_node(&make_node(&run_id, "a"))
-        .unwrap();
-
-    storage
-        .set_workflow_node_job(&run_id, "a", "job-123")
-        .unwrap();
-    let fetched = storage.get_workflow_node(&run_id, "a").unwrap().unwrap();
-    assert_eq!(fetched.job_id, Some("job-123".to_string()));
-
-    let start = now_millis();
-    storage
-        .set_workflow_node_started(&run_id, "a", start)
-        .unwrap();
-    let fetched = storage.get_workflow_node(&run_id, "a").unwrap().unwrap();
-    assert_eq!(fetched.status, WorkflowNodeStatus::Running);
-    assert_eq!(fetched.started_at, Some(start));
-
-    let end = now_millis();
-    storage
-        .set_workflow_node_completed(&run_id, "a", end, Some("abc123"))
-        .unwrap();
-    let fetched = storage.get_workflow_node(&run_id, "a").unwrap().unwrap();
-    assert_eq!(fetched.status, WorkflowNodeStatus::Completed);
-    assert_eq!(fetched.completed_at, Some(end));
-    assert_eq!(fetched.result_hash, Some("abc123".to_string()));
-}
-
-#[test]
-fn test_set_node_error() {
-    let storage = test_storage();
-    let def = make_definition("error_test");
-    storage.create_workflow_definition(&def).unwrap();
-    let run = make_run(&def.id);
-    let run_id = run.id.clone();
-    storage.create_workflow_run(&run).unwrap();
-    storage
-        .create_workflow_node(&make_node(&run_id, "a"))
-        .unwrap();
-
-    storage
-        .set_workflow_node_error(&run_id, "a", "kaboom")
-        .unwrap();
-    let fetched = storage.get_workflow_node(&run_id, "a").unwrap().unwrap();
-    assert_eq!(fetched.status, WorkflowNodeStatus::Failed);
-    assert_eq!(fetched.error, Some("kaboom".to_string()));
-}
-
-// ── Ready nodes (DAG-aware) ──────────────────────────────────
-
-#[test]
-fn test_get_ready_nodes_roots_are_ready() {
-    let storage = test_storage();
-    let def = make_definition("ready_test");
-    let dag_json = String::from_utf8(def.dag_data.clone()).unwrap();
-    storage.create_workflow_definition(&def).unwrap();
-
-    let run = make_run(&def.id);
-    let run_id = run.id.clone();
-    storage.create_workflow_run(&run).unwrap();
-
-    let nodes = vec![
-        make_node(&run_id, "a"),
-        make_node(&run_id, "b"),
-        make_node(&run_id, "c"),
-    ];
-    storage.create_workflow_nodes_batch(&nodes).unwrap();
-
-    // Only root node "a" should be ready (b depends on a, c depends on b)
-    let ready = storage
-        .get_ready_workflow_nodes(&run_id, &dag_json)
-        .unwrap();
-    assert_eq!(ready.len(), 1);
-    assert_eq!(ready[0].node_name, "a");
-}
-
-#[test]
-fn test_get_ready_nodes_after_completion() {
-    let storage = test_storage();
-    let def = make_definition("completion_ready");
-    let dag_json = String::from_utf8(def.dag_data.clone()).unwrap();
-    storage.create_workflow_definition(&def).unwrap();
-
-    let run = make_run(&def.id);
-    let run_id = run.id.clone();
-    storage.create_workflow_run(&run).unwrap();
-
-    storage
-        .create_workflow_nodes_batch(&[
-            make_node(&run_id, "a"),
-            make_node(&run_id, "b"),
-            make_node(&run_id, "c"),
-        ])
-        .unwrap();
-
-    // Complete "a" → "b" becomes ready
-    storage
-        .set_workflow_node_completed(&run_id, "a", now_millis(), None)
-        .unwrap();
-
-    let ready = storage
-        .get_ready_workflow_nodes(&run_id, &dag_json)
-        .unwrap();
-    assert_eq!(ready.len(), 1);
-    assert_eq!(ready[0].node_name, "b");
-}
-
-#[test]
-fn test_get_ready_nodes_all_completed() {
-    let storage = test_storage();
-    let def = make_definition("all_done");
-    let dag_json = String::from_utf8(def.dag_data.clone()).unwrap();
-    storage.create_workflow_definition(&def).unwrap();
-
-    let run = make_run(&def.id);
-    let run_id = run.id.clone();
-    storage.create_workflow_run(&run).unwrap();
-
-    storage
-        .create_workflow_nodes_batch(&[
-            make_node(&run_id, "a"),
-            make_node(&run_id, "b"),
-            make_node(&run_id, "c"),
-        ])
-        .unwrap();
-
-    // Complete all
-    for name in &["a", "b", "c"] {
-        storage
-            .set_workflow_node_completed(&run_id, name, now_millis(), None)
-            .unwrap();
-    }
-
-    let ready = storage
-        .get_ready_workflow_nodes(&run_id, &dag_json)
-        .unwrap();
-    assert!(ready.is_empty());
-}
-
+/// Diamond DAG (a → b, a → c, b → d, c → d) is not covered by the linear
+/// case in `tests/storage_contract.rs`; we keep it here because the setup is
+/// long and the topology logic is backend-agnostic (`compute_ready_nodes` is
+/// shared Rust). It uses the SQLite store for convenience.
 #[test]
 fn test_get_ready_nodes_diamond_dag() {
-    let storage = test_storage();
+    let base = SqliteStorage::in_memory().unwrap();
+    let storage = WorkflowSqliteStorage::new(base).unwrap();
 
-    // Diamond: a → b, a → c, b → d, c → d
     let dag_json = serde_json::json!({
         "nodes": [{"name": "a"}, {"name": "b"}, {"name": "c"}, {"name": "d"}],
         "edges": [
@@ -522,7 +90,7 @@ fn test_get_ready_nodes_diamond_dag() {
         ]
     });
 
-    let mut step_meta = std::collections::HashMap::new();
+    let mut step_meta = HashMap::new();
     for name in &["a", "b", "c", "d"] {
         step_meta.insert(
             name.to_string(),
@@ -562,12 +130,10 @@ fn test_get_ready_nodes_diamond_dag() {
             .unwrap();
     }
 
-    // Initially only "a" is ready
     let ready = storage.get_ready_workflow_nodes(&run_id, &dag_str).unwrap();
     assert_eq!(ready.len(), 1);
     assert_eq!(ready[0].node_name, "a");
 
-    // Complete "a" → "b" and "c" become ready (parallel)
     storage
         .set_workflow_node_completed(&run_id, "a", now_millis(), None)
         .unwrap();
@@ -577,264 +143,17 @@ fn test_get_ready_nodes_diamond_dag() {
     assert!(names.contains(&"b"));
     assert!(names.contains(&"c"));
 
-    // Complete only "b" → "d" NOT ready yet (needs "c" too)
     storage
         .set_workflow_node_completed(&run_id, "b", now_millis(), None)
         .unwrap();
     let ready = storage.get_ready_workflow_nodes(&run_id, &dag_str).unwrap();
     assert_eq!(ready.len(), 1);
-    assert_eq!(ready[0].node_name, "c"); // only c is pending+ready
+    assert_eq!(ready[0].node_name, "c");
 
-    // Complete "c" → "d" becomes ready
     storage
         .set_workflow_node_completed(&run_id, "c", now_millis(), None)
         .unwrap();
     let ready = storage.get_ready_workflow_nodes(&run_id, &dag_str).unwrap();
     assert_eq!(ready.len(), 1);
     assert_eq!(ready[0].node_name, "d");
-}
-
-// ── WorkflowState transition tests ───────────────────────────
-
-#[test]
-fn test_state_transitions() {
-    assert!(WorkflowState::Pending.can_transition_to(WorkflowState::Running));
-    assert!(WorkflowState::Running.can_transition_to(WorkflowState::Completed));
-    assert!(WorkflowState::Running.can_transition_to(WorkflowState::Failed));
-    assert!(WorkflowState::Running.can_transition_to(WorkflowState::Cancelled));
-    assert!(WorkflowState::Running.can_transition_to(WorkflowState::Paused));
-    assert!(WorkflowState::Paused.can_transition_to(WorkflowState::Running));
-    assert!(WorkflowState::Paused.can_transition_to(WorkflowState::Cancelled));
-
-    // Invalid transitions
-    assert!(!WorkflowState::Pending.can_transition_to(WorkflowState::Completed));
-    assert!(!WorkflowState::Completed.can_transition_to(WorkflowState::Running));
-    assert!(!WorkflowState::Failed.can_transition_to(WorkflowState::Running));
-}
-
-#[test]
-fn test_state_is_terminal() {
-    assert!(WorkflowState::Completed.is_terminal());
-    assert!(WorkflowState::Failed.is_terminal());
-    assert!(WorkflowState::Cancelled.is_terminal());
-    assert!(!WorkflowState::Pending.is_terminal());
-    assert!(!WorkflowState::Running.is_terminal());
-    assert!(!WorkflowState::Paused.is_terminal());
-}
-
-// ── Fan-out storage tests ───────────────────────────────────
-
-#[test]
-fn test_set_fan_out_count() {
-    let storage = test_storage();
-    let def = make_definition("fanout_pipe");
-    storage.create_workflow_definition(&def).unwrap();
-    let run = make_run(&def.id);
-    let run_id = run.id.clone();
-    storage.create_workflow_run(&run).unwrap();
-
-    let node = make_node(&run_id, "process");
-    storage.create_workflow_node(&node).unwrap();
-
-    // Initially pending, no fan_out_count
-    let fetched = storage
-        .get_workflow_node(&run_id, "process")
-        .unwrap()
-        .unwrap();
-    assert_eq!(fetched.status, WorkflowNodeStatus::Pending);
-    assert_eq!(fetched.fan_out_count, None);
-
-    // Set fan_out_count → status transitions to Running
-    storage
-        .set_workflow_node_fan_out_count(&run_id, "process", 5)
-        .unwrap();
-
-    let fetched = storage
-        .get_workflow_node(&run_id, "process")
-        .unwrap()
-        .unwrap();
-    assert_eq!(fetched.status, WorkflowNodeStatus::Running);
-    assert_eq!(fetched.fan_out_count, Some(5));
-}
-
-#[test]
-fn test_get_nodes_by_prefix() {
-    let storage = test_storage();
-    let def = make_definition("prefix_pipe");
-    storage.create_workflow_definition(&def).unwrap();
-    let run = make_run(&def.id);
-    let run_id = run.id.clone();
-    storage.create_workflow_run(&run).unwrap();
-
-    // Create parent and children
-    for name in &[
-        "process",
-        "process[0]",
-        "process[1]",
-        "process[2]",
-        "aggregate",
-    ] {
-        storage
-            .create_workflow_node(&make_node(&run_id, name))
-            .unwrap();
-    }
-
-    // Prefix "process[" should return only the children
-    let children = storage
-        .get_workflow_nodes_by_prefix(&run_id, "process[")
-        .unwrap();
-    assert_eq!(children.len(), 3);
-    let names: Vec<&str> = children.iter().map(|n| n.node_name.as_str()).collect();
-    assert!(names.contains(&"process[0]"));
-    assert!(names.contains(&"process[1]"));
-    assert!(names.contains(&"process[2]"));
-
-    // Prefix "aggregate" should match just the one node
-    let agg = storage
-        .get_workflow_nodes_by_prefix(&run_id, "aggregate")
-        .unwrap();
-    assert_eq!(agg.len(), 1);
-
-    // Prefix "nonexistent[" should return nothing
-    let empty = storage
-        .get_workflow_nodes_by_prefix(&run_id, "nonexistent[")
-        .unwrap();
-    assert!(empty.is_empty());
-}
-
-// ── Regression tests for correctness fixes (2026-04-24) ──────────
-
-/// Explicit `set_workflow_node_running` transitions without overloading
-/// fan_out_count — used by the sub-workflow tracker after the child
-/// successfully compiles and submits.
-#[test]
-fn test_set_workflow_node_running() {
-    let storage = test_storage();
-    let def = make_definition("sub_wf_parent");
-    storage.create_workflow_definition(&def).unwrap();
-    let run = make_run(&def.id);
-    let run_id = run.id.clone();
-    storage.create_workflow_run(&run).unwrap();
-    storage
-        .create_workflow_node(&make_node(&run_id, "parent"))
-        .unwrap();
-
-    let before = now_millis();
-    storage
-        .set_workflow_node_running(&run_id, "parent", before)
-        .unwrap();
-
-    let fetched = storage
-        .get_workflow_node(&run_id, "parent")
-        .unwrap()
-        .unwrap();
-    assert_eq!(fetched.status, WorkflowNodeStatus::Running);
-    assert_eq!(fetched.started_at, Some(before));
-    assert_eq!(
-        fetched.fan_out_count, None,
-        "set_workflow_node_running must not set fan_out_count"
-    );
-}
-
-/// The CAS-based finalize must transition exactly once even when called
-/// twice in a row (simulating concurrent callers that both see all children
-/// terminal). This is the storage-layer guarantee behind the P0 fan-in race fix.
-#[test]
-fn test_finalize_fan_out_parent_is_idempotent() {
-    let storage = test_storage();
-    let def = make_definition("fan_in_race");
-    storage.create_workflow_definition(&def).unwrap();
-    let run = make_run(&def.id);
-    let run_id = run.id.clone();
-    storage.create_workflow_run(&run).unwrap();
-    storage
-        .create_workflow_node(&make_node(&run_id, "process"))
-        .unwrap();
-
-    // First call: not terminal → transition runs.
-    let now = now_millis();
-    let first = storage
-        .finalize_fan_out_parent(&run_id, "process", true, None, now)
-        .unwrap();
-    assert!(first, "first caller must perform the transition");
-
-    let after_first = storage
-        .get_workflow_node(&run_id, "process")
-        .unwrap()
-        .unwrap();
-    assert_eq!(after_first.status, WorkflowNodeStatus::Completed);
-
-    // Second call: already terminal → CAS returns false, state unchanged.
-    let second = storage
-        .finalize_fan_out_parent(&run_id, "process", true, None, now + 1000)
-        .unwrap();
-    assert!(!second, "second caller must be rejected by the CAS");
-
-    let after_second = storage
-        .get_workflow_node(&run_id, "process")
-        .unwrap()
-        .unwrap();
-    assert_eq!(after_second.status, WorkflowNodeStatus::Completed);
-    assert_eq!(
-        after_second.completed_at, after_first.completed_at,
-        "second caller must not overwrite completed_at"
-    );
-}
-
-/// Rejected-path of the CAS: any child failure routes through the
-/// failure branch and sets the node error.
-#[test]
-fn test_finalize_fan_out_parent_failure_branch() {
-    let storage = test_storage();
-    let def = make_definition("fan_in_fail");
-    storage.create_workflow_definition(&def).unwrap();
-    let run = make_run(&def.id);
-    let run_id = run.id.clone();
-    storage.create_workflow_run(&run).unwrap();
-    storage
-        .create_workflow_node(&make_node(&run_id, "process"))
-        .unwrap();
-
-    let now = now_millis();
-    let transitioned = storage
-        .finalize_fan_out_parent(&run_id, "process", false, Some("boom"), now)
-        .unwrap();
-    assert!(transitioned);
-
-    let node = storage
-        .get_workflow_node(&run_id, "process")
-        .unwrap()
-        .unwrap();
-    assert_eq!(node.status, WorkflowNodeStatus::Failed);
-    assert_eq!(node.error.as_deref(), Some("boom"));
-}
-
-/// Nodes that are already in a terminal state must not be re-transitioned
-/// by the CAS — this guards against a late-arriving event from a
-/// cascade-skipped child.
-#[test]
-fn test_finalize_fan_out_parent_no_op_on_terminal_node() {
-    let storage = test_storage();
-    let def = make_definition("skipped_parent");
-    storage.create_workflow_definition(&def).unwrap();
-    let run = make_run(&def.id);
-    let run_id = run.id.clone();
-    storage.create_workflow_run(&run).unwrap();
-    storage
-        .create_workflow_node(&make_node(&run_id, "process"))
-        .unwrap();
-    storage
-        .update_workflow_node_status(&run_id, "process", WorkflowNodeStatus::Skipped)
-        .unwrap();
-
-    let transitioned = storage
-        .finalize_fan_out_parent(&run_id, "process", true, None, now_millis())
-        .unwrap();
-    assert!(!transitioned, "already-skipped nodes must be left alone");
-
-    let node = storage
-        .get_workflow_node(&run_id, "process")
-        .unwrap()
-        .unwrap();
-    assert_eq!(node.status, WorkflowNodeStatus::Skipped);
 }

--- a/crates/taskito-workflows/tests/storage_contract.rs
+++ b/crates/taskito-workflows/tests/storage_contract.rs
@@ -1,0 +1,658 @@
+//! Multi-backend contract suite for the `WorkflowStorage` trait.
+//!
+//! Every test body takes `&impl WorkflowStorage` so the same scenarios can
+//! run against SQLite (always), PostgreSQL (when `TASKITO_POSTGRES_TEST_URL`
+//! is set + `--features postgres`), and Redis (when `TASKITO_REDIS_TEST_URL`
+//! is set + `--features redis`). The three entry-point tests live at the
+//! bottom of this file and select the right storage handle for the active
+//! feature set, mirroring the per-backend pattern in
+//! `taskito-core/tests/rust/storage_tests.rs`.
+//!
+//! Skip-when-env-unset is the same convention used by the core contract
+//! suite — local `cargo test --features workflows,postgres,redis` runs all
+//! three only when the URLs are present; CI provides the URLs via service
+//! containers.
+
+use std::collections::HashMap;
+
+use taskito_core::job::now_millis;
+use taskito_workflows::{
+    StepMetadata, WorkflowDefinition, WorkflowNode, WorkflowNodeStatus, WorkflowRun, WorkflowState,
+    WorkflowStorage,
+};
+
+// ── Fixtures ───────────────────────────────────────────────────────────────
+
+fn make_step(task_name: &str) -> StepMetadata {
+    StepMetadata {
+        task_name: task_name.to_string(),
+        queue: None,
+        args_template: None,
+        kwargs_template: None,
+        max_retries: None,
+        timeout_ms: None,
+        priority: None,
+        fan_out: None,
+        fan_in: None,
+        condition: None,
+    }
+}
+
+fn make_definition(name: &str) -> WorkflowDefinition {
+    let mut step_metadata = HashMap::new();
+    step_metadata.insert("a".to_string(), make_step("task_a"));
+    step_metadata.insert("b".to_string(), make_step("task_b"));
+    step_metadata.insert("c".to_string(), make_step("task_c"));
+
+    let dag_json = serde_json::json!({
+        "nodes": [{"name": "a"}, {"name": "b"}, {"name": "c"}],
+        "edges": [
+            {"from": "a", "to": "b", "weight": 1.0},
+            {"from": "b", "to": "c", "weight": 1.0}
+        ]
+    });
+
+    WorkflowDefinition {
+        id: uuid::Uuid::now_v7().to_string(),
+        name: name.to_string(),
+        version: 1,
+        dag_data: serde_json::to_vec(&dag_json).unwrap(),
+        step_metadata,
+        created_at: now_millis(),
+    }
+}
+
+fn make_run(definition_id: &str) -> WorkflowRun {
+    WorkflowRun {
+        id: uuid::Uuid::now_v7().to_string(),
+        definition_id: definition_id.to_string(),
+        params: Some(r#"{"region":"eu"}"#.to_string()),
+        state: WorkflowState::Pending,
+        started_at: None,
+        completed_at: None,
+        error: None,
+        parent_run_id: None,
+        parent_node_name: None,
+        created_at: now_millis(),
+    }
+}
+
+fn make_node(run_id: &str, name: &str) -> WorkflowNode {
+    WorkflowNode {
+        id: uuid::Uuid::now_v7().to_string(),
+        run_id: run_id.to_string(),
+        node_name: name.to_string(),
+        job_id: None,
+        status: WorkflowNodeStatus::Pending,
+        result_hash: None,
+        fan_out_count: None,
+        fan_in_data: None,
+        started_at: None,
+        completed_at: None,
+        error: None,
+    }
+}
+
+// ── Per-test cases (each takes &impl WorkflowStorage) ─────────────────────
+
+fn case_create_and_get_definition(s: &impl WorkflowStorage) {
+    let def = make_definition("my_pipeline");
+    s.create_workflow_definition(&def).unwrap();
+
+    let fetched = s
+        .get_workflow_definition("my_pipeline", None)
+        .unwrap()
+        .unwrap();
+    assert_eq!(fetched.name, "my_pipeline");
+    assert_eq!(fetched.version, 1);
+    assert_eq!(fetched.step_metadata.len(), 3);
+    assert!(fetched.step_metadata.contains_key("a"));
+}
+
+fn case_get_definition_by_version(s: &impl WorkflowStorage) {
+    let mut def_v1 = make_definition("versioned");
+    def_v1.version = 1;
+    s.create_workflow_definition(&def_v1).unwrap();
+
+    let mut def_v2 = make_definition("versioned");
+    def_v2.id = uuid::Uuid::now_v7().to_string();
+    def_v2.version = 2;
+    s.create_workflow_definition(&def_v2).unwrap();
+
+    let latest = s
+        .get_workflow_definition("versioned", None)
+        .unwrap()
+        .unwrap();
+    assert_eq!(latest.version, 2);
+
+    let v1 = s
+        .get_workflow_definition("versioned", Some(1))
+        .unwrap()
+        .unwrap();
+    assert_eq!(v1.version, 1);
+}
+
+fn case_get_definition_by_id(s: &impl WorkflowStorage) {
+    let def = make_definition("by_id_test");
+    let def_id = def.id.clone();
+    s.create_workflow_definition(&def).unwrap();
+
+    let fetched = s.get_workflow_definition_by_id(&def_id).unwrap().unwrap();
+    assert_eq!(fetched.id, def_id);
+}
+
+fn case_definition_not_found(s: &impl WorkflowStorage) {
+    let result = s.get_workflow_definition("nonexistent", None).unwrap();
+    assert!(result.is_none());
+}
+
+fn case_create_and_get_run(s: &impl WorkflowStorage) {
+    let def = make_definition("run_test");
+    s.create_workflow_definition(&def).unwrap();
+
+    let run = make_run(&def.id);
+    let run_id = run.id.clone();
+    s.create_workflow_run(&run).unwrap();
+
+    let fetched = s.get_workflow_run(&run_id).unwrap().unwrap();
+    assert_eq!(fetched.id, run_id);
+    assert_eq!(fetched.state, WorkflowState::Pending);
+    assert_eq!(fetched.params, Some(r#"{"region":"eu"}"#.to_string()));
+}
+
+fn case_update_run_state(s: &impl WorkflowStorage) {
+    let def = make_definition("state_test");
+    s.create_workflow_definition(&def).unwrap();
+
+    let run = make_run(&def.id);
+    let run_id = run.id.clone();
+    s.create_workflow_run(&run).unwrap();
+
+    s.update_workflow_run_state(&run_id, WorkflowState::Running, None)
+        .unwrap();
+    let fetched = s.get_workflow_run(&run_id).unwrap().unwrap();
+    assert_eq!(fetched.state, WorkflowState::Running);
+
+    s.update_workflow_run_state(&run_id, WorkflowState::Failed, Some("node X blew up"))
+        .unwrap();
+    let fetched = s.get_workflow_run(&run_id).unwrap().unwrap();
+    assert_eq!(fetched.state, WorkflowState::Failed);
+    assert_eq!(fetched.error, Some("node X blew up".to_string()));
+}
+
+fn case_set_run_started_and_completed(s: &impl WorkflowStorage) {
+    let def = make_definition("timing_test");
+    s.create_workflow_definition(&def).unwrap();
+
+    let run = make_run(&def.id);
+    let run_id = run.id.clone();
+    s.create_workflow_run(&run).unwrap();
+
+    let start_time = now_millis();
+    s.set_workflow_run_started(&run_id, start_time).unwrap();
+    let fetched = s.get_workflow_run(&run_id).unwrap().unwrap();
+    assert_eq!(fetched.state, WorkflowState::Running);
+    assert_eq!(fetched.started_at, Some(start_time));
+
+    let end_time = now_millis();
+    s.set_workflow_run_completed(&run_id, end_time).unwrap();
+    let fetched = s.get_workflow_run(&run_id).unwrap().unwrap();
+    assert_eq!(fetched.completed_at, Some(end_time));
+}
+
+fn case_list_runs(s: &impl WorkflowStorage) {
+    let def = make_definition("list_test");
+    s.create_workflow_definition(&def).unwrap();
+
+    for _ in 0..5 {
+        s.create_workflow_run(&make_run(&def.id)).unwrap();
+    }
+
+    let all = s
+        .list_workflow_runs(Some("list_test"), None, 100, 0)
+        .unwrap();
+    assert_eq!(all.len(), 5);
+
+    let limited = s.list_workflow_runs(Some("list_test"), None, 2, 0).unwrap();
+    assert_eq!(limited.len(), 2);
+
+    let offset = s
+        .list_workflow_runs(Some("list_test"), None, 100, 3)
+        .unwrap();
+    assert_eq!(offset.len(), 2);
+}
+
+fn case_list_runs_by_state(s: &impl WorkflowStorage) {
+    let def = make_definition("state_filter");
+    s.create_workflow_definition(&def).unwrap();
+
+    let run1 = make_run(&def.id);
+    let run1_id = run1.id.clone();
+    s.create_workflow_run(&run1).unwrap();
+
+    let run2 = make_run(&def.id);
+    s.create_workflow_run(&run2).unwrap();
+
+    s.update_workflow_run_state(&run1_id, WorkflowState::Running, None)
+        .unwrap();
+
+    let running = s
+        .list_workflow_runs(Some("state_filter"), Some(WorkflowState::Running), 100, 0)
+        .unwrap();
+    assert_eq!(running.len(), 1);
+    assert_eq!(running[0].id, run1_id);
+
+    let pending = s
+        .list_workflow_runs(Some("state_filter"), Some(WorkflowState::Pending), 100, 0)
+        .unwrap();
+    assert_eq!(pending.len(), 1);
+}
+
+fn case_create_and_get_node(s: &impl WorkflowStorage) {
+    let def = make_definition("node_test");
+    s.create_workflow_definition(&def).unwrap();
+    let run = make_run(&def.id);
+    let run_id = run.id.clone();
+    s.create_workflow_run(&run).unwrap();
+
+    s.create_workflow_node(&make_node(&run_id, "a")).unwrap();
+
+    let fetched = s.get_workflow_node(&run_id, "a").unwrap().unwrap();
+    assert_eq!(fetched.node_name, "a");
+    assert_eq!(fetched.status, WorkflowNodeStatus::Pending);
+    assert!(fetched.job_id.is_none());
+}
+
+fn case_create_nodes_batch(s: &impl WorkflowStorage) {
+    let def = make_definition("batch_test");
+    s.create_workflow_definition(&def).unwrap();
+    let run = make_run(&def.id);
+    let run_id = run.id.clone();
+    s.create_workflow_run(&run).unwrap();
+
+    let nodes = vec![
+        make_node(&run_id, "a"),
+        make_node(&run_id, "b"),
+        make_node(&run_id, "c"),
+    ];
+    s.create_workflow_nodes_batch(&nodes).unwrap();
+
+    let all = s.get_workflow_nodes(&run_id).unwrap();
+    assert_eq!(all.len(), 3);
+}
+
+fn case_update_node_status(s: &impl WorkflowStorage) {
+    let def = make_definition("status_test");
+    s.create_workflow_definition(&def).unwrap();
+    let run = make_run(&def.id);
+    let run_id = run.id.clone();
+    s.create_workflow_run(&run).unwrap();
+    s.create_workflow_node(&make_node(&run_id, "a")).unwrap();
+
+    s.update_workflow_node_status(&run_id, "a", WorkflowNodeStatus::Running)
+        .unwrap();
+    let fetched = s.get_workflow_node(&run_id, "a").unwrap().unwrap();
+    assert_eq!(fetched.status, WorkflowNodeStatus::Running);
+}
+
+fn case_set_node_job_and_timing(s: &impl WorkflowStorage) {
+    let def = make_definition("job_test");
+    s.create_workflow_definition(&def).unwrap();
+    let run = make_run(&def.id);
+    let run_id = run.id.clone();
+    s.create_workflow_run(&run).unwrap();
+    s.create_workflow_node(&make_node(&run_id, "a")).unwrap();
+
+    s.set_workflow_node_job(&run_id, "a", "job-123").unwrap();
+    let fetched = s.get_workflow_node(&run_id, "a").unwrap().unwrap();
+    assert_eq!(fetched.job_id, Some("job-123".to_string()));
+
+    let start = now_millis();
+    s.set_workflow_node_started(&run_id, "a", start).unwrap();
+    let fetched = s.get_workflow_node(&run_id, "a").unwrap().unwrap();
+    assert_eq!(fetched.status, WorkflowNodeStatus::Running);
+    assert_eq!(fetched.started_at, Some(start));
+
+    let end = now_millis();
+    s.set_workflow_node_completed(&run_id, "a", end, Some("abc123"))
+        .unwrap();
+    let fetched = s.get_workflow_node(&run_id, "a").unwrap().unwrap();
+    assert_eq!(fetched.status, WorkflowNodeStatus::Completed);
+    assert_eq!(fetched.completed_at, Some(end));
+    assert_eq!(fetched.result_hash, Some("abc123".to_string()));
+}
+
+fn case_set_node_error(s: &impl WorkflowStorage) {
+    let def = make_definition("error_test");
+    s.create_workflow_definition(&def).unwrap();
+    let run = make_run(&def.id);
+    let run_id = run.id.clone();
+    s.create_workflow_run(&run).unwrap();
+    s.create_workflow_node(&make_node(&run_id, "a")).unwrap();
+
+    s.set_workflow_node_error(&run_id, "a", "kaboom").unwrap();
+    let fetched = s.get_workflow_node(&run_id, "a").unwrap().unwrap();
+    assert_eq!(fetched.status, WorkflowNodeStatus::Failed);
+    assert_eq!(fetched.error, Some("kaboom".to_string()));
+}
+
+fn case_ready_nodes_roots(s: &impl WorkflowStorage) {
+    let def = make_definition("ready_test");
+    let dag_json = String::from_utf8(def.dag_data.clone()).unwrap();
+    s.create_workflow_definition(&def).unwrap();
+
+    let run = make_run(&def.id);
+    let run_id = run.id.clone();
+    s.create_workflow_run(&run).unwrap();
+
+    let nodes = vec![
+        make_node(&run_id, "a"),
+        make_node(&run_id, "b"),
+        make_node(&run_id, "c"),
+    ];
+    s.create_workflow_nodes_batch(&nodes).unwrap();
+
+    let ready = s.get_ready_workflow_nodes(&run_id, &dag_json).unwrap();
+    assert_eq!(ready.len(), 1);
+    assert_eq!(ready[0].node_name, "a");
+}
+
+fn case_ready_nodes_after_completion(s: &impl WorkflowStorage) {
+    let def = make_definition("completion_ready");
+    let dag_json = String::from_utf8(def.dag_data.clone()).unwrap();
+    s.create_workflow_definition(&def).unwrap();
+
+    let run = make_run(&def.id);
+    let run_id = run.id.clone();
+    s.create_workflow_run(&run).unwrap();
+
+    s.create_workflow_nodes_batch(&[
+        make_node(&run_id, "a"),
+        make_node(&run_id, "b"),
+        make_node(&run_id, "c"),
+    ])
+    .unwrap();
+
+    s.set_workflow_node_completed(&run_id, "a", now_millis(), None)
+        .unwrap();
+
+    let ready = s.get_ready_workflow_nodes(&run_id, &dag_json).unwrap();
+    assert_eq!(ready.len(), 1);
+    assert_eq!(ready[0].node_name, "b");
+}
+
+fn case_ready_nodes_all_completed(s: &impl WorkflowStorage) {
+    let def = make_definition("all_done");
+    let dag_json = String::from_utf8(def.dag_data.clone()).unwrap();
+    s.create_workflow_definition(&def).unwrap();
+
+    let run = make_run(&def.id);
+    let run_id = run.id.clone();
+    s.create_workflow_run(&run).unwrap();
+
+    s.create_workflow_nodes_batch(&[
+        make_node(&run_id, "a"),
+        make_node(&run_id, "b"),
+        make_node(&run_id, "c"),
+    ])
+    .unwrap();
+
+    for name in &["a", "b", "c"] {
+        s.set_workflow_node_completed(&run_id, name, now_millis(), None)
+            .unwrap();
+    }
+
+    let ready = s.get_ready_workflow_nodes(&run_id, &dag_json).unwrap();
+    assert!(ready.is_empty());
+}
+
+fn case_set_fan_out_count(s: &impl WorkflowStorage) {
+    let def = make_definition("fanout_pipe");
+    s.create_workflow_definition(&def).unwrap();
+    let run = make_run(&def.id);
+    let run_id = run.id.clone();
+    s.create_workflow_run(&run).unwrap();
+
+    s.create_workflow_node(&make_node(&run_id, "process"))
+        .unwrap();
+
+    let fetched = s.get_workflow_node(&run_id, "process").unwrap().unwrap();
+    assert_eq!(fetched.status, WorkflowNodeStatus::Pending);
+    assert_eq!(fetched.fan_out_count, None);
+
+    s.set_workflow_node_fan_out_count(&run_id, "process", 5)
+        .unwrap();
+
+    let fetched = s.get_workflow_node(&run_id, "process").unwrap().unwrap();
+    assert_eq!(fetched.status, WorkflowNodeStatus::Running);
+    assert_eq!(fetched.fan_out_count, Some(5));
+}
+
+fn case_get_nodes_by_prefix(s: &impl WorkflowStorage) {
+    let def = make_definition("prefix_pipe");
+    s.create_workflow_definition(&def).unwrap();
+    let run = make_run(&def.id);
+    let run_id = run.id.clone();
+    s.create_workflow_run(&run).unwrap();
+
+    for name in &[
+        "process",
+        "process[0]",
+        "process[1]",
+        "process[2]",
+        "aggregate",
+    ] {
+        s.create_workflow_node(&make_node(&run_id, name)).unwrap();
+    }
+
+    let children = s.get_workflow_nodes_by_prefix(&run_id, "process[").unwrap();
+    assert_eq!(children.len(), 3);
+    let names: Vec<&str> = children.iter().map(|n| n.node_name.as_str()).collect();
+    assert!(names.contains(&"process[0]"));
+    assert!(names.contains(&"process[1]"));
+    assert!(names.contains(&"process[2]"));
+
+    let agg = s
+        .get_workflow_nodes_by_prefix(&run_id, "aggregate")
+        .unwrap();
+    assert_eq!(agg.len(), 1);
+
+    let empty = s
+        .get_workflow_nodes_by_prefix(&run_id, "nonexistent[")
+        .unwrap();
+    assert!(empty.is_empty());
+}
+
+fn case_set_workflow_node_running(s: &impl WorkflowStorage) {
+    let def = make_definition("sub_wf_parent");
+    s.create_workflow_definition(&def).unwrap();
+    let run = make_run(&def.id);
+    let run_id = run.id.clone();
+    s.create_workflow_run(&run).unwrap();
+    s.create_workflow_node(&make_node(&run_id, "parent"))
+        .unwrap();
+
+    let before = now_millis();
+    s.set_workflow_node_running(&run_id, "parent", before)
+        .unwrap();
+
+    let fetched = s.get_workflow_node(&run_id, "parent").unwrap().unwrap();
+    assert_eq!(fetched.status, WorkflowNodeStatus::Running);
+    assert_eq!(fetched.started_at, Some(before));
+    assert_eq!(
+        fetched.fan_out_count, None,
+        "set_workflow_node_running must not set fan_out_count"
+    );
+}
+
+fn case_finalize_fan_out_parent_is_idempotent(s: &impl WorkflowStorage) {
+    let def = make_definition("fan_in_race");
+    s.create_workflow_definition(&def).unwrap();
+    let run = make_run(&def.id);
+    let run_id = run.id.clone();
+    s.create_workflow_run(&run).unwrap();
+    s.create_workflow_node(&make_node(&run_id, "process"))
+        .unwrap();
+
+    let now = now_millis();
+    let first = s
+        .finalize_fan_out_parent(&run_id, "process", true, None, now)
+        .unwrap();
+    assert!(first, "first caller must perform the transition");
+
+    let after_first = s.get_workflow_node(&run_id, "process").unwrap().unwrap();
+    assert_eq!(after_first.status, WorkflowNodeStatus::Completed);
+
+    let second = s
+        .finalize_fan_out_parent(&run_id, "process", true, None, now + 1000)
+        .unwrap();
+    assert!(!second, "second caller must be rejected by the CAS");
+
+    let after_second = s.get_workflow_node(&run_id, "process").unwrap().unwrap();
+    assert_eq!(after_second.status, WorkflowNodeStatus::Completed);
+    assert_eq!(
+        after_second.completed_at, after_first.completed_at,
+        "second caller must not overwrite completed_at"
+    );
+}
+
+fn case_finalize_fan_out_parent_failure_branch(s: &impl WorkflowStorage) {
+    let def = make_definition("fan_in_fail");
+    s.create_workflow_definition(&def).unwrap();
+    let run = make_run(&def.id);
+    let run_id = run.id.clone();
+    s.create_workflow_run(&run).unwrap();
+    s.create_workflow_node(&make_node(&run_id, "process"))
+        .unwrap();
+
+    let now = now_millis();
+    let transitioned = s
+        .finalize_fan_out_parent(&run_id, "process", false, Some("boom"), now)
+        .unwrap();
+    assert!(transitioned);
+
+    let node = s.get_workflow_node(&run_id, "process").unwrap().unwrap();
+    assert_eq!(node.status, WorkflowNodeStatus::Failed);
+    assert_eq!(node.error.as_deref(), Some("boom"));
+}
+
+fn case_finalize_fan_out_parent_no_op_on_terminal_node(s: &impl WorkflowStorage) {
+    let def = make_definition("skipped_parent");
+    s.create_workflow_definition(&def).unwrap();
+    let run = make_run(&def.id);
+    let run_id = run.id.clone();
+    s.create_workflow_run(&run).unwrap();
+    s.create_workflow_node(&make_node(&run_id, "process"))
+        .unwrap();
+    s.update_workflow_node_status(&run_id, "process", WorkflowNodeStatus::Skipped)
+        .unwrap();
+
+    let transitioned = s
+        .finalize_fan_out_parent(&run_id, "process", true, None, now_millis())
+        .unwrap();
+    assert!(!transitioned, "already-skipped nodes must be left alone");
+
+    let node = s.get_workflow_node(&run_id, "process").unwrap().unwrap();
+    assert_eq!(node.status, WorkflowNodeStatus::Skipped);
+}
+
+fn case_get_child_workflow_runs(s: &impl WorkflowStorage) {
+    let def = make_definition("parent_def");
+    s.create_workflow_definition(&def).unwrap();
+
+    let parent = make_run(&def.id);
+    let parent_id = parent.id.clone();
+    s.create_workflow_run(&parent).unwrap();
+
+    let mut child = make_run(&def.id);
+    child.parent_run_id = Some(parent_id.clone());
+    child.parent_node_name = Some("subflow_node".to_string());
+    let child_id = child.id.clone();
+    s.create_workflow_run(&child).unwrap();
+
+    let children = s.get_child_workflow_runs(&parent_id).unwrap();
+    assert_eq!(children.len(), 1);
+    assert_eq!(children[0].id, child_id);
+}
+
+// ── Contract runner ────────────────────────────────────────────────────────
+
+fn run_contract(s: &impl WorkflowStorage) {
+    case_create_and_get_definition(s);
+    case_get_definition_by_version(s);
+    case_get_definition_by_id(s);
+    case_definition_not_found(s);
+    case_create_and_get_run(s);
+    case_update_run_state(s);
+    case_set_run_started_and_completed(s);
+    case_list_runs(s);
+    case_list_runs_by_state(s);
+    case_create_and_get_node(s);
+    case_create_nodes_batch(s);
+    case_update_node_status(s);
+    case_set_node_job_and_timing(s);
+    case_set_node_error(s);
+    case_ready_nodes_roots(s);
+    case_ready_nodes_after_completion(s);
+    case_ready_nodes_all_completed(s);
+    case_set_fan_out_count(s);
+    case_get_nodes_by_prefix(s);
+    case_set_workflow_node_running(s);
+    case_finalize_fan_out_parent_is_idempotent(s);
+    case_finalize_fan_out_parent_failure_branch(s);
+    case_finalize_fan_out_parent_no_op_on_terminal_node(s);
+    case_get_child_workflow_runs(s);
+}
+
+// ── Per-backend entry points ──────────────────────────────────────────────
+
+#[test]
+fn sqlite_storage_contract() {
+    use taskito_core::storage::sqlite::SqliteStorage;
+    use taskito_workflows::WorkflowSqliteStorage;
+
+    let base = SqliteStorage::in_memory().unwrap();
+    let s = WorkflowSqliteStorage::new(base).unwrap();
+    run_contract(&s);
+}
+
+#[cfg(feature = "postgres")]
+#[test]
+fn postgres_storage_contract() {
+    use taskito_core::storage::postgres::PostgresStorage;
+    use taskito_workflows::WorkflowPostgresStorage;
+
+    let url = match std::env::var("TASKITO_POSTGRES_TEST_URL") {
+        Ok(u) => u,
+        Err(_) => {
+            eprintln!("skipping postgres_storage_contract: TASKITO_POSTGRES_TEST_URL not set");
+            return;
+        }
+    };
+    // Use a unique schema per run so concurrent test invocations and stale
+    // workflow rows from a prior run can't bleed across.
+    let schema = format!("wf_contract_{}", uuid::Uuid::now_v7().simple());
+    let base = PostgresStorage::with_schema(&url, &schema).unwrap();
+    let s = WorkflowPostgresStorage::new(base).unwrap();
+    run_contract(&s);
+}
+
+#[cfg(feature = "redis")]
+#[test]
+fn redis_storage_contract() {
+    use taskito_core::storage::redis_backend::RedisStorage;
+    use taskito_workflows::WorkflowRedisStorage;
+
+    let url = match std::env::var("TASKITO_REDIS_TEST_URL") {
+        Ok(u) => u,
+        Err(_) => {
+            eprintln!("skipping redis_storage_contract: TASKITO_REDIS_TEST_URL not set");
+            return;
+        }
+    };
+    // Use a unique prefix per run to isolate keys.
+    let prefix = format!("wf_contract_{}:", uuid::Uuid::now_v7().simple());
+    let base = RedisStorage::with_prefix(&url, &prefix).unwrap();
+    let s = WorkflowRedisStorage::new(base).unwrap();
+    run_contract(&s);
+}


### PR DESCRIPTION
## Summary

Audit P1 step 3 of 3 — workflow backend parity is now machine-verified.

**Stacks on #179 + #180.** Once both Postgres and Redis backends land, this PR's contract suite proves they're functionally identical to SQLite.

- `crates/taskito-workflows/tests/storage_contract.rs` — 24 cases, each takes \`&impl WorkflowStorage\`. Three test entry points dispatch to the right backend:
  - \`sqlite_storage_contract\` always runs.
  - \`postgres_storage_contract\` runs when \`TASKITO_POSTGRES_TEST_URL\` is set + \`--features postgres\` (skips otherwise).
  - \`redis_storage_contract\` runs when \`TASKITO_REDIS_TEST_URL\` is set + \`--features redis\` (skips otherwise).
- Per-run isolation: Postgres uses a fresh schema name (\`wf_contract_{uuid}\`), Redis uses a fresh prefix (\`wf_contract_{uuid}:\`). No bleed between concurrent test invocations.
- Existing inline \`tests.rs\` shrunk to the cases that don't fit the contract format: state-machine assertions (pure Rust, no storage) and the diamond DAG test (long setup). Net diff: −729 / +48 LOC there.
- \`pg_rewrite\` SQL helper gated behind \`#[cfg(feature = "postgres")]\` so non-postgres builds don't warn about dead code.
- CI: \`Rust Tests (PostgreSQL)\` and \`Rust Tests (Redis)\` jobs now run with \`--features postgres,workflows\` / \`--features redis,workflows\`. The contract suite gets exercised on every PR.

## Test plan

- [x] \`cargo test -p taskito-workflows\` (SQLite only, no env vars) — 3 inline + 1 contract case
- [x] \`TASKITO_POSTGRES_TEST_URL=... cargo test -p taskito-workflows --features postgres --test storage_contract\` — both sqlite + postgres pass
- [x] \`TASKITO_REDIS_TEST_URL=... cargo test -p taskito-workflows --features redis --test storage_contract\` — both sqlite + redis pass
- [x] Both URLs set with \`--features postgres,redis\` — all 3 backends pass (24 cases each)
- [x] CI workflow changes pass actionlint locally (yaml only, no behavioral changes)

## Outcome

Audit P1 "Workflows are SQLite-only" — **CLOSED**. Backend parity is machine-enforced going forward.