### PR TITLE
fix: guard wait() against transient FAILED during saga startup

### DIFF
--- a/py_src/taskito/workflows/run.py
+++ b/py_src/taskito/workflows/run.py
@@ -68,6 +68,27 @@ class WorkflowRun:
             while True:
                 snapshot = self.status()
                 if snapshot.state.is_terminal():
+                    # FAILED and COMPLETED_WITH_FAILURES can transition to
+                    # COMPENSATING when a saga is about to start.  Between
+                    # mark_workflow_node_result (sets FAILED in Rust) and
+                    # start_compensation (sets COMPENSATING from Python)
+                    # there is a window where the poll sees the transient
+                    # terminal state.  When the tracker owns an event for
+                    # this run, defer to the event — it is set only after
+                    # the saga decision is made — instead of returning the
+                    # possibly-transient state.
+                    if (
+                        snapshot.state
+                        in (WorkflowState.FAILED, WorkflowState.COMPLETED_WITH_FAILURES)
+                        and event is not None
+                        and not event.is_set()
+                    ):
+                        grace = poll_interval
+                        if deadline is not None:
+                            grace = min(grace, max(0.0, deadline - time.monotonic()))
+                        if grace > 0:
+                            event.wait(timeout=grace)
+                            continue
                     return snapshot
 
                 remaining: float

--- a/py_src/taskito/workflows/saga/orchestrator.py
+++ b/py_src/taskito/workflows/saga/orchestrator.py
@@ -601,11 +601,21 @@ class SagaOrchestrator:
         )
 
     def _mark_run_compensating(self, run_id: str) -> None:
-        """Move the run from ``Running`` to ``Compensating`` in storage."""
-        try:
-            self._queue._inner.set_workflow_run_compensating(run_id)
-        except Exception:
-            logger.exception("saga: failed to mark run %s compensating", run_id)
+        """Move the run to ``Compensating`` in storage.
+
+        Retries briefly on transient SQLite "database is locked" errors
+        so that contention from a concurrent result-handler write does
+        not silently leave the run in ``Failed``.
+        """
+        for attempt in range(5):
+            try:
+                self._queue._inner.set_workflow_run_compensating(run_id)
+                return
+            except Exception as exc:
+                if "database is locked" not in str(exc) or attempt == 4:
+                    logger.exception("saga: failed to mark run %s compensating", run_id)
+                    return
+                time.sleep(0.05 * (attempt + 1))
 
     def _finalize_locked(self, run_id: str, *, succeeded: bool) -> None:
         """Cleanly finalize a saga. Must be called with ``self._lock``."""


### PR DESCRIPTION
## Summary

The previous fix (#201) moved `_mark_run_compensating` earlier in `start_compensation` to narrow the FAILED→COMPENSATING race window, but Python overhead between `mark_workflow_node_result` (Rust sets FAILED) and the Python-side transition still left a gap the 100ms poll could catch on slow Windows CI.

This PR eliminates the race entirely with two changes:

- **`wait()` defers to the tracker event on transient terminal states.** When the polled state is `FAILED` or `COMPLETED_WITH_FAILURES` and the tracker's waiter event hasn't been set yet, `wait()` defers to the event instead of returning immediately. The event is set only after the saga decision is made — either the saga finishes (COMPENSATED/COMPENSATION_FAILED) or no saga starts (FAILED is emitted as terminal). This closes the race regardless of how long the Python overhead takes.

- **`_mark_run_compensating` retries on "database is locked".** Transient SQLite write contention could silently leave the run in FAILED. The method now retries up to 5 times with backoff, matching the existing pattern in `_dispatch_single`.

## Test plan

- [x] All 23 saga tests pass
- [x] All 98 workflow tests pass
- [x] Full suite: 998 passed, 6 skipped
- [x] ruff + mypy clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow run status handling during compensation by deferring transient failure states until confirmation is available.
  * Enhanced database operation resilience during workflow compensation with automatic retry logic and exponential backoff, reducing interruptions from database locks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ByteVeda/taskito/pull/203?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->