### PR TITLE
feat(saga): propagate compensation into sub-workflow children

### DIFF
--- a/py_src/taskito/workflows/saga/orchestrator.py
+++ b/py_src/taskito/workflows/saga/orchestrator.py
@@ -53,6 +53,20 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("taskito.workflows.saga")
 
+# Cap nested saga propagation. A parent workflow compensating a sub-workflow
+# node that itself triggers nested compensation, and so on, must not recurse
+# indefinitely. Ten levels is far beyond any reasonable real workflow.
+MAX_SAGA_DEPTH = 10
+
+
+class SagaDepthExceededError(RuntimeError):
+    """Raised when nested saga propagation exceeds :data:`MAX_SAGA_DEPTH`.
+
+    Hitting this almost always means a workflow graph has accidental sub-
+    workflow recursion. Surface it loudly rather than silently truncating
+    compensation.
+    """
+
 
 class SagaOrchestrator:
     """Per-Queue saga state machine."""
@@ -74,6 +88,18 @@ class SagaOrchestrator:
         # a worker restart between enqueue and execute loses the context,
         # which is consistent with the rest of the saga's in-memory state.
         self._comp_contexts: dict[str, CompensationContext] = {}
+        # Saga-depth bookkeeping for nested propagation. Keyed by run_id;
+        # populated at ``start_compensation`` time, decremented at finalize.
+        # When a parent run propagates compensation into a child sub-workflow
+        # the child inherits ``parent_depth + 1`` — raising
+        # :class:`SagaDepthExceededError` past :data:`MAX_SAGA_DEPTH`.
+        self._run_depth: dict[str, int] = {}
+        # Mapping: child_run_id → (parent_run_id, parent_node_name) for the
+        # ongoing nested-saga propagations the orchestrator is waiting on.
+        # When the child saga finalises, the parent node is marked
+        # compensated/failed based on the child's outcome and the parent's
+        # wave advances.
+        self._pending_parent_after_child: dict[str, tuple[str, str]] = {}
 
     # ── Public API used by tracker ──────────────────────────────────────
 
@@ -99,20 +125,37 @@ class SagaOrchestrator:
         run_id: str,
         run_config: _RunConfig,
         steps: dict[str, _Step],
+        depth: int = 0,
     ) -> bool:
         """Begin reverse-order compensation for ``run_id``.
 
         Returns ``True`` if compensation was started, ``False`` if the
         run is not eligible (no compensable completed nodes, or already
         compensating).
+
+        ``depth`` is the nested-saga propagation depth. Each parent →
+        child propagation increments it; callers from the tracker pass
+        ``0``. Exceeding :data:`MAX_SAGA_DEPTH` raises
+        :class:`SagaDepthExceededError`.
         """
+        if depth > MAX_SAGA_DEPTH:
+            raise SagaDepthExceededError(
+                f"saga propagation depth exceeded {MAX_SAGA_DEPTH} for run {run_id}"
+            )
+
         with self._lock:
             if run_id in self._run_waves:
                 return False
-            if not run_config.compensation_map:
+
+            # A run is saga-eligible when it has *any* form of compensation:
+            # an explicit ``compensation_map`` entry, or a sub-workflow node
+            # whose child run carries its own saga (propagation).
+            has_explicit = bool(run_config.compensation_map)
+            has_subwf_propagation = self._has_propagatable_subworkflows(run_id, run_config)
+            if not (has_explicit or has_subwf_propagation):
                 return False
 
-            completed = self._fetch_compensable_nodes(run_id, run_config.compensation_map)
+            completed = self._fetch_compensable_nodes(run_id, run_config)
             if not completed:
                 return False
 
@@ -123,6 +166,7 @@ class SagaOrchestrator:
             self._run_waves[run_id] = waves
             self._run_inflight[run_id] = set()
             self._run_any_failed[run_id] = False
+            self._run_depth[run_id] = depth
 
             self._mark_run_compensating(run_id)
 
@@ -180,13 +224,16 @@ class SagaOrchestrator:
     def _fetch_compensable_nodes(
         self,
         run_id: str,
-        compensation_map: dict[str, str],
+        run_config: _RunConfig,
     ) -> set[str]:
-        """Return the subset of ``compensation_map`` that should run.
+        """Return the set of completed nodes that should run during compensation.
 
         A node is compensable when its current storage status is
-        ``"completed"`` or ``"cache_hit"`` AND it has a registered
-        compensator.
+        ``"completed"`` or ``"cache_hit"`` AND either:
+
+        - it has an explicit compensator in ``run_config.compensation_map``, or
+        - it is a sub-workflow node whose child run has its own saga
+          (propagation candidate).
         """
         try:
             node_data = self._queue._inner.get_base_run_node_data(run_id)
@@ -194,20 +241,53 @@ class SagaOrchestrator:
             logger.exception("saga: failed to fetch node data for run %s", run_id)
             return set()
 
+        compensation_map = run_config.compensation_map
+        sub_refs = run_config.sub_workflow_refs
+
         compensable: set[str] = set()
-        # node_data is list[(name, status_str, result_hash)] per the Rust
-        # binding's `get_base_run_node_data` shape.
         for entry in node_data:
             try:
                 name = entry[0]
                 status = entry[1]
             except (IndexError, TypeError):
                 continue
-            if status in ("completed", "cache_hit") and name in compensation_map:
+            if status not in ("completed", "cache_hit"):
+                continue
+            if name in compensation_map:
+                compensable.add(name)
+                continue
+            # Implicit sub-workflow propagation: include only if a child
+            # exists *and* has its own saga.
+            if name in sub_refs and self._child_has_saga(run_id, name):
                 compensable.add(name)
         return compensable
 
+    def _has_propagatable_subworkflows(self, run_id: str, run_config: _RunConfig) -> bool:
+        """Are any of this run's sub-workflow children eligible for saga
+        propagation? Cheap check used to decide whether to start a saga at
+        all when the run has no explicit ``compensation_map`` entries."""
+        for node_name in run_config.sub_workflow_refs:
+            if self._child_has_saga(run_id, node_name):
+                return True
+        return False
+
+    def _child_has_saga(self, parent_run_id: str, parent_node_name: str) -> bool:
+        """Whether any tracked child run of ``(parent_run_id, parent_node_name)``
+        has a non-empty ``compensation_map``."""
+        tracker = getattr(self._queue, "_workflow_tracker", None)
+        if tracker is None:
+            return False
+        with getattr(tracker, "_state_lock", threading.RLock()):
+            for cid, (prid, pnn) in list(getattr(tracker, "_child_to_parent", {}).items()):
+                if prid != parent_run_id or pnn != parent_node_name:
+                    continue
+                cfg = getattr(tracker, "_run_configs", {}).get(cid)
+                if cfg is not None and cfg.compensation_map:
+                    return True
+        return False
+
     def _advance_or_finalize(self, run_id: str, run_config: _RunConfig | None) -> None:
+        finalized: tuple[bool, str | None] | None = None
         with self._lock:
             waves = self._run_waves.get(run_id)
             any_failed = self._run_any_failed.get(run_id, False)
@@ -217,11 +297,22 @@ class SagaOrchestrator:
                 if waves:
                     self._run_waves[run_id] = []
                 self._finalize_locked(run_id, succeeded=False)
-                return
-
-            if not waves:
+                finalized = (False, f"sub-workflow {run_id} compensation failed")
+            elif not waves:
                 self._finalize_locked(run_id, succeeded=True)
-                return
+                finalized = (True, None)
+
+        # If this run was a child saga whose parent is waiting on it, hand
+        # the outcome back to the parent so it can complete its node and
+        # advance. Run outside the lock — the callback re-enters
+        # ``_handle_inline_no_op`` which acquires it.
+        if finalized is not None:
+            with self._lock:
+                pending = run_id in self._pending_parent_after_child
+            if pending:
+                succeeded, err = finalized
+                self._on_child_saga_terminal(run_id, succeeded, err)
+            return
 
         if run_config is not None:
             self._dispatch_next_wave(run_id, run_config)
@@ -244,6 +335,20 @@ class SagaOrchestrator:
         run_config: _RunConfig,
     ) -> None:
         comp_task_name = run_config.compensation_map.get(node_name)
+
+        # Sub-workflow propagation: if the parent has NO explicit compensator
+        # for this node but the node *was* a sub-workflow whose child run has
+        # its own saga, propagate compensation into the child. The parent
+        # node is held in the inflight set until the child finalises; on the
+        # child's terminal event the parent node is marked accordingly and
+        # the parent's wave advances.
+        if (
+            comp_task_name is None
+            and node_name in run_config.sub_workflow_refs
+            and self._propagate_to_child_saga(run_id, node_name)
+        ):
+            return
+
         if comp_task_name is None:
             logger.warning(
                 "saga: no compensator registered for %s/%s — skipping",
@@ -341,6 +446,84 @@ class SagaOrchestrator:
             },
         )
 
+    def _propagate_to_child_saga(self, parent_run_id: str, parent_node_name: str) -> bool:
+        """Trigger compensation on a sub-workflow child run.
+
+        Returns ``True`` if propagation started (parent node now waits on
+        the child's terminal event), ``False`` if there's no eligible child
+        to propagate to (the caller should fall back to the no-op path).
+        """
+        tracker = getattr(self._queue, "_workflow_tracker", None)
+        if tracker is None:
+            return False
+
+        child_runs: list[tuple[str, _RunConfig]] = []
+        # ``_child_to_parent`` maps child_run_id → (parent_run_id, parent_node_name).
+        # Reverse-scan to find children of this specific parent node.
+        with getattr(tracker, "_state_lock", threading.RLock()):
+            for cid, (prid, pnn) in list(getattr(tracker, "_child_to_parent", {}).items()):
+                if prid != parent_run_id or pnn != parent_node_name:
+                    continue
+                cfg = getattr(tracker, "_run_configs", {}).get(cid)
+                if cfg is None or not cfg.compensation_map:
+                    continue
+                child_runs.append((cid, cfg))
+
+        if not child_runs:
+            return False
+
+        # Single child per parent sub-workflow node is the common shape. If
+        # multiple children exist (parallel sub-workflows under the same
+        # node) we propagate to all of them and complete the parent only
+        # after every child terminates.
+        parent_depth = self._run_depth.get(parent_run_id, 0)
+        propagated_any = False
+        for child_run_id, child_cfg in child_runs:
+            child_steps = getattr(tracker, "_run_steps", {}).get(child_run_id, {})
+            try:
+                started = self.start_compensation(
+                    child_run_id,
+                    child_cfg,
+                    child_steps,
+                    depth=parent_depth + 1,
+                )
+            except SagaDepthExceededError:
+                logger.exception(
+                    "saga: depth guard tripped propagating from %s/%s to %s",
+                    parent_run_id,
+                    parent_node_name,
+                    child_run_id,
+                )
+                return False
+
+            if started:
+                with self._lock:
+                    self._pending_parent_after_child[child_run_id] = (
+                        parent_run_id,
+                        parent_node_name,
+                    )
+                propagated_any = True
+
+        return propagated_any
+
+    def _on_child_saga_terminal(
+        self, child_run_id: str, child_succeeded: bool, child_error: str | None
+    ) -> None:
+        """Callback fired by :meth:`_finalize_locked` for a child saga whose
+        parent run is waiting for it. Marks the parent node compensated
+        (success) or failed (failure) and advances the parent's wave."""
+        with self._lock:
+            mapping = self._pending_parent_after_child.pop(child_run_id, None)
+        if mapping is None:
+            return
+        parent_run_id, parent_node_name = mapping
+        self._handle_inline_no_op(
+            parent_run_id,
+            parent_node_name,
+            succeeded=child_succeeded,
+            error=child_error,
+        )
+
     def _handle_inline_no_op(
         self,
         run_id: str,
@@ -411,6 +594,7 @@ class SagaOrchestrator:
         """Cleanly finalize a saga. Must be called with ``self._lock``."""
         self._run_waves.pop(run_id, None)
         self._run_inflight.pop(run_id, None)
+        self._run_depth.pop(run_id, None)
         any_failed = self._run_any_failed.pop(run_id, False)
         # Drop any straggling job→node mappings and their stashed contexts.
         stale_jids = [jid for jid, (rid, _nn) in self._comp_job_to_node.items() if rid == run_id]
@@ -440,6 +624,10 @@ class SagaOrchestrator:
             event_type,
             {"workflow_run_id": run_id, "any_failed": any_failed},
         )
+
+        # ``_advance_or_finalize`` handles sub-workflow saga propagation
+        # (calling ``_on_child_saga_terminal`` *after* this method returns
+        # and the orchestrator lock has been released).
 
     def _safe_call(self, method_name: str, *args: Any) -> None:
         """Invoke a storage method on the Rust binding, logging on failure."""

--- a/py_src/taskito/workflows/tracker/sub_workflows.py
+++ b/py_src/taskito/workflows/tracker/sub_workflows.py
@@ -79,13 +79,17 @@ def submit_sub_workflow(
             node_name,
         )
 
-    # Register child with tracker if it has deferred nodes.
+    # Register child with tracker if it has deferred nodes OR if it has
+    # registered compensators (so the saga orchestrator can propagate into
+    # it on parent failure).
+    child_compensation_map = getattr(child_wf, "_compiled_compensation_map", {}) or {}
     needs_child_tracker = (
         bool(deferred)
         or bool(callables)
         or bool(gates)
         or bool(sub_refs)
         or on_failure != "fail_fast"
+        or bool(child_compensation_map)
     )
     if needs_child_tracker:
         child_payloads = {n: payloads[n] for n in deferred if n in payloads}
@@ -99,6 +103,8 @@ def submit_sub_workflow(
             callable_conditions=callables,
             gate_configs=gates,
             sub_workflow_refs=sub_refs,
+            compensation_map=child_compensation_map,
+            steps=getattr(child_wf, "_steps", None),
         )
 
     config.deferred_nodes.discard(node_name)

--- a/py_src/taskito/workflows/tracker/tracker.py
+++ b/py_src/taskito/workflows/tracker/tracker.py
@@ -231,14 +231,15 @@ class WorkflowTracker:
         run_id, node_name, terminal_state = result
 
         if terminal_state is not None:
-            # If the run ended in failure AND the workflow has a saga
-            # (non-empty compensation_map), hand off to the orchestrator
-            # before emitting the terminal event — the saga will emit its
-            # own terminal event when compensation finishes.
+            # If the run ended in failure AND the workflow has a saga in any
+            # form — an explicit ``compensation_map`` OR a sub-workflow node
+            # whose child has its own compensators (propagation) — hand off
+            # to the saga orchestrator before emitting the terminal event.
+            # The orchestrator emits its own terminal event when compensation
+            # finishes; ``start_compensation`` decides eligibility internally.
             if (
                 terminal_state == "failed"
                 and config is not None
-                and config.compensation_map
                 and config.on_failure == "fail_fast"
             ):
                 steps = self._run_steps.get(run_id, {})
@@ -324,8 +325,36 @@ class WorkflowTracker:
         self._release_waiters(run_id)
 
     def _cleanup_run(self, run_id: str) -> None:
-        """Drop all tracker state tied to ``run_id`` and cancel any live timers."""
+        """Drop all tracker state tied to ``run_id`` and cancel any live timers.
+
+        When the run is a sub-workflow child whose parent is still being
+        tracked, ``_run_configs`` and ``_run_steps`` are *retained* so the
+        parent's saga orchestrator can propagate compensation into the
+        child later. The parent's own cleanup sweeps these entries when it
+        finalises (see ``stale_child_ids`` below).
+        """
         with self._state_lock:
+            parent_still_alive = False
+            parent_link = self._child_to_parent.get(run_id)
+            if parent_link is not None:
+                parent_run_id = parent_link[0]
+                parent_still_alive = parent_run_id in self._run_configs
+
+            if parent_still_alive:
+                # Keep config + steps so the parent can propagate compensation.
+                # Drop transient state (job→run map entries, gate timers) so
+                # the worker doesn't keep routing fan-out / gate events to a
+                # finished child.
+                self._job_to_run = {
+                    jid: rid for jid, rid in self._job_to_run.items() if rid != run_id
+                }
+                stale_timer_keys = [k for k in self._gate_timers if k[0] == run_id]
+                for key in stale_timer_keys:
+                    timer = self._gate_timers.pop(key, None)
+                    if timer is not None:
+                        timer.cancel()
+                return
+
             self._run_configs.pop(run_id, None)
             self._run_steps.pop(run_id, None)
             self._job_to_run = {jid: rid for jid, rid in self._job_to_run.items() if rid != run_id}
@@ -339,6 +368,10 @@ class WorkflowTracker:
             ]
             for cid in stale_child_ids:
                 self._child_to_parent.pop(cid, None)
+                # Children whose cleanup we deferred (because the parent was
+                # still alive) get swept here on parent finalization.
+                self._run_configs.pop(cid, None)
+                self._run_steps.pop(cid, None)
 
     def _try_finalize(self, run_id: str) -> None:
         """If all nodes are terminal, finalize the run and emit the event."""
@@ -381,12 +414,18 @@ class WorkflowTracker:
     # ── Sub-workflow listener ──────────────────────────────────────
 
     def _on_child_workflow_terminal(self, _event_type: EventType, payload: dict[str, Any]) -> None:
-        """Handle child workflow completion → update parent node."""
+        """Handle child workflow completion → update parent node.
+
+        The ``_child_to_parent`` link is *not* popped here — it stays in
+        place until the parent run finalises (or until the parent's saga
+        orchestrator has had a chance to propagate compensation into the
+        child). The parent's ``_cleanup_run`` sweeps stale links.
+        """
         child_run_id = payload.get("run_id")
         if not child_run_id:
             return
         with self._state_lock:
-            parent_info = self._child_to_parent.pop(child_run_id, None)
+            parent_info = self._child_to_parent.get(child_run_id)
         if parent_info is None:
             return  # Not a sub-workflow child.
 

--- a/tests/workflows/test_workflows_saga_subworkflow.py
+++ b/tests/workflows/test_workflows_saga_subworkflow.py
@@ -1,0 +1,184 @@
+"""Sub-workflow saga propagation.
+
+When a parent workflow's compensation reaches a node that *was* a
+sub-workflow, and the sub-workflow has its own registered compensators,
+the parent's saga propagates compensation into the child run. The child
+saga runs its compensators in reverse topological order; the parent node
+is marked compensated/failed based on the child's terminal outcome; the
+parent's wave advances.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+from taskito import Queue
+from taskito.workflows import Workflow, WorkflowState
+
+WorkflowWorkerFactory = Any
+
+
+def _wait_for_state(run: Any, states: set[WorkflowState], timeout: float = 30) -> WorkflowState:
+    final = run.wait(timeout=timeout)
+    state: WorkflowState = final.state
+    assert state in states, f"expected one of {states}, got {state}"
+    return state
+
+
+def test_child_saga_propagates_when_parent_node_is_sub_workflow(
+    queue: Queue, workflow_worker: WorkflowWorkerFactory
+) -> None:
+    """Parent workflow has a sub-workflow node with no explicit
+    ``compensates=``. The sub-workflow itself has a saga (its steps
+    register compensators). When a later parent step fails, the
+    sub-workflow's compensators must run in reverse order."""
+    order_lock = threading.Lock()
+    call_order: list[str] = []
+
+    # Sub-workflow with its own saga ----------------------------------------
+    @queue.task(max_retries=0)
+    def comp_pack(forward_args: tuple, forward_kwargs: dict, forward_result: Any) -> None:
+        with order_lock:
+            call_order.append("comp_pack")
+
+    @queue.task(max_retries=0)
+    def comp_label(forward_args: tuple, forward_kwargs: dict, forward_result: Any) -> None:
+        with order_lock:
+            call_order.append("comp_label")
+
+    @queue.task(max_retries=0, compensates=comp_pack)
+    def pack() -> str:
+        with order_lock:
+            call_order.append("pack")
+        return "packed"
+
+    @queue.task(max_retries=0, compensates=comp_label)
+    def label() -> str:
+        with order_lock:
+            call_order.append("label")
+        return "labeled"
+
+    @queue.workflow("ship_subwf")
+    def ship_subwf() -> Workflow:
+        wf = Workflow()
+        wf.step("pack", pack)
+        wf.step("label", label, after="pack")
+        return wf
+
+    # Parent workflow -------------------------------------------------------
+    @queue.task(max_retries=0)
+    def fail_later() -> None:
+        with order_lock:
+            call_order.append("fail")
+        raise RuntimeError("kaboom in parent")
+
+    parent_wf = Workflow(name="parent_with_subwf_saga")
+    parent_wf.step("ship", ship_subwf.as_step())
+    parent_wf.step("notify", fail_later, after="ship")
+
+    with workflow_worker():
+        run = queue.submit_workflow(parent_wf)
+        _wait_for_state(
+            run,
+            {WorkflowState.COMPENSATED, WorkflowState.COMPENSATION_FAILED},
+            timeout=30,
+        )
+
+    fwd = [e for e in call_order if e in {"pack", "label", "fail"}]
+    comp = [e for e in call_order if e.startswith("comp_")]
+    assert fwd == ["pack", "label", "fail"], call_order
+    # Compensation order inside the child sub-workflow is reverse-topological:
+    # label compensates before pack.
+    assert comp == ["comp_label", "comp_pack"], call_order
+
+
+def test_explicit_compensator_on_subworkflow_node_overrides_propagation(
+    queue: Queue, workflow_worker: WorkflowWorkerFactory
+) -> None:
+    """If the parent step has its own ``compensates=``, propagation does
+    not happen — the parent's explicit compensator runs instead."""
+    order_lock = threading.Lock()
+    call_order: list[str] = []
+
+    @queue.task(max_retries=0)
+    def comp_inner(forward_args: tuple, forward_kwargs: dict, forward_result: Any) -> None:
+        with order_lock:
+            call_order.append("comp_inner")
+
+    @queue.task(max_retries=0)
+    def comp_ship_explicit(forward_args: tuple, forward_kwargs: dict, forward_result: Any) -> None:
+        with order_lock:
+            call_order.append("comp_ship_explicit")
+
+    @queue.task(max_retries=0, compensates=comp_inner)
+    def inner_step() -> None:
+        with order_lock:
+            call_order.append("inner")
+
+    @queue.workflow("ship_inner")
+    def ship_inner() -> Workflow:
+        wf = Workflow()
+        wf.step("inner", inner_step)
+        return wf
+
+    @queue.task(max_retries=0)
+    def boom() -> None:
+        raise RuntimeError("parent boom")
+
+    parent_wf = Workflow(name="parent_explicit_comp")
+    parent_wf.step("ship", ship_inner.as_step(), compensates=comp_ship_explicit)
+    parent_wf.step("notify", boom, after="ship")
+
+    with workflow_worker():
+        run = queue.submit_workflow(parent_wf)
+        _wait_for_state(
+            run,
+            {WorkflowState.COMPENSATED, WorkflowState.COMPENSATION_FAILED},
+            timeout=30,
+        )
+
+    # Explicit parent-step compensator wins: ``comp_ship_explicit`` runs,
+    # the child's ``comp_inner`` does NOT (would only run via propagation).
+    assert "comp_ship_explicit" in call_order
+    assert "comp_inner" not in call_order
+
+
+def test_subworkflow_compensation_failure_marks_parent_failed(
+    queue: Queue, workflow_worker: WorkflowWorkerFactory
+) -> None:
+    """When the propagated child saga itself fails (one of its
+    compensators errors), the parent node ends compensation_failed and so
+    does the parent run."""
+
+    @queue.task(max_retries=0)
+    def comp_inner_failing(forward_args: tuple, forward_kwargs: dict, forward_result: Any) -> None:
+        raise RuntimeError("inner comp failed")
+
+    @queue.task(max_retries=0, compensates=comp_inner_failing)
+    def inner_step() -> None:
+        pass
+
+    @queue.workflow("ship_failing_inner")
+    def ship_failing_inner() -> Workflow:
+        wf = Workflow()
+        wf.step("inner", inner_step)
+        return wf
+
+    @queue.task(max_retries=0)
+    def boom() -> None:
+        raise RuntimeError("parent boom")
+
+    parent_wf = Workflow(name="parent_propagated_failure")
+    parent_wf.step("ship", ship_failing_inner.as_step())
+    parent_wf.step("notify", boom, after="ship")
+
+    with workflow_worker():
+        run = queue.submit_workflow(parent_wf)
+        final = _wait_for_state(
+            run,
+            {WorkflowState.COMPENSATED, WorkflowState.COMPENSATION_FAILED},
+            timeout=30,
+        )
+
+    assert final == WorkflowState.COMPENSATION_FAILED


### PR DESCRIPTION
## Summary

When a parent workflow's saga reaches a sub-workflow node whose child run has its own registered compensators, the parent now propagates compensation into the child run. The child's compensators run in reverse topological order; once the child terminates, the parent's node is marked compensated (or failed) and the parent's wave advances.

**Stacks on #186** (PR A — compensator contract fully wired).

### Behaviour

\`\`\`
parent_wf:
    ship (sub-workflow with pack → label, both registering compensators)
    notify (fails)

⇒ saga starts on parent
⇒ parent compensable set = {ship}     # sub-workflow node, child has compensators
⇒ wave 1 = [ship] (parent has no own compensator; propagates)
⇒ child saga runs: comp_label, comp_pack
⇒ child finalises COMPENSATED
⇒ parent's ship node marked Compensated
⇒ parent finalises COMPENSATED
\`\`\`

If the parent step has an explicit ``compensates=`` of its own, the explicit compensator wins (no propagation). If the propagated child saga itself fails, the parent ends ``COMPENSATION_FAILED``.

### Files

- \`py_src/taskito/workflows/saga/orchestrator.py\`
  - \`start_compensation\` takes a ``depth`` parameter; raises \`SagaDepthExceededError\` past \`MAX_SAGA_DEPTH=10\`.
  - New \`_propagate_to_child_saga\`, \`_on_child_saga_terminal\`, \`_has_propagatable_subworkflows\`, \`_child_has_saga\` helpers.
  - \`_fetch_compensable_nodes\` now considers sub-workflow nodes (with child sagas) as implicitly compensable.
  - \`_advance_or_finalize\` calls the parent-waiting callback once the child saga finishes.
- \`py_src/taskito/workflows/tracker/tracker.py\`
  - \`_cleanup_run\` preserves child \`_run_configs\` + \`_run_steps\` while the parent is still alive; parent finalisation sweeps them.
  - \`_on_child_workflow_terminal\` no longer pops \`_child_to_parent\` immediately (parent cleanup handles it).
  - Saga-trigger condition no longer requires \`config.compensation_map\` — \`start_compensation\` decides internally now that propagation can fire saga without an explicit map.
- \`py_src/taskito/workflows/tracker/sub_workflows.py\`
  - Sub-workflow \`register_run\` propagates the child workflow's \`_compiled_compensation_map\` and \`_steps\` so the orchestrator can read them at propagation time.
  - Registration triggers if the child has compensators (previously only registered for deferred / gate / condition / sub-workflow cases).

### Test plan

- [x] 3 new tests in \`tests/workflows/test_workflows_saga_subworkflow.py\`:
  - child saga propagates when parent node is a sub-workflow
  - explicit parent ``compensates=`` overrides propagation
  - failing child compensator marks the parent run \`COMPENSATION_FAILED\`
- [x] All existing saga + workflow tests pass (244 + 2 skipped)
- [x] \`uv run ruff check\` / \`mypy\` clean