### PR TITLE
ci: harden publish workflow against transient API failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,10 +265,11 @@ jobs:
         run: uv sync --extra dev --extra oauth
 
       - name: Build native extension with maturin
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@v1.51.0
         with:
           command: develop
           args: --release --features extension-module,postgres,redis,native-async,workflows
+          maturin-version: v1.13.3
 
       - name: Run Python test suite
         # The pytest_unconfigure hook in tests/conftest.py calls

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,7 @@ jobs:
     needs: build-dashboard
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest
@@ -68,6 +69,7 @@ jobs:
     needs: build-dashboard
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest
@@ -108,6 +110,7 @@ jobs:
     needs: build-dashboard
     runs-on: macos-latest
     strategy:
+      fail-fast: false
       matrix:
         target:
           - x86_64-apple-darwin
@@ -163,6 +166,7 @@ jobs:
     needs: build-dashboard
     runs-on: windows-latest
     strategy:
+      fail-fast: false
       matrix:
         include:
           - target: x86_64-pc-windows-msvc

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,11 +48,12 @@ jobs:
         run: test -f py_src/taskito/static/dashboard/index.html
 
       - name: Build wheels
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@v1.51.0
         with:
           target: ${{ matrix.target }}
           args: --release --out dist --features extension-module,postgres,redis,native-async,workflows --interpreter 3.10 3.11 3.12 3.13
           manylinux: 2_28
+          maturin-version: v1.13.3
           before-script-linux: |
             dnf install -y openssl-devel perl-core perl-IPC-Cmd
 
@@ -87,11 +88,12 @@ jobs:
         run: test -f py_src/taskito/static/dashboard/index.html
 
       - name: Build wheels
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@v1.51.0
         with:
           target: ${{ matrix.target }}
           args: --release --out dist --features extension-module,postgres,redis,native-async,workflows --interpreter 3.10 3.11 3.12 3.13
           manylinux: musllinux_1_2
+          maturin-version: v1.13.3
           before-script-linux: |
             apt-get update && apt-get install -y libssl-dev perl pkg-config
 
@@ -144,10 +146,11 @@ jobs:
           python-version: "3.13"
 
       - name: Build wheels
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@v1.51.0
         with:
           target: ${{ matrix.target }}
           args: --release --out dist --features extension-module,postgres,redis,native-async,workflows --interpreter 3.10 3.11 3.12 3.13
+          maturin-version: v1.13.3
 
       - name: Upload wheels
         uses: actions/upload-artifact@v7
@@ -197,10 +200,11 @@ jobs:
           python-version: "3.13"
 
       - name: Build wheels
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@v1.51.0
         with:
           target: ${{ matrix.target }}
           args: --release --out dist --features extension-module,postgres,redis,native-async,workflows --interpreter 3.10 3.11 3.12 3.13
+          maturin-version: v1.13.3
 
       - name: Upload wheels
         uses: actions/upload-artifact@v7
@@ -226,10 +230,11 @@ jobs:
         run: test -f py_src/taskito/static/dashboard/index.html
 
       - name: Build sdist
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@v1.51.0
         with:
           command: sdist
           args: --out dist
+          maturin-version: v1.13.3
 
       - name: Upload sdist
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary
The 0.14.0 publish workflow failed because \`PyO3/maturin-action@v1\` got \`HttpClientError: Bad credentials\` (401) calling the GitHub Releases API to discover the latest maturin binary. Other jobs in the same run using the same action succeeded — confirming the API blip was transient, not a config error. But the default matrix \`fail-fast\` cancelled siblings, taking the entire publish run down with it.

## Root cause
\`maturin-action\` defaults to \`maturin-version: latest\`, which calls \`api.github.com/repos/PyO3/maturin/releases\` on every run. That call uses \`\${{ github.token }}\` and is subject to transient 401s.

## Fix
Two independent commits:

1. **Pin \`PyO3/maturin-action@v1.51.0\` and \`maturin-version: v1.13.3\`** (all 7 invocations across \`publish.yml\` + \`ci.yml\`). Skips the GitHub Releases API discovery call entirely — the action downloads a known release artifact directly. Action pin follows the project's own README guidance against the floating \`@v1\` tag.
2. **\`fail-fast: false\`** on the four wheel matrices in \`publish.yml\`. Transient hiccups stay isolated; recovery is \`gh run rerun --failed\` instead of restarting every platform from scratch.

## Verification
- [ ] CI green on this PR
- [ ] After merge, re-trigger the 0.14.0 publish workflow (existing tag — no retag needed)