### PR TITLE
fix(docs): link path for canvas.chunks() in batching guide

### DIFF
--- a/docs/content/docs/guides/core/batching.mdx
+++ b/docs/content/docs/guides/core/batching.mdx
@@ -90,4 +90,4 @@ When not to use it:
 - Tasks where per-item retry matters.
 - Heterogeneous work that doesn't share the same downstream code path.
 
-See also the [`canvas.chunks()`](/docs/guides/workflows/canvas) primitive — it's a producer-side equivalent that creates `N` separate jobs each holding a sub-list, with full per-chunk retry semantics.
+See also the [`canvas.chunks()`](/guides/workflows/canvas) primitive — it's a producer-side equivalent that creates `N` separate jobs each holding a sub-list, with full per-chunk retry semantics.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a documentation reference link in the batching guide to ensure proper navigation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ByteVeda/taskito/pull/204?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->