### PR TITLE
docs: sagas, batching, workflow parity

### DIFF
--- a/docs/content/docs/guides/core/batching.mdx
+++ b/docs/content/docs/guides/core/batching.mdx
@@ -1,0 +1,93 @@
+---
+title: Task batching
+description: Collect many small calls into one larger job
+---
+
+When a task does small per-call work — sending an email, writing a row, calling an API — running one job per call is wasteful. `@queue.task(batch=...)` collects calls in memory and dispatches them as a single job whose payload is the list of accumulated items.
+
+```python
+from taskito import Queue
+
+queue = Queue()
+
+@queue.task(batch={"max_size": 100, "max_wait_ms": 500})
+def send_emails(items: list[dict]) -> None:
+    for item in items:
+        smtp.send(item)
+
+# Each call adds ONE item to the batch.
+for recipient in many_recipients:
+    send_emails.delay(recipient)
+
+# When 100 items accumulate OR 500ms elapse since the first call,
+# the framework enqueues ONE job: send_emails([item1, item2, ..., itemN]).
+```
+
+## Configuration
+
+| Param          | Default | Meaning                                                             |
+|----------------|--------:|---------------------------------------------------------------------|
+| `max_size`     |     100 | Flush when the buffer reaches this many items                       |
+| `max_wait_ms`  |     500 | Flush after this many ms have passed since the first item arrived   |
+
+Either threshold triggers a flush — whichever fires first. `@queue.task(batch=True)` uses both defaults.
+
+## Function signature contract
+
+A batched task **must** accept a list as its first positional arg:
+
+```python
+@queue.task(batch=True)
+def fn(items: list[T]) -> None: ...
+```
+
+Each call must pass exactly one positional arg — that arg becomes one element of `items`. Keyword arguments are not accepted for batched tasks:
+
+```python
+send_emails.delay({"to": "a@x.com"})        # ✓
+send_emails.delay({"to": "a@x.com"}, foo=1) # ✗ ValueError
+send_emails.delay(item1, item2)             # ✗ ValueError
+```
+
+## Durability trade-off
+
+<Callout type="warn" title="Items in the buffer are not durable">
+Items that have been added to the in-memory accumulator but not yet flushed are **lost** if the process crashes. taskito does **not** persist them between the `.delay()` call and the flush.
+
+This matches Celery's `Batches` extension semantics — it's the price you pay for higher throughput. For tasks where every item must reach the queue (financial transactions, ordered side effects), do not enable batching. Use regular `.delay()`.
+
+`Queue.close()` and `atexit` both flush remaining items. Crashes between flushes lose whatever was in the buffer.
+</Callout>
+
+## Concurrency, rate limits, and retries
+
+- **A batch counts as one job.** A batched task with `max_concurrent=1` runs **one batch** at a time, not one item. A rate limit of `"10/m"` allows ten batches per minute.
+- **Retries are per-batch.** If the function raises while processing item 5 of 10, the entire batch is retried (with the same `items` list). For per-item resilience, wrap each item in your own try/except.
+- **No per-item idempotency.** `idempotent=True` is incompatible with `batch=...` and is rejected at decoration time — the auto-derived dedup key would change with each batch flush.
+
+## Return value
+
+`.delay()` on a batched task returns a `BatchedJobResult` sentinel rather than a real `JobResult`:
+
+```python
+result = send_emails.delay(item)
+# result.id    → None  (no real job until flush)
+# result.batched → True
+# result.result() → raises NotImplementedError
+```
+
+Calling `.result()` on a batched return value is intentionally an error — there is no per-item result. If you need a return value per item, batching is the wrong primitive.
+
+## When to use batching
+
+- Many small writes to the same downstream system (databases, APIs).
+- Notification fan-out (mail, push, SMS).
+- Aggregating analytics events.
+
+When not to use it:
+
+- Critical individual jobs (financial transactions, billing events).
+- Tasks where per-item retry matters.
+- Heterogeneous work that doesn't share the same downstream code path.
+
+See also the [`canvas.chunks()`](/docs/guides/workflows/canvas) primitive — it's a producer-side equivalent that creates `N` separate jobs each holding a sub-list, with full per-chunk retry semantics.

--- a/docs/content/docs/guides/core/meta.json
+++ b/docs/content/docs/guides/core/meta.json
@@ -7,6 +7,7 @@
     "execution-model",
     "scheduling",
     "predicates",
+    "batching",
     "workflows"
   ]
 }

--- a/docs/content/docs/guides/workflows/meta.json
+++ b/docs/content/docs/guides/workflows/meta.json
@@ -6,6 +6,7 @@
     "conditions",
     "gates",
     "composition",
+    "sagas",
     "caching",
     "analysis",
     "canvas"

--- a/docs/content/docs/guides/workflows/sagas.mdx
+++ b/docs/content/docs/guides/workflows/sagas.mdx
@@ -1,0 +1,120 @@
+---
+title: Sagas
+description: Reverse-order compensation when a workflow step fails
+---
+
+A saga is a workflow where each step has a registered **compensator** — a task that undoes the step's side effect. If a later step fails, taskito automatically runs the compensators of every already-completed step, in reverse topological order, so the system ends up in a consistent state.
+
+```python
+from taskito import Queue
+from taskito.workflows import Workflow
+
+queue = Queue()
+
+@queue.task
+def refund(forward_args, forward_kwargs, forward_result):
+    charge_id = forward_result  # the id returned by charge()
+    payment_api.refund(charge_id)
+
+@queue.task(compensates=refund)
+def charge(amount: int, customer_id: str) -> str:
+    return payment_api.charge(amount, customer_id)
+
+@queue.task
+def ship(order_id: int):
+    shipping_api.ship(order_id)
+
+wf = Workflow(name="checkout")
+wf.step("charge",  charge, args=(100, "c1"))
+wf.step("ship",    ship,   args=(42,),  after="charge")
+
+run = queue.submit_workflow(wf)
+final = run.wait()
+```
+
+If `ship` fails after `charge` succeeded, taskito enqueues `refund` automatically. The final run state is `COMPENSATED` (every compensator succeeded) or `COMPENSATION_FAILED` (one or more failed).
+
+## Compensation contract
+
+Every compensator receives three positional args:
+
+```python
+def compensator(forward_args: tuple, forward_kwargs: dict, forward_result: Any) -> None:
+    ...
+```
+
+That's the **only** signature taskito calls compensators with. It lets one compensator service multiple workflows without coupling to specific step shapes.
+
+<Callout type="info" title="v1 limitations">
+For the initial saga release:
+
+- `forward_args` / `forward_kwargs` are populated only for *deferred* nodes (fan-out, fan-in, conditional, gate, sub-workflow). Static steps currently pass empty tuples/dicts. Look up state yourself if you need the originals.
+- `forward_result` is always `None` in v1.
+- Sagas trigger only when `on_failure="fail_fast"` (the default). `on_failure="continue"` workflows do not compensate.
+</Callout>
+
+## Declaring compensators
+
+There are two places you can declare a compensator. The step-level setting always wins.
+
+**Decorator-level** — the default compensator for this task wherever it's used:
+
+```python
+@queue.task(compensates=refund)
+def charge(amount: int, customer_id: str) -> str:
+    ...
+```
+
+**Step-level** — override or add the compensator for one specific workflow step:
+
+```python
+wf.step("charge", charge, args=(100, "c1"), compensates=refund_v2)
+```
+
+To explicitly disable compensation for a specific step (even when the task has a decorator-level default):
+
+```python
+wf.step("charge", charge, args=(100, "c1"), compensates=None)
+```
+
+## Execution model
+
+When a workflow step's forward execution fails with retries exhausted:
+
+1. The run transitions to state `Compensating`. A `WORKFLOW_COMPENSATING` event fires.
+2. taskito collects every step that **completed successfully** AND has a registered compensator. Failed, skipped, pending, and ready nodes are not compensated.
+3. Those steps are grouped into **reverse topological waves**: leaves first, roots last. Within a wave, compensators run in parallel.
+4. Each compensator is enqueued with an idempotency key of `compensation:{run_id}:{node_name}` — re-triggering compensation (e.g. after a tracker restart) is safe.
+5. After a wave finishes:
+   - All compensators succeeded → next wave starts.
+   - Any failed → the run terminates as `CompensationFailed`. **Subsequent waves are not dispatched** because downstream rollback may depend on the failed step.
+
+## Final run states
+
+| State                 | Meaning                                                                   |
+|-----------------------|---------------------------------------------------------------------------|
+| `COMPLETED`           | Run finished normally — no compensation ran                               |
+| `FAILED`              | Forward failure with no registered compensators                           |
+| `COMPENSATED`         | Forward failed, every applicable compensator succeeded                    |
+| `COMPENSATION_FAILED` | Forward failed, and one or more compensators failed during rollback       |
+
+`WorkflowState.is_terminal()` returns `True` for all four.
+
+## Idempotency
+
+Compensators **must** be idempotent: taskito guarantees at-most-one compensation per `(run, node)` pair via the idempotency key, but the underlying network/database call can still be retried by the worker before reaching exhaustion. Treat the compensator like any other worker task — write it to be safe to retry.
+
+## Events
+
+Saga lifecycle emits dedicated events on the queue's event bus:
+
+| Event                                  | Fires when                                              |
+|----------------------------------------|---------------------------------------------------------|
+| `WORKFLOW_COMPENSATING`                | Run enters the compensation phase                       |
+| `WORKFLOW_COMPENSATED`                 | All compensators succeeded                              |
+| `WORKFLOW_COMPENSATION_FAILED`         | At least one compensator failed                         |
+| `NODE_COMPENSATING`                    | A node's compensator was enqueued                       |
+| `NODE_COMPENSATED`                     | A node's compensator finished successfully              |
+| `NODE_COMPENSATION_FAILED`             | A node's compensator failed after retries               |
+
+Subscribe via `queue.on(EventType.WORKFLOW_COMPENSATED, callback)` like any other workflow event.

--- a/docs/content/docs/more/changelog.mdx
+++ b/docs/content/docs/more/changelog.mdx
@@ -5,6 +5,21 @@ description: "Release history for taskito — every notable change, fix, and fea
 
 All notable changes to taskito are documented here.
 
+## Unreleased
+
+### Added
+
+- **Workflow PostgreSQL backend.** `WorkflowPostgresStorage` mirrors the SQLite implementation through the shared `impl_workflow_diesel_ops!` macro. Workflows now run on Postgres-backed queues — the previous `PyRuntimeError` on non-SQLite backends is gone.
+- **Workflow Redis backend.** `WorkflowRedisStorage` (in `crates/taskito-workflows/src/redis_store.rs`) stores definitions, runs, and nodes as hashes under a `wf:` prefix, with sorted-set indexes for state/definition lookup and a Lua `FINALIZE_FAN_OUT` script for atomic fan-in CAS.
+- **Multi-backend workflow contract suite** (`crates/taskito-workflows/tests/storage_contract.rs`). 27 cases run against every workflow backend. CI now verifies parity on every PR for SQLite, PostgreSQL, and Redis.
+- **`@queue.task(batch=...)`.** Producer-side task batching collects per-call items in memory and dispatches them as a single job whose payload is the list. Tunable `max_size` / `max_wait_ms`. See `/docs/guides/core/batching`.
+- **Saga compensation.** `@queue.task(compensates=...)` and `Workflow.step(..., compensates=...)` declare a compensator. On forward failure (in `fail_fast` mode) taskito runs the registered compensators in reverse topological order, with idempotency guaranteed via `compensation:{run_id}:{node_name}` dedup keys. New workflow states: `Compensating`, `Compensated`, `CompensationFailed`. See `/docs/guides/workflows/sagas`.
+
+### Fixed
+
+- **Atomic fan-out node creation.** `expand_fan_out` now uses the transactional `create_workflow_nodes_batch` to insert all child workflow nodes in one transaction. A crash partway through fan-out expansion no longer leaves half-tracked children.
+- **Diesel `?`-placeholder rewriting for Postgres.** `sql_query` does not auto-rewrite `?` → `$N` for PostgreSQL; the workflow crate's macro now does it explicitly via the `pg_rewrite` helper.
+
 ## 0.12.3
 
 ### Added


### PR DESCRIPTION
## Summary

Documentation for the three feature shipments in PRs #179 / #180 / #181 (workflow parity), #182 (batching), and #183 / #184 (sagas).

- New guide: ``/docs/guides/workflows/sagas`` — orchestration model, compensation contract, declaration sites, idempotency, lifecycle events, final-state semantics.
- New guide: ``/docs/guides/core/batching`` — when to use it, configuration, function-signature contract, the durability trade-off, concurrency/rate-limit/retry semantics.
- Updated ``meta.json`` nav for ``core`` and ``workflows`` sections.
- Changelog "Unreleased" entry covering all 6 sibling PRs.

## Test plan

- [x] ``pnpm --dir docs types:check`` clean
- [x] ``pnpm --dir docs build`` produces all routes (incl. ``/docs/guides/workflows/sagas`` and ``/docs/guides/core/batching``)