### PR TITLE
docs: document 0.14.0 features and add changelog

### DIFF
--- a/docs/content/docs/guides/advanced-execution/batch-enqueue.mdx
+++ b/docs/content/docs/guides/advanced-execution/batch-enqueue.mdx
@@ -1,7 +1,9 @@
 ---
 title: Batch Enqueue
-description: "Insert many jobs in a single SQLite transaction with task.map() and enqueue_many()."
+description: "Insert many jobs in a single SQLite transaction with task.map() and enqueue_many(). Includes per-item result tracking for batched tasks."
 ---
+
+import { Callout } from "fumadocs-ui/components/callout";
 
 Insert many jobs in a single SQLite transaction for high throughput.
 
@@ -42,3 +44,94 @@ jobs = queue.enqueue_many(
 Per-job lists (`delay_list`, `metadata_list`, `expires_list`,
 `result_ttl_list`) override uniform values when both are provided. See the
 [API reference](/api-reference/queue) for the full parameter list.
+
+## Per-item results for batched tasks
+
+When using task-level batching (`@queue.task(batch=...)`), you can get an
+individual result for each enqueued item rather than the whole batch list.
+Enable it with `per_item_results=True`:
+
+```python
+from taskito import BatchItemResult
+
+@queue.task(
+    batch={"max_size": 50, "max_wait_ms": 500, "per_item_results": True}
+)
+def process(items: list[int]) -> list[BatchItemResult]:
+    results = []
+    for i, item in enumerate(items):
+        try:
+            value = expensive_computation(item)
+            results.append(BatchItemResult.success(item_index=i, result=value))
+        except Exception as exc:
+            results.append(BatchItemResult.failure(item_index=i, error=str(exc)))
+    return results
+```
+
+Each caller gets back a `BatchedJobResult` handle. Calling `.result()` blocks
+until the batch flushes and returns **this caller's per-item value**:
+
+```python
+h0 = process.delay(10)
+h1 = process.delay(20)
+h2 = process.delay(30)
+
+# Each call returns its own value, not the whole list.
+assert h0.result(timeout=15) == 100
+assert h1.result(timeout=15) == 200
+assert h2.result(timeout=15) == 300
+```
+
+### `BatchItemResult`
+
+```python
+from taskito import BatchItemResult
+
+# Convenience constructors:
+item = BatchItemResult.success(item_index=2, result="done")
+item = BatchItemResult.failure(item_index=0, error="network timeout")
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `status` | `"success" \| "failure"` | Outcome for this item |
+| `result` | `Any` | Return value (success only; `None` otherwise) |
+| `error` | `str \| None` | Error message (failure only; `None` otherwise) |
+| `item_index` | `int` | Position in the original batch (≥ 0) |
+
+### Partial failures and retries
+
+When any item reports `status="failure"`, the worker raises
+`BatchPartialFailureError` and the whole batch retries (standard retry
+policy). On retry, the task receives the **same items** again — write
+the task function to be idempotent at the per-item level:
+
+```python
+@queue.task(batch={"max_size": 50, "max_wait_ms": 500, "per_item_results": True})
+def idempotent_process(items: list[int]) -> list[BatchItemResult]:
+    results = []
+    for i, item in enumerate(items):
+        # Check external state before acting — safe to replay.
+        if already_processed(item):
+            results.append(BatchItemResult.success(item_index=i, result=cached_result(item)))
+        else:
+            results.append(BatchItemResult.success(item_index=i, result=do_work(item)))
+    return results
+```
+
+### `partial_failures()`
+
+After a batch completes, call `.partial_failures()` to get the list of failed
+items (empty list on full success):
+
+```python
+handle = process.delay(42)
+failures = handle.partial_failures(timeout=15)
+# Returns [] on full success; list[BatchItemResult] otherwise.
+```
+
+<Callout type="warn" title="Incompatible with idempotent=True">
+  `per_item_results=True` and `idempotent=True` cannot be combined — the
+  decorator will raise `ValueError` at decoration time. Each item's identity
+  comes from `item_index`, not from a dedup key on the whole job.
+</Callout>

--- a/docs/content/docs/guides/dashboard/rest-api.mdx
+++ b/docs/content/docs/guides/dashboard/rest-api.mdx
@@ -448,6 +448,112 @@ Public readiness check with storage, worker, and resource health.
 
 Public Prometheus metrics endpoint (requires `prometheus-client` package).
 
+## Workflows
+
+These endpoints expose workflow run data for dashboards and external tooling.
+All timestamps are Unix milliseconds.
+
+### `GET /api/workflows/runs`
+
+Paginated list of workflow runs.
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `definition_name` | `string` | all | Filter by workflow name |
+| `state` | `string` | all | Filter by run state (e.g. `running`, `completed`, `failed`) |
+| `limit` | `int` | `50` | Page size |
+| `offset` | `int` | `0` | Pagination offset |
+
+```json
+{
+  "runs": [
+    {
+      "id": "01H...",
+      "definition_id": "checkout-v1",
+      "state": "completed",
+      "params": null,
+      "started_at": 1716000000000,
+      "completed_at": 1716000030000,
+      "error": null,
+      "parent_run_id": null,
+      "parent_node_name": null,
+      "created_at": 1716000000000
+    }
+  ],
+  "limit": 50,
+  "offset": 0
+}
+```
+
+### `GET /api/workflows/runs/{run_id}`
+
+Full detail for a single run: the run header plus per-node status.
+
+```json
+{
+  "run": {
+    "id": "01H...",
+    "definition_id": "checkout-v1",
+    "state": "compensated",
+    "params": null,
+    "started_at": 1716000000000,
+    "completed_at": 1716000060000,
+    "error": null,
+    "parent_run_id": null,
+    "parent_node_name": null,
+    "created_at": 1716000000000
+  },
+  "nodes": [
+    {
+      "node_name": "charge",
+      "status": "completed",
+      "job_id": "01H...",
+      "result_hash": "abc123",
+      "fan_out_count": null,
+      "started_at": 1716000001000,
+      "completed_at": 1716000005000,
+      "error": null,
+      "compensation_job_id": "01H...",
+      "compensation_started_at": 1716000050000,
+      "compensation_completed_at": 1716000055000,
+      "compensation_error": null
+    }
+  ]
+}
+```
+
+Returns `404` when the run ID doesn't exist.
+
+### `GET /api/workflows/runs/{run_id}/dag`
+
+DAG definition for the workflow that produced this run, as a JSON string.
+
+```json
+{
+  "dag": "{\"nodes\": [{\"name\": \"charge\", ...}], \"edges\": [...]}"
+}
+```
+
+Returns `404` when the run ID doesn't exist.
+
+### `GET /api/workflows/runs/{run_id}/children`
+
+Child sub-workflow runs spawned by this run. Returns an empty list for
+top-level runs.
+
+```json
+{
+  "children": [
+    {
+      "id": "01H...",
+      "definition_id": "notify-v1",
+      "state": "completed",
+      ...
+    }
+  ]
+}
+```
+
 ## Settings
 
 ### `GET /api/settings`

--- a/docs/content/docs/guides/operations/autoscaler.mdx
+++ b/docs/content/docs/guides/operations/autoscaler.mdx
@@ -1,0 +1,258 @@
+---
+title: Bare-Metal Autoscaler
+description: "Automatically scale taskito worker processes on bare metal, Docker, or systemd — no Kubernetes required."
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+The bare-metal autoscaler spawns and drains `taskito worker` subprocesses
+based on queue depth and worker utilisation. It mirrors the Kubernetes HPA
+formula so the scaling behaviour is predictable if you're already familiar
+with KEDA or the Horizontal Pod Autoscaler.
+
+Use this when you're running on bare metal, Docker, or systemd and can't
+use [KEDA + Kubernetes](/guides/operations/keda).
+
+## Quick start
+
+```python
+from taskito import Queue
+from taskito.autoscale import AutoscaleConfig, serve_autoscaler
+
+queue = Queue(db_path="taskito.db")
+
+serve_autoscaler(
+    queue,
+    AutoscaleConfig(
+        app_path="myapp:queue",
+        min_workers=1,
+        max_workers=10,
+    ),
+)
+```
+
+`serve_autoscaler` blocks until SIGTERM or SIGINT arrives, at which point it
+drains all worker processes gracefully before returning.
+
+## How it works
+
+Every `poll_interval_sec` seconds (default 5 s) the controller:
+
+1. Reads `pending` and `running` counts from the queue.
+2. Reaps any crashed workers and replaces them up to `min_workers`.
+3. Computes a desired worker count using two signals:
+
+```
+depth_desired = ceil(pending / target_queue_depth_per_worker)
+util_desired  = ceil(current_workers × (utilisation / target_utilisation))
+desired       = clamp(max(depth_desired, util_desired), min_workers, max_workers)
+```
+
+4. Applies stabilisation windows to smooth the decision.
+5. Spawns or terminates workers to reach the smoothed target.
+
+### Stabilisation windows
+
+Rapid oscillation ("flapping") is prevented by buffering recent
+recommendations:
+
+- **Scale-up window** — takes the *minimum* recent recommendation, so the
+  controller scales up as soon as any recent tick agreed to do so.
+  Default `scale_up_window_sec=0` means immediate scale-up to absorb bursts.
+- **Scale-down window** — takes the *maximum* recent recommendation, so a
+  brief lull doesn't immediately kill workers.
+  Default `scale_down_window_sec=300` (5 minutes) matches Kubernetes HPA.
+
+### Tolerance band
+
+If the desired count is within `tolerance` (default 10%) of the current
+count, the controller skips the scaling action. This suppresses single-tick
+noise from small queue depth fluctuations.
+
+### Overload override
+
+When `running > capacity` (where `capacity = current_workers × threads_per_worker`),
+the controller bypasses tolerance and bumps the count by +1. This handles
+the edge case where a worker has claimed jobs beyond its thread budget.
+
+## `AutoscaleConfig` reference
+
+```python
+from taskito.autoscale import AutoscaleConfig
+
+config = AutoscaleConfig(
+    app_path="myapp:queue",           # Required. Passed as --app to workers.
+    min_workers=1,                    # Never scale below this (≥ 0).
+    max_workers=10,                   # Never scale above this (≥ 1).
+    target_queue_depth_per_worker=15, # Pending jobs per worker (depth signal).
+    target_utilisation=0.75,          # Target running/capacity ratio.
+    scale_up_window_sec=0,            # Immediate scale-up.
+    scale_down_window_sec=300,        # 5-minute scale-down stabilisation.
+    tolerance=0.1,                    # 10% tolerance band.
+    poll_interval_sec=5,              # Seconds between decision ticks.
+    drain_timeout_sec=30,             # Per-worker SIGTERM grace period.
+    threads_per_worker=4,             # Must match the workers= on Queue().
+)
+```
+
+| Parameter | Default | Description |
+|---|---|---|
+| `app_path` | — | Python import path to the `Queue` instance |
+| `min_workers` | `1` | Minimum live workers. Set to `0` to allow idle scale-to-zero |
+| `max_workers` | `10` | Maximum live workers |
+| `target_queue_depth_per_worker` | `15` | Pending jobs target per worker (depth signal) |
+| `target_utilisation` | `0.75` | Target `running / capacity` ratio (HPA formula) |
+| `scale_up_window_sec` | `0` | Stabilisation window for scale-up decisions (seconds) |
+| `scale_down_window_sec` | `300` | Stabilisation window for scale-down decisions |
+| `tolerance` | `0.1` | Skip scaling when delta is within this fraction of current |
+| `poll_interval_sec` | `5` | Seconds between metric polls |
+| `drain_timeout_sec` | `30` | SIGTERM grace period before SIGKILL escalation |
+| `threads_per_worker` | `4` | Must match `workers=` on the target `Queue` |
+
+<Callout type="warn" title="threads_per_worker must match your worker config">
+  The controller can't introspect running workers — it uses `threads_per_worker`
+  to calculate capacity for the utilisation signal. Set it to the same value
+  as the `workers=` kwarg on your `Queue()` (or the equivalent CLI flag).
+</Callout>
+
+## Programmatic API
+
+### `serve_autoscaler(queue, config)`
+
+Convenience entry point. Equivalent to:
+
+```python
+AutoscaleController(queue, config).serve_forever()
+```
+
+Blocks until a signal arrives, then drains all workers in parallel.
+
+### `AutoscaleController`
+
+Lower-level class for embedding the control loop in a larger program:
+
+```python
+from taskito.autoscale import AutoscaleConfig, AutoscaleController
+
+controller = AutoscaleController(queue, config)
+
+# Run one decision tick manually (useful for tests or custom loops):
+decision = controller.tick()
+print(decision.rationale)
+
+# Access the process manager directly:
+pids = controller.process_manager.live_pids()
+```
+
+### `ScaleDecision`
+
+The return value of `controller.tick()` — useful for logging or integration
+with external monitoring:
+
+```python
+@dataclass(frozen=True)
+class ScaleDecision:
+    pending: int          # Pending job count at decision time
+    running: int          # Running job count at decision time
+    current_workers: int  # Worker count before this tick
+    desired_workers: int  # Worker count after this tick
+    rationale: str        # Human-readable explanation ("scale-up: ...", etc.)
+```
+
+### `ProcessManager`
+
+Manages the actual OS subprocesses. Available as `controller.process_manager`:
+
+| Method | Description |
+|---|---|
+| `spawn_worker() -> int` | Spawn a new worker; returns PID |
+| `terminate_worker(pid) -> bool` | SIGTERM → wait → SIGKILL. Returns `True` if clean |
+| `reap_dead() -> list[int]` | Non-blocking poll; returns PIDs of exited workers |
+| `count_live() -> int` | Number of tracked live workers |
+| `live_pids() -> list[int]` | PIDs of all tracked workers |
+| `shutdown()` | Parallel SIGTERM all workers |
+| `kill_all()` | Hard SIGKILL all workers (emergency) |
+
+Workers are started with `start_new_session=True` so the autoscaler's own
+SIGTERM/SIGINT doesn't cascade into the worker process group.
+
+## systemd deployment
+
+Write a thin Python entry point that calls `serve_autoscaler`:
+
+```python
+# autoscale_main.py
+from taskito import Queue
+from taskito.autoscale import AutoscaleConfig, serve_autoscaler
+
+queue = Queue(db_path="/var/lib/taskito/taskito.db")
+serve_autoscaler(
+    queue,
+    AutoscaleConfig(
+        app_path="myapp:queue",
+        min_workers=2,
+        max_workers=20,
+        target_queue_depth_per_worker=10,
+        drain_timeout_sec=60,
+    ),
+)
+```
+
+Then a systemd unit that manages the worker pool:
+
+```ini
+[Unit]
+Description=Taskito Autoscaler
+After=network.target
+
+[Service]
+User=appuser
+WorkingDirectory=/opt/myapp
+ExecStart=/opt/myapp/.venv/bin/python autoscale_main.py
+Restart=always
+RestartSec=5
+KillMode=process
+TimeoutStopSec=120
+
+[Install]
+WantedBy=multi-user.target
+```
+
+`KillMode=process` ensures systemd's SIGTERM reaches only the autoscaler
+process — the autoscaler then handles draining its own worker pool.
+
+## Docker Compose
+
+```yaml
+services:
+  autoscaler:
+    image: my-taskito-app:latest
+    command: python autoscale_main.py
+    volumes:
+      - taskito_data:/data
+    environment:
+      - TASKITO_DB_PATH=/data/taskito.db
+    stop_grace_period: 60s
+
+volumes:
+  taskito_data:
+```
+
+<Callout type="info">
+  The autoscaler logs to `taskito.autoscale` at INFO level. Each tick
+  produces one line: `pending=N running=M workers=X -> Y (rationale)`.
+  Wire it into your log aggregator to track scaling history.
+</Callout>
+
+## vs. KEDA autoscaling
+
+| | Bare-metal autoscaler | KEDA |
+|---|---|---|
+| Infrastructure | Bare metal, Docker, systemd | Kubernetes |
+| Worker type | OS processes | Kubernetes Pods |
+| Scaling signal | Queue depth + utilisation (dual HPA formula) | Queue depth (single metric) |
+| Stabilisation | Built-in, configurable | KEDA's `cooldownPeriod` |
+| Crash recovery | Auto-replaces crashed workers | Kubernetes restarts pods |
+| Setup | Zero — no external components | KEDA operator + ScaledObject |
+
+For Kubernetes deployments, use [KEDA](/guides/operations/keda).

--- a/docs/content/docs/guides/operations/index.mdx
+++ b/docs/content/docs/guides/operations/index.mdx
@@ -11,6 +11,7 @@ Run taskito reliably in production.
 | [Job Management](/guides/operations/job-management) | Cancel, pause, archive, revoke, replay, and clean up jobs |
 | [Troubleshooting](/guides/operations/troubleshooting) | Diagnose stuck jobs, lock contention, and worker issues |
 | [Deployment](/guides/operations/deployment) | systemd, Docker, WAL mode, Postgres, and production checklists |
+| [Bare-Metal Autoscaler](/guides/operations/autoscaler) | Automatically scale worker processes without Kubernetes |
 | [KEDA Autoscaling](/guides/operations/keda) | Kubernetes event-driven autoscaling for workers |
 | [Postgres Backend](/guides/operations/postgres) | Set up and run taskito with PostgreSQL |
 | [Migrating from Celery](/guides/operations/migration) | Side-by-side comparison and step-by-step migration guide |

--- a/docs/content/docs/guides/operations/meta.json
+++ b/docs/content/docs/guides/operations/meta.json
@@ -5,6 +5,7 @@
     "job-management",
     "troubleshooting",
     "deployment",
+    "autoscaler",
     "keda",
     "postgres",
     "migration"

--- a/docs/content/docs/guides/workflows/canvas.mdx
+++ b/docs/content/docs/guides/workflows/canvas.mdx
@@ -1,6 +1,6 @@
 ---
 title: Canvas Primitives
-description: "Lightweight chain / group / chord composition for simpler pipelines."
+description: "Lightweight chain / group / chord composition for simpler pipelines, with optional saga compensation."
 ---
 
 import { Callout } from "fumadocs-ui/components/callout";
@@ -91,6 +91,140 @@ result = chord(
 ).apply(queue)
 ```
 
+## Saga compensation
+
+Canvas primitives support in-thread saga compensation via `.with_compensation()`.
+When a step fails, taskito dispatches the compensators for the steps that already
+succeeded — no workflow engine required.
+
+<Callout type="info">
+  Canvas compensation is in-thread: compensators are enqueued synchronously
+  during the `apply()` call that raised. For DAG-level sagas with full
+  observability and sub-workflow propagation, see the
+  [Sagas guide](/guides/workflows/sagas).
+</Callout>
+
+### chain compensation
+
+Attach one compensator per chain step. `None` skips a slot. On failure,
+compensators for completed steps run in **reverse order**:
+
+```python
+from taskito import chain
+
+@queue.task()
+def step_a(x: int) -> int:
+    return charge_payment(x)
+
+@queue.task()
+def step_b(x: int) -> str:
+    return create_order(x)
+
+@queue.task()
+def refund(forward_args, forward_kwargs, forward_result):
+    payment_id = forward_result
+    payment_api.refund(payment_id)
+
+@queue.task()
+def cancel_order(forward_args, forward_kwargs, forward_result):
+    order_id = forward_result
+    order_api.cancel(order_id)
+
+result = chain(
+    step_a.s(100),
+    step_b.s(),
+).with_compensation([refund, cancel_order]).apply(queue)
+```
+
+`with_compensation` requires exactly one entry per chain step. If `step_b`
+fails after `step_a` succeeded, `cancel_order` then `refund` are enqueued —
+reverse order, one at a time.
+
+### group compensation
+
+One compensator per group member. On failure of any member, compensators for
+the **succeeded** members dispatch in parallel. The failed member is not
+compensated:
+
+```python
+from taskito import group
+
+g = group(
+    debit_account.s(100),
+    reserve_inventory.s("item-7"),
+    notify_warehouse.s(42),
+).with_compensation([
+    refund_account,
+    release_inventory,
+    cancel_notification,
+])
+
+g.apply(queue)
+```
+
+### chord compensation
+
+`chord.with_compensation` takes separate `group=` and `callback=` arguments:
+
+```python
+from taskito import chord, group
+
+ch = chord(
+    group(fetch.s("url1"), fetch.s("url2")),
+    merge.s(),
+).with_compensation(
+    group=[rollback_fetch1, rollback_fetch2],
+    callback=rollback_merge,
+)
+
+ch.apply(queue)
+```
+
+Compensation order:
+
+- Group member fails before callback runs → group compensators dispatch, callback compensator does **not** run.
+- Callback fails after group succeeded → callback compensator dispatches first, then group compensators in parallel.
+
+### Compensator contract
+
+Every compensator receives three positional args — the same contract as
+DAG-level saga compensators:
+
+```python
+@queue.task()
+def my_compensator(forward_args: tuple, forward_kwargs: dict, forward_result: object) -> None:
+    # forward_result is the return value of the step being compensated.
+    ...
+```
+
+### Idempotency
+
+Each compensator is enqueued with a deterministic unique key of the form
+`canvas_compensation:{run_id}:{slot}`. A second call to `apply()` on the
+same canvas object (e.g. inside a retry loop) never double-dispatches a
+compensator for the same `(run, slot)` pair.
+
+### Passing `None` to disable compensation
+
+```python
+# Disables all compensation (equivalent to not calling with_compensation).
+chain(a.si(), b.si()).with_compensation(None).apply(queue)
+
+# Disables compensation for one specific slot.
+chain(a.si(), b.si()).with_compensation([compensate_a, None]).apply(queue)
+```
+
+### Per-signature compensator
+
+A single `Signature` can also carry its own compensator:
+
+```python
+sig = step_a.si().with_compensation(refund)
+```
+
+This is useful when the same signature is reused across several chains with
+different compensators.
+
 ## chunks / starmap
 
 ```python
@@ -118,6 +252,7 @@ results = starmap(add, [(1, 2), (3, 4), (5, 6)]).apply(queue)
 | Fan-out | Static (known at build time) | Dynamic (from return values) |
 | Conditions | None | `on_success`, `on_failure`, `always`, callables |
 | Error handling | Per-task retries only | Workflow-level strategies |
+| Saga compensation | `chain` / `group` / `chord` | DAG-level, with sub-workflow propagation |
 | Approval gates | No | Yes |
 | Sub-workflows | No | Yes |
 | Incremental runs | No | Yes |

--- a/docs/content/docs/guides/workflows/sagas.mdx
+++ b/docs/content/docs/guides/workflows/sagas.mdx
@@ -3,6 +3,8 @@ title: Sagas
 description: Reverse-order compensation when a workflow step fails
 ---
 
+import { Callout } from "fumadocs-ui/components/callout";
+
 A saga is a workflow where each step has a registered **compensator** — a task that undoes the step's side effect. If a later step fails, taskito automatically runs the compensators of every already-completed step, in reverse topological order, so the system ends up in a consistent state.
 
 ```python
@@ -45,12 +47,11 @@ def compensator(forward_args: tuple, forward_kwargs: dict, forward_result: Any) 
 
 That's the **only** signature taskito calls compensators with. It lets one compensator service multiple workflows without coupling to specific step shapes.
 
-<Callout type="info" title="v1 limitations">
-For the initial saga release:
-
-- `forward_args` / `forward_kwargs` are populated only for *deferred* nodes (fan-out, fan-in, conditional, gate, sub-workflow). Static steps currently pass empty tuples/dicts. Look up state yourself if you need the originals.
-- `forward_result` is always `None` in v1.
-- Sagas trigger only when `on_failure="fail_fast"` (the default). `on_failure="continue"` workflows do not compensate.
+<Callout type="info">
+  `forward_args`, `forward_kwargs`, and `forward_result` are fully populated
+  for both static and deferred workflow nodes. Use
+  `current_compensation_context()` inside a compensator body to access the
+  workflow run ID, node name, forward job ID, and forward result.
 </Callout>
 
 ## Declaring compensators
@@ -89,16 +90,46 @@ When a workflow step's forward execution fails with retries exhausted:
    - All compensators succeeded → next wave starts.
    - Any failed → the run terminates as `CompensationFailed`. **Subsequent waves are not dispatched** because downstream rollback may depend on the failed step.
 
+## Compensating on `on_failure="continue"` workflows
+
+By default, `on_failure="continue"` workflows never trigger compensation —
+they collect failures and always complete. Set `compensate_on_continue=True`
+to opt in:
+
+```python
+wf = Workflow(
+    name="resilient_checkout",
+    on_failure="continue",
+    compensate_on_continue=True,
+)
+wf.step("charge", charge, args=(100, "c1"))
+wf.step("ship",   ship,   args=(42,), after="charge")
+
+run = queue.submit_workflow(wf)
+```
+
+With `compensate_on_continue=True`:
+
+- The run completes all steps regardless of individual failures (continue semantics).
+- When the run terminates, if any steps failed, the run transitions to
+  `CompletedWithFailures` before entering `Compensating`.
+- Compensators for every *succeeded* step then run in reverse topological order.
+- Final state is `Compensated` or `CompensationFailed` (same as fail-fast sagas).
+
+Without `compensate_on_continue=True`, a `continue`-mode run with failures
+ends in `CompletedWithFailures` and no compensation runs.
+
 ## Final run states
 
-| State                 | Meaning                                                                   |
-|-----------------------|---------------------------------------------------------------------------|
-| `COMPLETED`           | Run finished normally — no compensation ran                               |
-| `FAILED`              | Forward failure with no registered compensators                           |
-| `COMPENSATED`         | Forward failed, every applicable compensator succeeded                    |
-| `COMPENSATION_FAILED` | Forward failed, and one or more compensators failed during rollback       |
+| State | Meaning |
+|---|---|
+| `COMPLETED` | Run finished normally — no compensation ran |
+| `FAILED` | Forward failure with no registered compensators (`fail_fast` mode) |
+| `COMPLETED_WITH_FAILURES` | `continue` mode completed with some step failures |
+| `COMPENSATED` | Every applicable compensator succeeded |
+| `COMPENSATION_FAILED` | One or more compensators failed during rollback |
 
-`WorkflowState.is_terminal()` returns `True` for all four.
+`WorkflowState.is_terminal()` returns `True` for all five.
 
 ## Idempotency
 
@@ -110,6 +141,7 @@ Saga lifecycle emits dedicated events on the queue's event bus:
 
 | Event                                  | Fires when                                              |
 |----------------------------------------|---------------------------------------------------------|
+| `WORKFLOW_COMPLETED_WITH_FAILURES`     | `continue`-mode run finished with at least one failure  |
 | `WORKFLOW_COMPENSATING`                | Run enters the compensation phase                       |
 | `WORKFLOW_COMPENSATED`                 | All compensators succeeded                              |
 | `WORKFLOW_COMPENSATION_FAILED`         | At least one compensator failed                         |

--- a/docs/content/docs/more/changelog.mdx
+++ b/docs/content/docs/more/changelog.mdx
@@ -5,6 +5,17 @@ description: "Release history for taskito — every notable change, fix, and fea
 
 All notable changes to taskito are documented here.
 
+## 0.14.0
+
+### Added
+
+- **Bare-metal autoscaler.** `taskito.autoscale` provides an in-process HPA-style control loop that spawns and drains `taskito worker` subprocesses based on queue depth and utilisation. Mirrors the Kubernetes HPA dual-signal formula (`depth_desired` + `util_desired`). Configurable stabilisation windows (default: scale-up immediate, scale-down 5 minutes), tolerance band (10%), overload override, and crash recovery. Use `serve_autoscaler(queue, AutoscaleConfig(...))` as the entry point. See the [Bare-Metal Autoscaler guide](/guides/operations/autoscaler).
+- **Dashboard `/api/workflows` backend.** Four new REST endpoints expose workflow run data: `GET /api/workflows/runs` (paginated list, filterable by definition name and state), `GET /api/workflows/runs/{id}` (run header + per-node detail with compensation fields), `GET /api/workflows/runs/{id}/dag` (DAG JSON), and `GET /api/workflows/runs/{id}/children` (sub-workflow runs). All timestamps are Unix milliseconds.
+- **Canvas saga compensation.** `chain`, `group`, and `chord` support `.with_compensation([...])`. On failure, compensators for completed steps are enqueued with a deterministic `canvas_compensation:{run_id}:{slot}` idempotency key. Dispatch order: chain → reverse-sequential, group → parallel, chord → callback compensator first then group members. `Signature.with_compensation(compensator)` lets individual signatures carry their own compensator.
+- **Per-item batch results.** `@queue.task(batch={"per_item_results": True})` enables per-item tracking for batched tasks. The task returns `list[BatchItemResult]`; each caller's `BatchedJobResult.result()` returns **only that caller's value**. `BatchItemResult.success(item_index, result)` and `BatchItemResult.failure(item_index, error)` are the constructors. `partial_failures()` returns failed items after a successful batch. `BatchPartialFailureError` and `BatchResultTypeError` are the new exception types. Cannot be combined with `idempotent=True`.
+- **Saga `compensate_on_continue`.** `Workflow(on_failure="continue", compensate_on_continue=True)` triggers compensation after a continue-mode run terminates with failures. The run transitions through `CompletedWithFailures` before entering `Compensating`, then ends in `Compensated` or `CompensationFailed`. Without the flag, continue-mode runs end in `CompletedWithFailures` with no compensation.
+- **`COMPLETED_WITH_FAILURES` workflow state.** New `WorkflowState` variant for `on_failure="continue"` runs that finished with at least one step failure. Emits `WORKFLOW_COMPLETED_WITH_FAILURES` event. Accessible as `"completed_with_failures"` in the REST API `state` field.
+
 ## 0.13.0
 
 ### Added


### PR DESCRIPTION
## Summary
Adds documentation for the five features that shipped in 0.14 (PRs #190–#195) and the 0.14.0 changelog entry.

## Changes
- **guides/operations/autoscaler.mdx** (new) — bare-metal autoscaler guide: HPA-style dual-signal formula, `AutoscaleConfig`, `serve_autoscaler` / `AutoscaleController` / `ScaleDecision` / `ProcessManager`, systemd + Docker Compose patterns, KEDA comparison. Added to operations nav and index.
- **guides/workflows/canvas.mdx** — `chain/group/chord.with_compensation`, compensator contract, idempotency key format, `None` slot semantics, feature-comparison row.
- **guides/workflows/sagas.mdx** — `compensate_on_continue=True`, `CompletedWithFailures` state, updated final-states table, new event entry. Removed the outdated v1-limitations callout (forward args/result are fully populated now).
- **guides/advanced-execution/batch-enqueue.mdx** — `per_item_results=True`, `BatchItemResult`, `BatchPartialFailureError` retry semantics, `partial_failures()`.
- **guides/dashboard/rest-api.mdx** — four new \`/api/workflows\` endpoints with query params and response shapes.
- **more/changelog.mdx** — 0.14.0 entry.

## Test plan
- [ ] \`pnpm --dir docs build\` succeeds (static export)
- [ ] New autoscaler page is reachable from the operations nav
- [ ] No broken cross-links between canvas and sagas