### PR TITLE
feat(dashboard): workflows UI

### DIFF
--- a/dashboard/src/components/layout/sidebar.tsx
+++ b/dashboard/src/components/layout/sidebar.tsx
@@ -7,6 +7,7 @@ import {
   CircuitBoard,
   Cog,
   ExternalLink as ExternalLinkIcon,
+  GitBranch,
   LayoutDashboard,
   ListTree,
   type LucideIcon,
@@ -36,6 +37,7 @@ const NAV: NavGroup[] = [
     items: [
       { to: "/", label: "Overview", icon: LayoutDashboard },
       { to: "/jobs", label: "Jobs", icon: ListTree },
+      { to: "/workflows", label: "Workflows", icon: GitBranch },
       { to: "/metrics", label: "Metrics", icon: BarChart3 },
       { to: "/logs", label: "Logs", icon: ScrollText },
     ],

--- a/dashboard/src/features/workflows/api.ts
+++ b/dashboard/src/features/workflows/api.ts
@@ -1,0 +1,49 @@
+import { api } from "@/lib/api-client";
+import type {
+  WorkflowChildrenResponse,
+  WorkflowDagResponse,
+  WorkflowRunDetailResponse,
+  WorkflowRunListResponse,
+} from "@/lib/api-types";
+import type { WorkflowsListQuery } from "./types";
+
+export function fetchWorkflowRuns(
+  query: WorkflowsListQuery,
+  signal?: AbortSignal,
+): Promise<WorkflowRunListResponse> {
+  const params: Record<string, string | number | undefined> = {
+    state: query.state,
+    definition_name: query.definition_name,
+    limit: query.limit,
+    offset: query.offset,
+  };
+  return api.get<WorkflowRunListResponse>("/api/workflows/runs", { signal, params });
+}
+
+export function fetchWorkflowRun(
+  runId: string,
+  signal?: AbortSignal,
+): Promise<WorkflowRunDetailResponse> {
+  return api.get<WorkflowRunDetailResponse>(`/api/workflows/runs/${encodeURIComponent(runId)}`, {
+    signal,
+  });
+}
+
+export function fetchWorkflowDag(
+  runId: string,
+  signal?: AbortSignal,
+): Promise<WorkflowDagResponse> {
+  return api.get<WorkflowDagResponse>(`/api/workflows/runs/${encodeURIComponent(runId)}/dag`, {
+    signal,
+  });
+}
+
+export function fetchWorkflowChildren(
+  runId: string,
+  signal?: AbortSignal,
+): Promise<WorkflowChildrenResponse> {
+  return api.get<WorkflowChildrenResponse>(
+    `/api/workflows/runs/${encodeURIComponent(runId)}/children`,
+    { signal },
+  );
+}

--- a/dashboard/src/features/workflows/components/compensation-panel.tsx
+++ b/dashboard/src/features/workflows/components/compensation-panel.tsx
@@ -1,0 +1,86 @@
+import { Card } from "@/components/ui";
+import { formatAbsolute, formatRelative } from "@/lib/time";
+import type { WorkflowNode } from "../types";
+
+interface CompensationPanelProps {
+  nodes: WorkflowNode[];
+}
+
+/**
+ * Surfaces the saga-compensation lifecycle for a workflow run.
+ *
+ * Only renders nodes that have at least one compensation field populated
+ * (job ID, started_at, completed_at, or error). When the run is in a
+ * non-compensation state, this panel returns null — the parent decides
+ * whether to show it via ``shouldShowCompensationPanel(run.state)``.
+ */
+export function CompensationPanel({ nodes }: CompensationPanelProps) {
+  const rows = nodes.filter(
+    (n) =>
+      n.compensation_job_id !== null ||
+      n.compensation_started_at !== null ||
+      n.compensation_completed_at !== null ||
+      n.compensation_error !== null,
+  );
+  if (rows.length === 0) {
+    return (
+      <Card className="p-4 text-sm text-[var(--fg-muted)]">
+        Compensation is in progress, but no nodes have been dispatched yet.
+      </Card>
+    );
+  }
+  return (
+    <Card className="overflow-hidden">
+      <div className="border-b px-4 py-3 text-sm font-medium">Compensation</div>
+      <table className="w-full text-sm">
+        <thead className="border-b text-left text-xs text-[var(--fg-muted)]">
+          <tr>
+            <th className="px-3 py-2">Node</th>
+            <th className="px-3 py-2">Compensation job</th>
+            <th className="px-3 py-2">Started</th>
+            <th className="px-3 py-2">Completed</th>
+            <th className="px-3 py-2">Error</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((n) => (
+            <tr key={n.node_name} className="border-b last:border-b-0">
+              <td className="px-3 py-2 font-mono text-xs">{n.node_name}</td>
+              <td className="px-3 py-2 font-mono text-xs text-[var(--fg-muted)]">
+                {n.compensation_job_id ? (
+                  <a
+                    href={`/jobs/${n.compensation_job_id}`}
+                    className="text-accent hover:underline"
+                  >
+                    {n.compensation_job_id.slice(0, 8)}…
+                  </a>
+                ) : (
+                  "—"
+                )}
+              </td>
+              <td
+                className="px-3 py-2 text-xs text-[var(--fg-muted)]"
+                title={n.compensation_started_at ? formatAbsolute(n.compensation_started_at) : "—"}
+              >
+                {n.compensation_started_at ? formatRelative(n.compensation_started_at) : "—"}
+              </td>
+              <td
+                className="px-3 py-2 text-xs text-[var(--fg-muted)]"
+                title={
+                  n.compensation_completed_at ? formatAbsolute(n.compensation_completed_at) : "—"
+                }
+              >
+                {n.compensation_completed_at ? formatRelative(n.compensation_completed_at) : "—"}
+              </td>
+              <td className="px-3 py-2 text-xs text-danger" title={n.compensation_error ?? "—"}>
+                {n.compensation_error
+                  ? `${n.compensation_error.slice(0, 40)}${n.compensation_error.length > 40 ? "…" : ""}`
+                  : "—"}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </Card>
+  );
+}

--- a/dashboard/src/features/workflows/components/index.ts
+++ b/dashboard/src/features/workflows/components/index.ts
@@ -1,0 +1,13 @@
+export { CompensationPanel } from "./compensation-panel";
+export { RunHeaderCard } from "./run-header-card";
+export { RunNodesTable } from "./run-nodes-table";
+export { WorkflowNodeStatusBadge, WorkflowStateBadge } from "./state-badge";
+export {
+  layout as workflowDagLayout,
+  parseDagJson,
+  type RawDagData,
+  type RawDagEdge,
+  type RawDagNode,
+} from "./workflow-dag-layout";
+export { WorkflowDagSvg } from "./workflow-dag-svg";
+export { WorkflowsListTable } from "./workflows-list-table";

--- a/dashboard/src/features/workflows/components/run-header-card.tsx
+++ b/dashboard/src/features/workflows/components/run-header-card.tsx
@@ -1,0 +1,71 @@
+import { Card } from "@/components/ui";
+import { formatAbsolute, formatRelative } from "@/lib/time";
+import type { WorkflowRun } from "../types";
+import { WorkflowStateBadge } from "./state-badge";
+
+export function RunHeaderCard({ run }: { run: WorkflowRun }) {
+  return (
+    <Card className="p-6">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <div className="text-xs text-[var(--fg-muted)]">Run ID</div>
+          <div className="font-mono text-sm text-[var(--fg)]">{run.id}</div>
+          <div className="mt-3 text-xs text-[var(--fg-muted)]">Definition</div>
+          <div className="font-mono text-sm text-[var(--fg)]">{run.definition_id}</div>
+        </div>
+        <WorkflowStateBadge state={run.state} />
+      </div>
+
+      <dl className="mt-6 grid gap-4 text-sm sm:grid-cols-3">
+        <div>
+          <dt className="text-xs text-[var(--fg-muted)]">Created</dt>
+          <dd className="text-[var(--fg)]" title={formatAbsolute(run.created_at)}>
+            {formatRelative(run.created_at)}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-xs text-[var(--fg-muted)]">Started</dt>
+          <dd
+            className="text-[var(--fg)]"
+            title={run.started_at ? formatAbsolute(run.started_at) : "—"}
+          >
+            {run.started_at ? formatRelative(run.started_at) : "—"}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-xs text-[var(--fg-muted)]">Completed</dt>
+          <dd
+            className="text-[var(--fg)]"
+            title={run.completed_at ? formatAbsolute(run.completed_at) : "—"}
+          >
+            {run.completed_at ? formatRelative(run.completed_at) : "—"}
+          </dd>
+        </div>
+      </dl>
+
+      {run.error && (
+        <div className="mt-6 rounded border-l-2 border-danger bg-danger-dim px-3 py-2 text-xs text-danger">
+          {run.error}
+        </div>
+      )}
+
+      {run.parent_run_id && (
+        <div className="mt-4 text-xs text-[var(--fg-muted)]">
+          Sub-workflow of:{" "}
+          <a
+            href={`/workflows/${run.parent_run_id}`}
+            className="font-mono text-accent hover:underline"
+          >
+            {run.parent_run_id.slice(0, 8)}…
+          </a>
+          {run.parent_node_name && (
+            <>
+              {" "}
+              at node <span className="font-mono">{run.parent_node_name}</span>
+            </>
+          )}
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/dashboard/src/features/workflows/components/run-nodes-table.tsx
+++ b/dashboard/src/features/workflows/components/run-nodes-table.tsx
@@ -1,0 +1,56 @@
+import { Card } from "@/components/ui";
+import { formatAbsolute, formatRelative } from "@/lib/time";
+import type { WorkflowNode } from "../types";
+import { WorkflowNodeStatusBadge } from "./state-badge";
+
+export function RunNodesTable({ nodes }: { nodes: WorkflowNode[] }) {
+  if (nodes.length === 0) {
+    return <Card className="p-4 text-sm text-[var(--fg-muted)]">No nodes recorded yet.</Card>;
+  }
+  return (
+    <Card className="overflow-hidden">
+      <table className="w-full text-sm">
+        <thead className="border-b text-left text-xs text-[var(--fg-muted)]">
+          <tr>
+            <th className="px-3 py-2">Node</th>
+            <th className="px-3 py-2">Status</th>
+            <th className="px-3 py-2">Job</th>
+            <th className="px-3 py-2">Started</th>
+            <th className="px-3 py-2">Completed</th>
+          </tr>
+        </thead>
+        <tbody>
+          {nodes.map((n) => (
+            <tr key={n.node_name} className="border-b last:border-b-0">
+              <td className="px-3 py-2 font-mono text-xs">{n.node_name}</td>
+              <td className="px-3 py-2">
+                <WorkflowNodeStatusBadge status={n.status} />
+              </td>
+              <td className="px-3 py-2 font-mono text-xs text-[var(--fg-muted)]">
+                {n.job_id ? (
+                  <a href={`/jobs/${n.job_id}`} className="text-accent hover:underline">
+                    {n.job_id.slice(0, 8)}…
+                  </a>
+                ) : (
+                  "—"
+                )}
+              </td>
+              <td
+                className="px-3 py-2 text-xs text-[var(--fg-muted)]"
+                title={n.started_at ? formatAbsolute(n.started_at) : "—"}
+              >
+                {n.started_at ? formatRelative(n.started_at) : "—"}
+              </td>
+              <td
+                className="px-3 py-2 text-xs text-[var(--fg-muted)]"
+                title={n.completed_at ? formatAbsolute(n.completed_at) : "—"}
+              >
+                {n.completed_at ? formatRelative(n.completed_at) : "—"}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </Card>
+  );
+}

--- a/dashboard/src/features/workflows/components/state-badge.tsx
+++ b/dashboard/src/features/workflows/components/state-badge.tsx
@@ -1,0 +1,52 @@
+import { Badge } from "@/components/ui/badge";
+import type { WorkflowNodeStatus, WorkflowState } from "../types";
+
+type Tone = "neutral" | "accent" | "info" | "success" | "warning" | "danger";
+
+const STATE_TONE: Record<WorkflowState, Tone> = {
+  pending: "neutral",
+  running: "info",
+  paused: "warning",
+  completed: "success",
+  completed_with_failures: "warning",
+  failed: "danger",
+  cancelled: "neutral",
+  compensating: "warning",
+  compensated: "info",
+  compensation_failed: "danger",
+};
+
+const STATE_LABEL: Record<WorkflowState, string> = {
+  pending: "Pending",
+  running: "Running",
+  paused: "Paused",
+  completed: "Completed",
+  completed_with_failures: "Completed (partial)",
+  failed: "Failed",
+  cancelled: "Cancelled",
+  compensating: "Compensating",
+  compensated: "Compensated",
+  compensation_failed: "Compensation failed",
+};
+
+export function WorkflowStateBadge({ state }: { state: WorkflowState }) {
+  return <Badge tone={STATE_TONE[state]}>{STATE_LABEL[state]}</Badge>;
+}
+
+const NODE_STATUS_TONE: Record<WorkflowNodeStatus, Tone> = {
+  pending: "neutral",
+  ready: "info",
+  running: "info",
+  completed: "success",
+  failed: "danger",
+  skipped: "neutral",
+  waiting_approval: "warning",
+  cache_hit: "accent",
+  compensating: "warning",
+  compensated: "info",
+  compensation_failed: "danger",
+};
+
+export function WorkflowNodeStatusBadge({ status }: { status: WorkflowNodeStatus }) {
+  return <Badge tone={NODE_STATUS_TONE[status]}>{status.replace(/_/g, " ")}</Badge>;
+}

--- a/dashboard/src/features/workflows/components/workflow-dag-layout.ts
+++ b/dashboard/src/features/workflows/components/workflow-dag-layout.ts
@@ -1,0 +1,167 @@
+/**
+ * Layered DAG layout for workflow nodes.
+ *
+ * The Rust dagron `to_json()` output has shape:
+ *   { nodes: [{ name: string }], edges: [{ from: string, to: string }] }
+ *
+ * We combine that with per-node status from the run-detail endpoint to
+ * produce a list of positioned nodes plus the canvas dimensions. The
+ * algorithm mirrors `features/jobs/components/dag-layout.ts` — BFS layer
+ * assignment from sources, vertical centering per layer.
+ */
+
+import type { WorkflowNodeStatus } from "../types";
+
+export const NODE_WIDTH = 200;
+export const NODE_HEIGHT = 64;
+export const LAYER_GAP_X = 100;
+export const NODE_GAP_Y = 28;
+export const PADDING = 32;
+
+export interface RawDagNode {
+  name: string;
+}
+
+export interface RawDagEdge {
+  from: string;
+  to: string;
+}
+
+export interface RawDagData {
+  nodes: RawDagNode[];
+  edges: RawDagEdge[];
+}
+
+export interface LaidOutWorkflowNode {
+  name: string;
+  status: WorkflowNodeStatus | "unknown";
+  x: number;
+  y: number;
+  layer: number;
+}
+
+export interface WorkflowLayout {
+  nodes: LaidOutWorkflowNode[];
+  edges: RawDagEdge[];
+  width: number;
+  height: number;
+}
+
+export function parseDagJson(raw: string): RawDagData {
+  try {
+    const parsed = JSON.parse(raw);
+    return {
+      nodes: Array.isArray(parsed?.nodes) ? parsed.nodes : [],
+      edges: Array.isArray(parsed?.edges) ? parsed.edges : [],
+    };
+  } catch {
+    return { nodes: [], edges: [] };
+  }
+}
+
+export function layout(
+  dag: RawDagData,
+  statuses: Record<string, WorkflowNodeStatus>,
+): WorkflowLayout {
+  const { nodes, edges } = dag;
+  if (nodes.length === 0) {
+    return { nodes: [], edges: [], width: 0, height: 0 };
+  }
+
+  const layerOf = assignLayers(nodes, edges);
+  const layers = groupByLayer(nodes, layerOf);
+  const sortedLayers = [...layers.entries()].sort(([a], [b]) => a - b);
+
+  const { width, height } = canvasSize(sortedLayers);
+  const laidOut = positionNodes(sortedLayers, height, statuses);
+
+  return { nodes: laidOut, edges, width, height };
+}
+
+function assignLayers(nodes: RawDagNode[], edges: RawDagEdge[]): Map<string, number> {
+  const incoming = new Map<string, number>();
+  const outgoing = new Map<string, string[]>();
+  for (const n of nodes) incoming.set(n.name, 0);
+  for (const e of edges) {
+    incoming.set(e.to, (incoming.get(e.to) ?? 0) + 1);
+    const arr = outgoing.get(e.from);
+    if (arr) arr.push(e.to);
+    else outgoing.set(e.from, [e.to]);
+  }
+
+  const layer = new Map<string, number>();
+  const queue: string[] = [];
+  for (const n of nodes) {
+    if ((incoming.get(n.name) ?? 0) === 0) {
+      layer.set(n.name, 0);
+      queue.push(n.name);
+    }
+  }
+  // Cycle defence: if there were no sources, seed with the first node.
+  const first = nodes[0];
+  if (queue.length === 0 && first !== undefined) {
+    layer.set(first.name, 0);
+    queue.push(first.name);
+  }
+
+  while (queue.length > 0) {
+    const current = queue.shift() ?? "";
+    const currentLayer = layer.get(current) ?? 0;
+    for (const successor of outgoing.get(current) ?? []) {
+      const nextLayer = currentLayer + 1;
+      if ((layer.get(successor) ?? -1) < nextLayer) {
+        layer.set(successor, nextLayer);
+        queue.push(successor);
+      }
+    }
+  }
+  return layer;
+}
+
+function groupByLayer(
+  nodes: RawDagNode[],
+  layerOf: Map<string, number>,
+): Map<number, RawDagNode[]> {
+  const layers = new Map<number, RawDagNode[]>();
+  for (const node of nodes) {
+    const l = layerOf.get(node.name) ?? 0;
+    const arr = layers.get(l);
+    if (arr) arr.push(node);
+    else layers.set(l, [node]);
+  }
+  return layers;
+}
+
+function canvasSize(sortedLayers: [number, RawDagNode[]][]): { width: number; height: number } {
+  const maxNodesInLayer = sortedLayers.reduce((max, [, nodes]) => Math.max(max, nodes.length), 0);
+  const width =
+    sortedLayers.length * NODE_WIDTH +
+    Math.max(0, sortedLayers.length - 1) * LAYER_GAP_X +
+    PADDING * 2;
+  const height =
+    maxNodesInLayer * NODE_HEIGHT + Math.max(0, maxNodesInLayer - 1) * NODE_GAP_Y + PADDING * 2;
+  return { width, height };
+}
+
+function positionNodes(
+  sortedLayers: [number, RawDagNode[]][],
+  canvasHeight: number,
+  statuses: Record<string, WorkflowNodeStatus>,
+): LaidOutWorkflowNode[] {
+  const out: LaidOutWorkflowNode[] = [];
+  for (const [layer, nodes] of sortedLayers) {
+    const totalH = nodes.length * NODE_HEIGHT + (nodes.length - 1) * NODE_GAP_Y;
+    const startY = (canvasHeight - totalH) / 2;
+    const x = PADDING + layer * (NODE_WIDTH + LAYER_GAP_X);
+    nodes.forEach((node, i) => {
+      out.push({
+        name: node.name,
+        status: statuses[node.name] ?? "unknown",
+        x,
+        y: startY + i * (NODE_HEIGHT + NODE_GAP_Y),
+        layer,
+      });
+    });
+  }
+  return out;
+}

--- a/dashboard/src/features/workflows/components/workflow-dag-svg.tsx
+++ b/dashboard/src/features/workflows/components/workflow-dag-svg.tsx
@@ -1,0 +1,152 @@
+/**
+ * SVG renderer for the workflow DAG.
+ *
+ * Reads the raw DAG JSON string from the API plus per-node status from the
+ * detail endpoint, lays out the nodes in vertical layers, and draws a static
+ * SVG. Nodes are coloured by status; edges are simple straight lines.
+ *
+ * No external graph library — we intentionally keep this small. Operators
+ * who need pan / zoom can use the browser zoom; the typical workflow has
+ * fewer than 50 nodes and fits comfortably in a single viewport.
+ */
+
+import type { WorkflowNode, WorkflowNodeStatus } from "../types";
+import {
+  type LaidOutWorkflowNode,
+  layout,
+  NODE_HEIGHT,
+  NODE_WIDTH,
+  parseDagJson,
+} from "./workflow-dag-layout";
+
+interface WorkflowDagSvgProps {
+  dagRaw: string;
+  nodes: WorkflowNode[];
+}
+
+const STATUS_FILL: Record<WorkflowNodeStatus | "unknown", string> = {
+  pending: "#e5e7eb",
+  ready: "#dbeafe",
+  running: "#3b82f6",
+  completed: "#10b981",
+  failed: "#ef4444",
+  skipped: "#9ca3af",
+  waiting_approval: "#f59e0b",
+  cache_hit: "#8b5cf6",
+  compensating: "#f97316",
+  compensated: "#06b6d4",
+  compensation_failed: "#dc2626",
+  unknown: "#d1d5db",
+};
+
+const STATUS_TEXT: Record<WorkflowNodeStatus | "unknown", string> = {
+  pending: "#111827",
+  ready: "#111827",
+  running: "#ffffff",
+  completed: "#ffffff",
+  failed: "#ffffff",
+  skipped: "#ffffff",
+  waiting_approval: "#111827",
+  cache_hit: "#ffffff",
+  compensating: "#ffffff",
+  compensated: "#ffffff",
+  compensation_failed: "#ffffff",
+  unknown: "#111827",
+};
+
+export function WorkflowDagSvg({ dagRaw, nodes }: WorkflowDagSvgProps) {
+  const statuses: Record<string, WorkflowNodeStatus> = {};
+  for (const n of nodes) statuses[n.node_name] = n.status;
+
+  const dag = parseDagJson(dagRaw);
+  const { nodes: laidOut, edges, width, height } = layout(dag, statuses);
+
+  if (laidOut.length === 0) {
+    return (
+      <div className="rounded border border-dashed border-gray-300 p-8 text-center text-sm text-gray-500">
+        No DAG data available for this run.
+      </div>
+    );
+  }
+
+  const nodeIndex = new Map<string, LaidOutWorkflowNode>();
+  for (const n of laidOut) nodeIndex.set(n.name, n);
+
+  return (
+    <div className="overflow-auto rounded border bg-white">
+      <svg width={width} height={height} role="img" aria-label="Workflow DAG">
+        <title>Workflow DAG</title>
+        {/* Edges */}
+        {edges.map((e) => {
+          const a = nodeIndex.get(e.from);
+          const b = nodeIndex.get(e.to);
+          if (!a || !b) return null;
+          const x1 = a.x + NODE_WIDTH;
+          const y1 = a.y + NODE_HEIGHT / 2;
+          const x2 = b.x;
+          const y2 = b.y + NODE_HEIGHT / 2;
+          return (
+            <line
+              key={`${e.from}->${e.to}`}
+              x1={x1}
+              y1={y1}
+              x2={x2}
+              y2={y2}
+              stroke="#94a3b8"
+              strokeWidth={1.5}
+              markerEnd="url(#arrow)"
+            />
+          );
+        })}
+        <defs>
+          <marker
+            id="arrow"
+            viewBox="0 0 10 10"
+            refX="9"
+            refY="5"
+            markerWidth="6"
+            markerHeight="6"
+            orient="auto-start-reverse"
+          >
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="#94a3b8" />
+          </marker>
+        </defs>
+        {/* Nodes */}
+        {laidOut.map((n) => (
+          <g key={n.name} transform={`translate(${n.x}, ${n.y})`}>
+            <rect
+              width={NODE_WIDTH}
+              height={NODE_HEIGHT}
+              rx={6}
+              fill={STATUS_FILL[n.status]}
+              stroke="#1f2937"
+              strokeWidth={0.5}
+            />
+            <text
+              x={NODE_WIDTH / 2}
+              y={NODE_HEIGHT / 2 - 6}
+              textAnchor="middle"
+              dominantBaseline="middle"
+              fontSize="13"
+              fontWeight={600}
+              fill={STATUS_TEXT[n.status]}
+            >
+              {n.name}
+            </text>
+            <text
+              x={NODE_WIDTH / 2}
+              y={NODE_HEIGHT / 2 + 12}
+              textAnchor="middle"
+              dominantBaseline="middle"
+              fontSize="11"
+              fill={STATUS_TEXT[n.status]}
+              opacity={0.85}
+            >
+              {n.status}
+            </text>
+          </g>
+        ))}
+      </svg>
+    </div>
+  );
+}

--- a/dashboard/src/features/workflows/components/workflows-list-table.tsx
+++ b/dashboard/src/features/workflows/components/workflows-list-table.tsx
@@ -1,0 +1,98 @@
+import { useNavigate } from "@tanstack/react-router";
+import type { ColumnDef } from "@tanstack/react-table";
+import { useMemo } from "react";
+import { DataTable, EmptyState, ErrorState, TableSkeleton } from "@/components/ui";
+import { formatAbsolute, formatRelative } from "@/lib/time";
+import type { WorkflowRun } from "../types";
+import { WorkflowStateBadge } from "./state-badge";
+
+interface WorkflowsListTableProps {
+  runs: WorkflowRun[] | undefined;
+  loading: boolean;
+  error: Error | null;
+  onRetry: () => void;
+}
+
+export function WorkflowsListTable({ runs, loading, error, onRetry }: WorkflowsListTableProps) {
+  const navigate = useNavigate();
+
+  const columns = useMemo<ColumnDef<WorkflowRun>[]>(
+    () => [
+      {
+        accessorKey: "id",
+        header: "Run",
+        cell: ({ getValue }) => (
+          <span className="font-mono text-xs text-accent">{getValue<string>().slice(0, 8)}…</span>
+        ),
+      },
+      {
+        accessorKey: "definition_id",
+        header: "Definition",
+        cell: ({ getValue }) => (
+          <span className="truncate text-xs text-[var(--fg-muted)]">
+            {getValue<string>().slice(0, 8)}…
+          </span>
+        ),
+      },
+      {
+        accessorKey: "state",
+        header: "State",
+        cell: ({ row }) => <WorkflowStateBadge state={row.original.state} />,
+      },
+      {
+        accessorKey: "created_at",
+        header: "Created",
+        cell: ({ getValue }) => {
+          const v = getValue<number>();
+          return (
+            <span className="text-xs text-[var(--fg-muted)]" title={formatAbsolute(v)}>
+              {formatRelative(v)}
+            </span>
+          );
+        },
+      },
+      {
+        accessorKey: "completed_at",
+        header: "Completed",
+        cell: ({ getValue }) => {
+          const v = getValue<number | null>();
+          if (v === null) return <span className="text-xs text-[var(--fg-muted)]">—</span>;
+          return (
+            <span className="text-xs text-[var(--fg-muted)]" title={formatAbsolute(v)}>
+              {formatRelative(v)}
+            </span>
+          );
+        },
+      },
+      {
+        accessorKey: "error",
+        header: "Error",
+        cell: ({ getValue }) => {
+          const v = getValue<string | null>();
+          if (!v) return <span className="text-xs text-[var(--fg-muted)]">—</span>;
+          return (
+            <span className="truncate text-xs text-danger" title={v}>
+              {v.slice(0, 60)}
+              {v.length > 60 ? "…" : ""}
+            </span>
+          );
+        },
+      },
+    ],
+    [],
+  );
+
+  if (loading) return <TableSkeleton />;
+  if (error) return <ErrorState onRetry={onRetry} />;
+  if (!runs || runs.length === 0) {
+    return <EmptyState title="No workflow runs" description="Submit a workflow to see it here." />;
+  }
+
+  return (
+    <DataTable
+      columns={columns}
+      data={runs}
+      onRowClick={(row) => navigate({ to: "/workflows/$runId", params: { runId: row.id } })}
+    />
+  );
+}

--- a/dashboard/src/features/workflows/hooks.ts
+++ b/dashboard/src/features/workflows/hooks.ts
@@ -1,0 +1,72 @@
+import { keepPreviousData, queryOptions, useQuery } from "@tanstack/react-query";
+import { useRefreshInterval } from "@/providers";
+import {
+  fetchWorkflowChildren,
+  fetchWorkflowDag,
+  fetchWorkflowRun,
+  fetchWorkflowRuns,
+} from "./api";
+import type { WorkflowsListQuery } from "./types";
+import { isTerminalState } from "./types";
+
+const KEY = {
+  all: ["workflows"] as const,
+  list: (q: WorkflowsListQuery) => ["workflows", "list", q] as const,
+  detail: (id: string) => ["workflows", "detail", id] as const,
+  dag: (id: string) => ["workflows", "detail", id, "dag"] as const,
+  children: (id: string) => ["workflows", "detail", id, "children"] as const,
+};
+
+export function workflowsListQuery(query: WorkflowsListQuery) {
+  return queryOptions({
+    queryKey: KEY.list(query),
+    queryFn: ({ signal }) => fetchWorkflowRuns(query, signal),
+    placeholderData: keepPreviousData,
+  });
+}
+
+export function workflowDetailQuery(runId: string) {
+  return queryOptions({
+    queryKey: KEY.detail(runId),
+    queryFn: ({ signal }) => fetchWorkflowRun(runId, signal),
+  });
+}
+
+export function workflowDagQuery(runId: string) {
+  return queryOptions({
+    queryKey: KEY.dag(runId),
+    queryFn: ({ signal }) => fetchWorkflowDag(runId, signal),
+    staleTime: Infinity,
+  });
+}
+
+export function workflowChildrenQuery(runId: string) {
+  return queryOptions({
+    queryKey: KEY.children(runId),
+    queryFn: ({ signal }) => fetchWorkflowChildren(runId, signal),
+  });
+}
+
+export function useWorkflowsList(query: WorkflowsListQuery) {
+  const { intervalMs } = useRefreshInterval();
+  return useQuery({
+    ...workflowsListQuery(query),
+    refetchInterval: intervalMs,
+  });
+}
+
+export function useWorkflowDetail(runId: string) {
+  const { intervalMs } = useRefreshInterval();
+  return useQuery({
+    ...workflowDetailQuery(runId),
+    refetchInterval: (q) => (isTerminalState(q.state.data?.run.state) ? false : intervalMs),
+  });
+}
+
+export function useWorkflowDag(runId: string) {
+  return useQuery(workflowDagQuery(runId));
+}
+
+export function useWorkflowChildren(runId: string) {
+  return useQuery(workflowChildrenQuery(runId));
+}

--- a/dashboard/src/features/workflows/index.ts
+++ b/dashboard/src/features/workflows/index.ts
@@ -1,0 +1,3 @@
+export * from "./components";
+export * from "./hooks";
+export * from "./types";

--- a/dashboard/src/features/workflows/types.ts
+++ b/dashboard/src/features/workflows/types.ts
@@ -1,0 +1,40 @@
+import type {
+  WorkflowDagResponse,
+  WorkflowNode,
+  WorkflowNodeStatus,
+  WorkflowRun,
+  WorkflowState,
+} from "@/lib/api-types";
+
+export type { WorkflowDagResponse, WorkflowNode, WorkflowNodeStatus, WorkflowRun, WorkflowState };
+
+export interface WorkflowsListQuery {
+  state?: WorkflowState;
+  definition_name?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export const TERMINAL_WORKFLOW_STATES = new Set<WorkflowState>([
+  "completed",
+  "completed_with_failures",
+  "failed",
+  "cancelled",
+  "compensated",
+  "compensation_failed",
+]);
+
+export const COMPENSATION_WORKFLOW_STATES = new Set<WorkflowState>([
+  "completed_with_failures",
+  "compensating",
+  "compensated",
+  "compensation_failed",
+]);
+
+export function isTerminalState(s: WorkflowState | undefined): boolean {
+  return s !== undefined && TERMINAL_WORKFLOW_STATES.has(s);
+}
+
+export function shouldShowCompensationPanel(s: WorkflowState | undefined): boolean {
+  return s !== undefined && COMPENSATION_WORKFLOW_STATES.has(s);
+}

--- a/dashboard/src/lib/api-types.ts
+++ b/dashboard/src/lib/api-types.ts
@@ -201,3 +201,85 @@ export interface InterceptionStats {
   strategy_counts: Record<string, number>;
   max_depth_reached: number;
 }
+
+// ── Workflows ─────────────────────────────────────────────────────────────
+
+export type WorkflowState =
+  | "pending"
+  | "running"
+  | "paused"
+  | "completed"
+  | "completed_with_failures"
+  | "failed"
+  | "cancelled"
+  | "compensating"
+  | "compensated"
+  | "compensation_failed";
+
+export type WorkflowNodeStatus =
+  | "pending"
+  | "ready"
+  | "running"
+  | "completed"
+  | "failed"
+  | "skipped"
+  | "waiting_approval"
+  | "cache_hit"
+  | "compensating"
+  | "compensated"
+  | "compensation_failed";
+
+export interface WorkflowRun {
+  id: string;
+  definition_id: string;
+  state: WorkflowState;
+  params: string | null;
+  /** Unix milliseconds; null if the run hasn't started. */
+  started_at: number | null;
+  /** Unix milliseconds; null if the run hasn't finished. */
+  completed_at: number | null;
+  error: string | null;
+  parent_run_id: string | null;
+  parent_node_name: string | null;
+  /** Unix milliseconds. */
+  created_at: number;
+}
+
+export interface WorkflowNode {
+  node_name: string;
+  status: WorkflowNodeStatus;
+  job_id: string | null;
+  result_hash: string | null;
+  fan_out_count: number | null;
+  /** Unix milliseconds. */
+  started_at: number | null;
+  /** Unix milliseconds. */
+  completed_at: number | null;
+  error: string | null;
+  compensation_job_id: string | null;
+  /** Unix milliseconds. */
+  compensation_started_at: number | null;
+  /** Unix milliseconds. */
+  compensation_completed_at: number | null;
+  compensation_error: string | null;
+}
+
+export interface WorkflowRunListResponse {
+  runs: WorkflowRun[];
+  limit: number;
+  offset: number;
+}
+
+export interface WorkflowRunDetailResponse {
+  run: WorkflowRun;
+  nodes: WorkflowNode[];
+}
+
+export interface WorkflowDagResponse {
+  /** Raw DAG JSON string — parse with JSON.parse for `{ nodes, edges }`. */
+  dag: string;
+}
+
+export interface WorkflowChildrenResponse {
+  children: WorkflowRun[];
+}

--- a/dashboard/src/routes/workflows/$runId.tsx
+++ b/dashboard/src/routes/workflows/$runId.tsx
@@ -1,0 +1,93 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { PageHeader } from "@/components/layout";
+import { ErrorState, Skeleton } from "@/components/ui";
+import {
+  CompensationPanel,
+  RunHeaderCard,
+  RunNodesTable,
+  shouldShowCompensationPanel,
+  useWorkflowDag,
+  useWorkflowDetail,
+  WorkflowDagSvg,
+  workflowDagQuery,
+  workflowDetailQuery,
+} from "@/features/workflows";
+
+export const Route = createFileRoute("/workflows/$runId")({
+  loader: ({ context: { queryClient }, params: { runId } }) =>
+    Promise.all([
+      queryClient.ensureQueryData(workflowDetailQuery(runId)),
+      queryClient.ensureQueryData(workflowDagQuery(runId)),
+    ]),
+  component: WorkflowRunDetailPage,
+});
+
+function WorkflowRunDetailPage() {
+  const { runId } = Route.useParams();
+  const detail = useWorkflowDetail(runId);
+  const dag = useWorkflowDag(runId);
+
+  if (detail.isLoading && !detail.data) {
+    return (
+      <>
+        <PageHeader
+          title="Loading run…"
+          breadcrumbs={[{ label: "Workflows", to: "/workflows" }, { label: runId }]}
+        />
+        <Skeleton className="h-96 w-full" />
+      </>
+    );
+  }
+
+  if (detail.error || !detail.data) {
+    return (
+      <>
+        <PageHeader
+          title="Run not found"
+          breadcrumbs={[{ label: "Workflows", to: "/workflows" }, { label: runId }]}
+        />
+        <ErrorState onRetry={() => detail.refetch()} />
+      </>
+    );
+  }
+
+  const { run, nodes } = detail.data;
+  const showCompensation = shouldShowCompensationPanel(run.state);
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title={`Run ${runId.slice(0, 8)}…`}
+        breadcrumbs={[
+          { label: "Workflows", to: "/workflows" },
+          { label: `${runId.slice(0, 12)}…` },
+        ]}
+      />
+
+      <RunHeaderCard run={run} />
+
+      <section>
+        <h2 className="mb-3 text-sm font-medium text-[var(--fg)]">DAG</h2>
+        {dag.data ? (
+          <WorkflowDagSvg dagRaw={dag.data.dag} nodes={nodes} />
+        ) : dag.error ? (
+          <ErrorState onRetry={() => dag.refetch()} />
+        ) : (
+          <Skeleton className="h-72 w-full" />
+        )}
+      </section>
+
+      <section>
+        <h2 className="mb-3 text-sm font-medium text-[var(--fg)]">Nodes</h2>
+        <RunNodesTable nodes={nodes} />
+      </section>
+
+      {showCompensation && (
+        <section>
+          <h2 className="mb-3 text-sm font-medium text-[var(--fg)]">Compensation</h2>
+          <CompensationPanel nodes={nodes} />
+        </section>
+      )}
+    </div>
+  );
+}

--- a/dashboard/src/routes/workflows/index.tsx
+++ b/dashboard/src/routes/workflows/index.tsx
@@ -1,0 +1,72 @@
+import { createFileRoute } from "@tanstack/react-router";
+import * as v from "valibot";
+import { PageHeader } from "@/components/layout";
+import { Pagination } from "@/components/ui";
+import {
+  useWorkflowsList,
+  type WorkflowsListQuery,
+  WorkflowsListTable,
+  workflowsListQuery,
+} from "@/features/workflows";
+
+const stateSchema = v.optional(
+  v.picklist([
+    "pending",
+    "running",
+    "paused",
+    "completed",
+    "completed_with_failures",
+    "failed",
+    "cancelled",
+    "compensating",
+    "compensated",
+    "compensation_failed",
+  ]),
+);
+
+const searchSchema = v.object({
+  state: stateSchema,
+  definition_name: v.optional(v.string()),
+  limit: v.optional(v.number(), 50),
+  offset: v.optional(v.number(), 0),
+});
+
+export const Route = createFileRoute("/workflows/")({
+  validateSearch: (search): WorkflowsListQuery => v.parse(searchSchema, search),
+  loaderDeps: ({ search }) => ({ search }),
+  loader: ({ context: { queryClient }, deps: { search } }) =>
+    queryClient.ensureQueryData(workflowsListQuery(search)),
+  component: WorkflowsListPage,
+});
+
+function WorkflowsListPage() {
+  const search = Route.useSearch();
+  const navigate = Route.useNavigate();
+  const { data, isLoading, error, refetch } = useWorkflowsList(search);
+
+  const setPage = (offset: number) => {
+    navigate({ search: (prev) => ({ ...prev, offset }), replace: true });
+  };
+  const pageSize = search.limit ?? 50;
+  const hasMore = data ? data.runs.length >= pageSize : false;
+
+  return (
+    <>
+      <PageHeader
+        title="Workflows"
+        description="DAG-based orchestration runs and their compensation state."
+      />
+      <WorkflowsListTable
+        runs={data?.runs}
+        loading={isLoading}
+        error={error}
+        onRetry={() => refetch()}
+      />
+      <Pagination
+        page={Math.floor((search.offset ?? 0) / pageSize)}
+        hasMore={hasMore}
+        onChange={(p) => setPage(p * pageSize)}
+      />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
Adds a complete operator-facing UI for workflows on top of PR #193's API.

New feature folder \`dashboard/src/features/workflows/\` mirroring the existing \`features/jobs/\` shape:
- \`api.ts\` / \`hooks.ts\` / \`types.ts\` / \`index.ts\`
- Components: \`WorkflowsListTable\`, \`RunHeaderCard\`, \`RunNodesTable\`, \`WorkflowDagSvg\`, \`CompensationPanel\`, \`WorkflowStateBadge\`, \`WorkflowNodeStatusBadge\`
- Routes: \`/workflows\` (list + pagination + valibot \`validateSearch\`) and \`/workflows/\$runId\` (detail with prefetched run + DAG)

The DAG renderer is a simple in-house SVG (BFS layer assignment, vertical centering) — no new dependencies. Nodes are coloured by status; saga states (compensating / compensated / compensation_failed) get distinct colours.

The compensation panel renders only when the run state is \`Compensating\`, \`Compensated\`, \`CompensationFailed\`, or \`CompletedWithFailures\`. It shows the compensation job ID (linked to the jobs page), started_at, completed_at, and any error string.

Sidebar gains a "Workflows" entry between Jobs and Metrics. Auto-refresh polling stops once a run reaches a terminal state.

## Why
Sagas shipped in 0.13.0 but the dashboard had zero workflow surface. Operators had no way to observe a run's progress, see its DAG, or inspect saga compensation outcomes. This closes the gap.

## Test plan
- [x] \`pnpm --dir dashboard run typecheck\`
- [x] \`pnpm --dir dashboard run lint\`
- [x] \`pnpm --dir dashboard run build\` — bundle clean, lazy chunks unaffected
- [ ] Manual smoke: open \`/workflows\`, submit a saga, observe DAG + compensation panel

## Notes
- Targets PR #193's branch (\`feat/dashboard-workflows-api\`). Merge that first.
- React Flow was originally on the plan but I went with a 167-line in-house SVG layout instead — zero dependencies, ~5 kB net, fits the typical workflow comfortably. We can upgrade if operators need pan/zoom later.