### PR TITLE
chore(release): 0.13.0

### DIFF
--- a/crates/taskito-async/Cargo.toml
+++ b/crates/taskito-async/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-async"
-version = "0.12.3"
+version = "0.13.0"
 edition = "2021"
 
 [dependencies]

--- a/crates/taskito-core/Cargo.toml
+++ b/crates/taskito-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-core"
-version = "0.12.3"
+version = "0.13.0"
 edition = "2021"
 
 [features]

--- a/crates/taskito-python/Cargo.toml
+++ b/crates/taskito-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-python"
-version = "0.12.3"
+version = "0.13.0"
 edition = "2021"
 
 [features]

--- a/crates/taskito-workflows/Cargo.toml
+++ b/crates/taskito-workflows/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-workflows"
-version = "0.12.3"
+version = "0.13.0"
 edition = "2021"
 
 [features]

--- a/docs/content/docs/more/changelog.mdx
+++ b/docs/content/docs/more/changelog.mdx
@@ -5,7 +5,7 @@ description: "Release history for taskito — every notable change, fix, and fea
 
 All notable changes to taskito are documented here.
 
-## Unreleased
+## 0.13.0
 
 ### Added
 

--- a/py_src/taskito/__init__.py
+++ b/py_src/taskito/__init__.py
@@ -108,4 +108,4 @@ try:
 
     __version__ = _get_version("taskito")
 except PackageNotFoundError:
-    __version__ = "0.12.3"
+    __version__ = "0.13.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "taskito"
-version = "0.12.3"
+version = "0.13.0"
 description = "Rust-powered task queue for Python. No broker required."
 requires-python = ">=3.10"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary

Cut 0.13.0. Bumps versions across the workspace (\`pyproject.toml\`, all four crate \`Cargo.toml\`s, \`py_src/taskito/__init__.py\` fallback) and finalises the changelog by renaming the \`## Unreleased\` section to \`## 0.13.0\`. No code changes — exact same shape as the 0.12.3 release commit (#177).

## Why a minor (not patch)

Three new public APIs and meaningful new capability ship in this release. Calling it a patch would mislead users into thinking there's no new surface to learn:

### Added
- Workflow PostgreSQL backend (audit P1 closed)
- Workflow Redis backend
- Multi-backend workflow contract suite + CI parity
- \`@queue.task(batch=…)\` — producer-side task batching
- Saga compensation: \`@queue.task(compensates=…)\`, \`Workflow.step(compensates=…)\`, \`current_compensation_context()\`, 3 new \`WorkflowState\` + 3 new \`WorkflowNodeStatus\` + 6 new event types, schema additions for compensation tracking
- Compensator contract fully wired for static nodes (forward args / kwargs / result)
- Sub-workflow saga propagation with \`MAX_SAGA_DEPTH=10\` guard
- \`PyJob.payload_bytes\` getter
- Saga + batching guides, API reference, runnable examples

### Fixed
- \`expand_fan_out\` atomicity (transactional batch insert)
- Diesel \`?\` → \`\$N\` placeholder rewrite for Postgres workflow queries

## Test plan

- [x] \`cargo test --workspace --features workflows\` — all suites green
- [x] \`pnpm --dir docs build\` — docs build clean (changelog 0.13.0 renders)
- [x] Pre-commit gates green (ruff + mypy + clippy + fmt)

## Tagging

Per the workflow, the tag will be created from the GitHub web UI after merge — this PR does **not** push a tag locally.