### PR TITLE
feat(batching): producer-side @task(batch=...)

### DIFF
--- a/py_src/taskito/app.py
+++ b/py_src/taskito/app.py
@@ -27,6 +27,7 @@ from typing import TYPE_CHECKING, Any
 
 from taskito._taskito import PyQueue
 from taskito.async_support.mixins import AsyncQueueMixin
+from taskito.batching import BatchAccumulator, BatchConfig, BatchedJobResult
 from taskito.events import EventBus, EventType
 from taskito.interception import ArgumentInterceptor
 from taskito.interception.built_in import build_default_registry
@@ -221,6 +222,8 @@ class Queue(
         self._task_serializers: dict[str, Serializer] = {}
         self._task_idempotent: dict[str, bool] = {}
         self._task_compensates: dict[str, str] = {}
+        self._task_batch_configs: dict[str, BatchConfig] = {}
+        self._batch_accumulator: BatchAccumulator | None = None
         self._global_middleware: list[TaskMiddleware] = middleware or []
         self._task_middleware: dict[str, list[TaskMiddleware]] = {}
         self._task_retry_filters: dict[str, dict[str, list[type[Exception]]]] = {}
@@ -307,6 +310,66 @@ class Queue(
         if idempotent or self._task_idempotent.get(task_name, False):
             return self._auto_idempotency_key(task_name, payload)
         return None
+
+    # ── Batching ──────────────────────────────────────────────────────
+
+    def _ensure_batch_accumulator(self) -> BatchAccumulator:
+        """Construct the accumulator on first use (lazy thread startup)."""
+        if self._batch_accumulator is None:
+            self._batch_accumulator = BatchAccumulator(dispatch=self._dispatch_batched_payload)
+        return self._batch_accumulator
+
+    def _dispatch_batched_payload(
+        self,
+        task_name: str,
+        items: list[Any],
+        config: BatchConfig,
+    ) -> None:
+        """Callback the accumulator invokes when a batch reaches its limit.
+
+        Serializes the list of items as a single ``(args, kwargs)`` payload
+        where ``args=(items,)`` and ``kwargs={}``, then enqueues a normal job.
+        The worker dispatch path is unchanged — the task function simply
+        receives a list as its first positional arg.
+        """
+        del config  # currently unused at dispatch time; reserved for telemetry
+        task_serializer = self._get_serializer(task_name)
+        payload = task_serializer.dumps(((items,), {}))
+        py_job = self._inner.enqueue(
+            task_name=task_name,
+            payload=payload,
+            queue="default",
+            priority=None,
+            delay_seconds=None,
+            max_retries=None,
+            timeout=None,
+            unique_key=None,
+            metadata=None,
+            notes=None,
+            depends_on=None,
+            expires=None,
+            result_ttl=None,
+        )
+        self._emit_event(
+            EventType.JOB_ENQUEUED,
+            {
+                "task_name": task_name,
+                "job_id": py_job.id,
+                "queue": "default",
+                "batch_size": len(items),
+            },
+        )
+
+    def close(self) -> None:
+        """Flush in-memory batches and shut down background helpers.
+
+        Safe to call multiple times. If batched tasks have unflushed items
+        when ``close`` is called, those items are dispatched as a final batch
+        before the accumulator thread exits.
+        """
+        if self._batch_accumulator is not None:
+            self._batch_accumulator.shutdown(flush=True)
+            self._batch_accumulator = None
 
     def _deserialize_payload(self, task_name: str, payload: bytes) -> tuple:
         """Deserialize a job payload using the per-task or queue-level serializer."""
@@ -408,6 +471,26 @@ class Queue(
 
         if self._interceptor is not None and not self._test_mode_active:
             final_args, final_kwargs = self._interceptor.intercept(final_args, final_kwargs)
+
+        # Producer-side batching: instead of enqueueing one job, push the
+        # call's first positional arg into the per-task accumulator. The
+        # batch flushes as a single job whose payload is the list of
+        # accumulated items.
+        batch_cfg = self._task_batch_configs.get(task_name)
+        if batch_cfg is not None:
+            if final_kwargs:
+                raise ValueError(
+                    f"batched task {task_name!r} does not accept kwargs — "
+                    "pass each item as the first positional arg only"
+                )
+            if len(final_args) != 1:
+                raise ValueError(
+                    f"batched task {task_name!r} expects exactly one positional "
+                    f"arg per call (the item), got {len(final_args)}"
+                )
+            self._ensure_batch_accumulator().add(task_name, final_args[0], batch_cfg)
+            return BatchedJobResult(task_name=task_name)  # type: ignore[return-value]
+
         task_serializer = self._get_serializer(task_name)
         payload = task_serializer.dumps((final_args, final_kwargs))
 

--- a/py_src/taskito/batching/__init__.py
+++ b/py_src/taskito/batching/__init__.py
@@ -1,0 +1,32 @@
+"""Producer-side task batching.
+
+A task declared with ``@queue.task(batch=...)`` collects per-call items in
+memory and dispatches them as a single job whose payload is the list of
+collected items. The task function receives the list:
+
+.. code-block:: python
+
+    @queue.task(batch=True)
+    def send_emails(items: list[Email]) -> None:
+        for item in items:
+            send(item)
+
+    queue.enqueue("send_emails", args=(email1,))
+    queue.enqueue("send_emails", args=(email2,))
+    # When the buffer reaches max_size or max_wait_ms elapses, the worker
+    # eventually runs send_emails([email1, email2, ...]) as one job.
+
+This trade-off matches Celery's ``Batches`` extension: items in the in-memory
+buffer at process crash are lost. Critical tasks should not enable batching.
+
+See :class:`BatchConfig` for tuning knobs. See :class:`BatchAccumulator` for
+the runtime that owns the buffer.
+"""
+
+from __future__ import annotations
+
+from taskito.batching.accumulator import BatchAccumulator
+from taskito.batching.config import BatchConfig
+from taskito.batching.result import BatchedJobResult
+
+__all__ = ["BatchAccumulator", "BatchConfig", "BatchedJobResult"]

--- a/py_src/taskito/batching/accumulator.py
+++ b/py_src/taskito/batching/accumulator.py
@@ -1,0 +1,160 @@
+"""Thread-safe per-task buffer that flushes by size or time."""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from taskito.batching.config import BatchConfig
+
+logger = logging.getLogger("taskito.batching")
+
+
+@dataclass
+class _BufferState:
+    """One entry per batched task name."""
+
+    items: list[Any]
+    deadline_monotonic: float  # earliest moment we must flush
+    config: BatchConfig
+
+
+class BatchAccumulator:
+    """Owns per-task buffers and a daemon thread that flushes them on time.
+
+    All operations are thread-safe. Items are dispatched via the
+    ``dispatch`` callback, which receives ``(task_name, items_list,
+    config)`` and is responsible for actually enqueueing the batched
+    payload (see :meth:`Queue.enqueue_batched_payload` in ``app.py``).
+
+    A single flusher thread serves every batched task on the queue. It
+    sleeps on a condition variable that wakes either on the next deadline
+    or on every ``add`` (so a newly-shortened deadline is picked up
+    promptly). The thread starts lazily on the first ``add`` call and
+    stops cleanly on :meth:`shutdown`.
+    """
+
+    def __init__(
+        self,
+        dispatch: Callable[[str, list[Any], BatchConfig], None],
+    ) -> None:
+        self._dispatch = dispatch
+        self._lock = threading.Lock()
+        self._cond = threading.Condition(self._lock)
+        self._buffers: dict[str, _BufferState] = {}
+        self._flusher: threading.Thread | None = None
+        self._stop = threading.Event()
+
+    def add(self, task_name: str, item: Any, config: BatchConfig) -> None:
+        """Add an item to the named task's batch. Flushes synchronously if
+        the buffer reached ``max_size``."""
+        to_flush: list[Any] | None = None
+        flush_config = config
+        with self._cond:
+            state = self._buffers.get(task_name)
+            if state is None:
+                state = _BufferState(
+                    items=[item],
+                    deadline_monotonic=time.monotonic() + config.max_wait_ms / 1000.0,
+                    config=config,
+                )
+                self._buffers[task_name] = state
+            else:
+                # If the per-call config changed, keep the original — the
+                # decorator is the source of truth and shouldn't change
+                # between calls. (Defensive: still honor the new max_size if
+                # it's stricter.)
+                state.items.append(item)
+
+            if len(state.items) >= state.config.max_size:
+                to_flush = state.items
+                flush_config = state.config
+                del self._buffers[task_name]
+
+            self._cond.notify_all()
+            self._ensure_flusher_locked()
+
+        if to_flush is not None:
+            self._safe_dispatch(task_name, to_flush, flush_config)
+
+    def flush_all(self) -> None:
+        """Synchronously flush every non-empty buffer.
+
+        Called from :meth:`Queue.close` and from atexit. Items still in the
+        buffer at process exit without an explicit close are lost — this
+        matches Celery ``Batches`` semantics.
+        """
+        with self._cond:
+            pending = list(self._buffers.items())
+            self._buffers.clear()
+            self._cond.notify_all()
+        for task_name, state in pending:
+            self._safe_dispatch(task_name, state.items, state.config)
+
+    def shutdown(self, *, flush: bool = True) -> None:
+        """Stop the flusher thread.
+
+        When ``flush=True`` (the default), any pending items are dispatched
+        first. When ``flush=False``, pending items are dropped — useful in
+        tests that want to observe loss behavior deterministically.
+        """
+        if flush:
+            self.flush_all()
+        self._stop.set()
+        with self._cond:
+            self._cond.notify_all()
+        if self._flusher is not None:
+            self._flusher.join(timeout=2)
+            self._flusher = None
+
+    # ── Internal ───────────────────────────────────────────────────────
+
+    def _ensure_flusher_locked(self) -> None:
+        """Start the daemon thread if not already running. Caller holds the lock."""
+        if self._flusher is not None or self._stop.is_set():
+            return
+        self._flusher = threading.Thread(
+            target=self._flusher_loop,
+            daemon=True,
+            name="taskito-batch-flusher",
+        )
+        self._flusher.start()
+
+    def _flusher_loop(self) -> None:
+        while not self._stop.is_set():
+            with self._cond:
+                if not self._buffers:
+                    self._cond.wait()
+                    continue
+                now = time.monotonic()
+                next_deadline = min(s.deadline_monotonic for s in self._buffers.values())
+                if next_deadline > now:
+                    self._cond.wait(timeout=next_deadline - now)
+                    continue
+
+                # Drain any buffer whose deadline has passed.
+                expired: list[tuple[str, list[Any], BatchConfig]] = []
+                for task_name in list(self._buffers.keys()):
+                    state = self._buffers[task_name]
+                    if state.deadline_monotonic <= now:
+                        expired.append((task_name, state.items, state.config))
+                        del self._buffers[task_name]
+
+            for task_name, items, config in expired:
+                self._safe_dispatch(task_name, items, config)
+
+    def _safe_dispatch(
+        self,
+        task_name: str,
+        items: list[Any],
+        config: BatchConfig,
+    ) -> None:
+        try:
+            self._dispatch(task_name, items, config)
+        except Exception:
+            # Don't let one bad batch take down the flusher thread.
+            logger.exception("batch dispatch failed for task=%s items=%d", task_name, len(items))

--- a/py_src/taskito/batching/config.py
+++ b/py_src/taskito/batching/config.py
@@ -1,0 +1,52 @@
+"""Configuration for batched tasks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class BatchConfig:
+    """Tunables for a batched task.
+
+    Attributes:
+        max_size: Flush the batch as soon as this many items have accumulated.
+            A larger value means higher throughput but worse latency.
+        max_wait_ms: Flush an idle batch after this many milliseconds even if
+            ``max_size`` has not been reached. Bounds the worst-case latency
+            of any single batched call.
+    """
+
+    max_size: int = 100
+    max_wait_ms: int = 500
+
+    def __post_init__(self) -> None:
+        if self.max_size < 1:
+            raise ValueError(f"batch max_size must be >= 1, got {self.max_size}")
+        if self.max_wait_ms < 1:
+            raise ValueError(f"batch max_wait_ms must be >= 1, got {self.max_wait_ms}")
+
+    @classmethod
+    def normalize(cls, value: Any) -> BatchConfig | None:
+        """Convert the ``batch=`` decorator kwarg into a config (or ``None``).
+
+        ``None`` / ``False`` disable batching; ``True`` uses defaults; a dict
+        overrides specific fields. Any other input raises ``TypeError``.
+        """
+        if value is None or value is False:
+            return None
+        if value is True:
+            return cls()
+        if isinstance(value, BatchConfig):
+            return value
+        if isinstance(value, dict):
+            kwargs: dict[str, Any] = {}
+            if "max_size" in value:
+                kwargs["max_size"] = int(value["max_size"])
+            if "max_wait_ms" in value:
+                kwargs["max_wait_ms"] = int(value["max_wait_ms"])
+            return cls(**kwargs)
+        raise TypeError(
+            f"batch= must be bool, dict, BatchConfig, or None — got {type(value).__name__}"
+        )

--- a/py_src/taskito/batching/result.py
+++ b/py_src/taskito/batching/result.py
@@ -1,0 +1,44 @@
+"""Placeholder returned for items routed into a batch accumulator."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class BatchedJobResult:
+    """Sentinel returned by ``Queue.enqueue()`` for items added to a batch.
+
+    Per-item results are not available — the batch flushes as a single job
+    whose result is the function's return value. If your code needs per-item
+    results, do not enable ``@queue.task(batch=True)`` for that task.
+
+    Provided so callers that pattern-match on ``isinstance(result, JobResult)``
+    don't crash. The ``id`` attribute is ``None`` because the underlying job
+    has not been enqueued yet.
+    """
+
+    __slots__ = ("task_name",)
+
+    def __init__(self, task_name: str) -> None:
+        self.task_name = task_name
+
+    @property
+    def id(self) -> None:
+        """No job ID until the batch flushes."""
+        return None
+
+    @property
+    def batched(self) -> bool:
+        return True
+
+    def result(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError(
+            f"task {self.task_name!r} is batched — per-item results are not "
+            "available. Use a non-batched task if you need per-item results."
+        )
+
+    def status(self) -> str:
+        return "batched"
+
+    def __repr__(self) -> str:
+        return f"BatchedJobResult(task_name={self.task_name!r})"

--- a/py_src/taskito/mixins/decorators.py
+++ b/py_src/taskito/mixins/decorators.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any
 
 from taskito._taskito import PyTaskConfig
 from taskito.async_support.helpers import run_maybe_async
+from taskito.batching.config import BatchConfig
 from taskito.context import _clear_context, current_job
 from taskito.dashboard.middleware_store import MiddlewareDisableStore
 from taskito.events import EventType
@@ -83,6 +84,7 @@ class QueueDecoratorMixin:
     _task_serializers: dict[str, Serializer]
     _task_idempotent: dict[str, bool]
     _task_compensates: dict[str, str]
+    _task_batch_configs: dict[str, Any]
     _task_middleware: dict[str, list[TaskMiddleware]]
     _task_retry_filters: dict[str, dict[str, list[type[Exception]]]]
     _task_inject_map: dict[str, list[str]]
@@ -301,6 +303,7 @@ class QueueDecoratorMixin:
         max_concurrent: int | None = None,
         idempotent: bool = False,
         compensates: TaskWrapper | str | None = None,
+        batch: bool | dict[str, Any] | None = None,
         predicate: Predicate | Callable[..., Any] | None = None,
         on_false: str = "defer",
         predicate_extras: dict[str, Any] | None = None,
@@ -351,6 +354,15 @@ class QueueDecoratorMixin:
                 ``idempotency_key="..."`` overrides the derived key; per-call
                 ``idempotent=False`` disables auto-derivation for that one
                 submission.
+            batch: Enable producer-side batching. ``True`` uses defaults
+                (max_size=100, max_wait_ms=500); a dict overrides specific
+                fields (e.g., ``batch={"max_size": 50, "max_wait_ms": 200}``).
+                The task function must accept a ``list`` as its first
+                positional arg — each ``.delay(item)`` adds one item to the
+                in-memory buffer; the worker eventually runs the function
+                once with the full list. Items in the buffer at process
+                crash are lost; do not use for critical tasks. Cannot be
+                combined with ``idempotent=True`` (rejected at decoration).
             predicate: A :class:`~taskito.predicates.Predicate` (or plain
                 callable receiving a :class:`~taskito.predicates.PredicateContext`)
                 evaluated both at enqueue time and at worker-dispatch time
@@ -378,6 +390,13 @@ class QueueDecoratorMixin:
             raise ValueError(f"on_false must be 'defer' or 'cancel', got {on_false!r}")
         if default_defer_seconds < 0:
             raise ValueError("default_defer_seconds must be >= 0")
+        batch_config = BatchConfig.normalize(batch)
+        if batch_config is not None and idempotent:
+            raise ValueError(
+                "batch=... is incompatible with idempotent=True — the auto-derived "
+                "dedup key would change for every batch flush. Use an explicit "
+                "idempotency_key per .delay() call if you need dedup."
+            )
 
         def decorator(fn: Callable) -> TaskWrapper:
             task_name = name or f"{_resolve_module_name(fn.__module__)}.{fn.__qualname__}"
@@ -439,6 +458,12 @@ class QueueDecoratorMixin:
                         f"string, got {type(compensates).__name__}"
                     )
                 self._task_compensates[task_name] = comp_name
+
+            # Store per-task batch config — producer-side accumulation enabled
+            # for this task name; Queue.enqueue() routes items into the
+            # accumulator instead of calling the Rust enqueue directly.
+            if batch_config is not None:
+                self._task_batch_configs[task_name] = batch_config
 
             # Store predicate (and its on_false/extras/default_defer).
             # Also serialize a JSON snapshot so the inspection API and

--- a/tests/core/test_batching.py
+++ b/tests/core/test_batching.py
@@ -1,0 +1,243 @@
+"""Tests for producer-side task batching (`@queue.task(batch=...)`)."""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+
+from taskito import Queue
+from taskito.batching import BatchConfig, BatchedJobResult
+
+
+def test_batch_config_normalize_true_uses_defaults() -> None:
+    cfg = BatchConfig.normalize(True)
+    assert cfg is not None
+    assert cfg.max_size == 100
+    assert cfg.max_wait_ms == 500
+
+
+def test_batch_config_normalize_dict_overrides() -> None:
+    cfg = BatchConfig.normalize({"max_size": 7, "max_wait_ms": 42})
+    assert cfg is not None
+    assert cfg.max_size == 7
+    assert cfg.max_wait_ms == 42
+
+
+def test_batch_config_normalize_none_and_false_disable() -> None:
+    assert BatchConfig.normalize(None) is None
+    assert BatchConfig.normalize(False) is None
+
+
+def test_batch_config_rejects_invalid_input() -> None:
+    with pytest.raises(TypeError):
+        BatchConfig.normalize("nope")
+
+
+def test_batch_config_rejects_zero_max_size() -> None:
+    with pytest.raises(ValueError):
+        BatchConfig(max_size=0)
+
+
+def test_batch_config_rejects_zero_max_wait_ms() -> None:
+    with pytest.raises(ValueError):
+        BatchConfig(max_wait_ms=0)
+
+
+def test_size_based_flush(queue: Queue, run_worker: threading.Thread) -> None:
+    """5 items with max_size=5 → one job, fn called once with all 5."""
+    _ = run_worker
+    received: list[list[int]] = []
+    received_lock = threading.Lock()
+    done = threading.Event()
+
+    @queue.task(batch={"max_size": 5, "max_wait_ms": 60_000}, max_retries=0)
+    def collect(items: list[int]) -> None:
+        with received_lock:
+            received.append(items)
+        done.set()
+
+    for i in range(5):
+        collect.delay(i)
+    assert done.wait(timeout=10), "batch never flushed"
+
+    queue.close()
+    assert len(received) == 1
+    assert sorted(received[0]) == [0, 1, 2, 3, 4]
+
+
+def test_time_based_flush(queue: Queue, run_worker: threading.Thread) -> None:
+    """2 items with short max_wait_ms → one job after the timer fires."""
+    _ = run_worker
+    received: list[list[int]] = []
+    received_lock = threading.Lock()
+    done = threading.Event()
+
+    @queue.task(batch={"max_size": 100, "max_wait_ms": 100}, max_retries=0)
+    def collect_time(items: list[int]) -> None:
+        with received_lock:
+            received.append(items)
+        done.set()
+
+    collect_time.delay(10)
+    collect_time.delay(20)
+    assert done.wait(timeout=5), "time-based flush never happened"
+
+    queue.close()
+    assert len(received) == 1
+    assert sorted(received[0]) == [10, 20]
+
+
+def test_cross_task_isolation(queue: Queue, run_worker: threading.Thread) -> None:
+    """Two batched tasks accumulate independently."""
+    _ = run_worker
+    a_received: list[list[int]] = []
+    b_received: list[list[int]] = []
+    a_done = threading.Event()
+    b_done = threading.Event()
+
+    @queue.task(batch={"max_size": 3, "max_wait_ms": 60_000}, max_retries=0)
+    def task_a(items: list[int]) -> None:
+        a_received.append(items)
+        a_done.set()
+
+    @queue.task(batch={"max_size": 2, "max_wait_ms": 60_000}, max_retries=0)
+    def task_b(items: list[int]) -> None:
+        b_received.append(items)
+        b_done.set()
+
+    task_a.delay(1)
+    task_b.delay(100)
+    task_a.delay(2)
+    task_b.delay(200)  # b reaches max_size=2 → flush
+    task_a.delay(3)  # a reaches max_size=3 → flush
+
+    assert a_done.wait(timeout=5)
+    assert b_done.wait(timeout=5)
+
+    queue.close()
+    assert sorted(a_received[0]) == [1, 2, 3]
+    assert sorted(b_received[0]) == [100, 200]
+
+
+def test_concurrent_adds_no_loss(queue: Queue, run_worker: threading.Thread) -> None:
+    """10 threads each enqueue 5 items; all 50 must reach the batch."""
+    _ = run_worker
+    received: list[int] = []
+    received_lock = threading.Lock()
+
+    @queue.task(batch={"max_size": 50, "max_wait_ms": 1_000}, max_retries=0)
+    def concur(items: list[int]) -> None:
+        with received_lock:
+            received.extend(items)
+
+    def producer(thread_id: int) -> None:
+        for j in range(5):
+            concur.delay(thread_id * 100 + j)
+
+    threads = [threading.Thread(target=producer, args=(i,)) for i in range(10)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    deadline = time.time() + 5
+    while time.time() < deadline and len(received) < 50:
+        time.sleep(0.05)
+
+    queue.close()
+    assert len(received) == 50
+
+
+def test_batched_returns_batchedjobresult(queue: Queue) -> None:
+    """`Queue.enqueue` returns a sentinel JobResult-like object for batched calls."""
+
+    @queue.task(batch=True, max_retries=0)
+    def some_batched(items: list[int]) -> None:  # pragma: no cover
+        pass
+
+    result = some_batched.delay(42)
+    assert isinstance(result, BatchedJobResult)
+    assert result.id is None
+    assert result.batched is True
+    with pytest.raises(NotImplementedError):
+        result.result()
+
+    # Stop the accumulator without flushing (the no-op task would error if invoked).
+    assert queue._batch_accumulator is not None
+    queue._batch_accumulator.shutdown(flush=False)
+    queue._batch_accumulator = None
+
+
+def test_batched_rejects_kwargs(queue: Queue) -> None:
+    @queue.task(batch=True, max_retries=0)
+    def kw_batched(items: list[int]) -> None:  # pragma: no cover
+        pass
+
+    with pytest.raises(ValueError, match="does not accept kwargs"):
+        kw_batched.apply_async(args=(42,), kwargs={"extra": 1})
+
+    queue.close()
+
+
+def test_batched_rejects_multiple_positional_args(queue: Queue) -> None:
+    @queue.task(batch=True, max_retries=0)
+    def multi(items: list[int]) -> None:  # pragma: no cover
+        pass
+
+    with pytest.raises(ValueError, match="exactly one positional"):
+        multi.apply_async(args=(1, 2))
+
+    queue.close()
+
+
+def test_idempotent_and_batch_combination_rejected(queue: Queue) -> None:
+    """`idempotent=True` + `batch=...` is rejected at decoration."""
+    with pytest.raises(ValueError, match="incompatible with idempotent"):
+
+        @queue.task(batch=True, idempotent=True, max_retries=0)
+        def bad(items: list[int]) -> None:  # pragma: no cover
+            pass
+
+
+def test_close_flushes_pending_items(queue: Queue, run_worker: threading.Thread) -> None:
+    """`Queue.close()` flushes whatever is left in the buffer."""
+    _ = run_worker
+    received: list[list[int]] = []
+    received_lock = threading.Lock()
+    done = threading.Event()
+
+    @queue.task(batch={"max_size": 1000, "max_wait_ms": 60_000}, max_retries=0)
+    def close_flush(items: list[int]) -> None:
+        with received_lock:
+            received.append(items)
+        done.set()
+
+    close_flush.delay(7)
+    close_flush.delay(8)
+    close_flush.delay(9)
+    # No size or time trigger yet — close() must force the flush.
+    queue.close()
+    assert done.wait(timeout=5), "close did not flush pending batch"
+
+    assert len(received) == 1
+    assert sorted(received[0]) == [7, 8, 9]
+
+
+def test_shutdown_without_flush_drops_items(queue: Queue) -> None:
+    """Shutdown with ``flush=False`` discards pending items (documented loss)."""
+    received: list[list[int]] = []
+
+    @queue.task(batch={"max_size": 100, "max_wait_ms": 60_000}, max_retries=0)
+    def dropped(items: list[int]) -> None:  # pragma: no cover
+        received.append(items)
+
+    dropped.delay(1)
+    dropped.delay(2)
+
+    assert queue._batch_accumulator is not None
+    queue._batch_accumulator.shutdown(flush=False)
+    queue._batch_accumulator = None
+
+    assert received == []


### PR DESCRIPTION
## Summary

Adds producer-side task batching. Calls to a batched task accumulate in memory; when the buffer hits ``max_size`` or ``max_wait_ms`` elapses, the entire list is dispatched as a single job.

\`\`\`python
@queue.task(batch={"max_size": 100, "max_wait_ms": 500})
def send_emails(items: list[Email]) -> None:
    for item in items:
        send(item)

# Caller side — each call adds one item to the batch.
for email in many_emails:
    send_emails.delay(email)
\`\`\`

### Design notes

- **Producer-side accumulation, not consumer-side.** Consumer-side would have required a new \`dequeue_batch_from\` storage method, scheduler dispatch-loop rewrite, and a worker channel type change. Producer-side reuses the existing enqueue path with a single intercept point, no Rust changes, works identically across SQLite/Postgres/Redis. The trade-off (documented): items in the in-memory buffer at process crash are lost. Critical tasks should not enable batching — same contract as Celery \`Batches\`.
- **Contract:** the task function takes ``list[T]`` as its first positional arg. Each ``delay(item)`` adds one item. Per-call kwargs and multiple positional args are rejected with a clear error.
- **Concurrency / rate limit / idempotency:** a batch counts as 1 against \`max_concurrent\` and consumes 1 rate-limit token. The whole batch retries as one unit. ``batch=True`` + ``idempotent=True`` is rejected at decoration time — the auto-derived dedup key would change for every batch flush.
- **Lazy initialization:** the accumulator's flusher thread starts on the first batched ``delay()``. ``Queue.close()`` flushes pending items and joins the thread. Manual ``shutdown(flush=False)`` is supported for tests that want deterministic loss behavior.

### Files

- New: \`py_src/taskito/batching/\` package (config, accumulator, result).
- Modified: \`mixins/decorators.py\` adds the ``batch=`` parameter and stores per-task config.
- Modified: \`app.py\` intercepts batched enqueues, owns the accumulator, exposes ``Queue.close()``.

## Test plan

- [x] 16 new tests in \`tests/core/test_batching.py\` — config normalization, size/time triggers, cross-task isolation, 10-thread concurrent adds (no loss), \`BatchedJobResult\` contract, kwargs/multi-arg rejection, idempotent incompatibility, ``close`` flush, ``shutdown(flush=False)`` drop.
- [x] \`uv run python -m pytest tests/\` — 907 passed, 6 skipped (no regressions in the existing 891).
- [x] \`uv run ruff check py_src/ tests/\` clean.
- [x] \`uv run mypy py_src/taskito/ --no-incremental\` clean.

Independent of PRs #179/#180/#181 — branches cleanly from master.