### PR TITLE
chore(release): 0.14.2

### DIFF
--- a/crates/taskito-async/Cargo.toml
+++ b/crates/taskito-async/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-async"
-version = "0.14.1"
+version = "0.14.2"
 edition = "2021"
 
 [dependencies]

--- a/crates/taskito-core/Cargo.toml
+++ b/crates/taskito-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-core"
-version = "0.14.1"
+version = "0.14.2"
 edition = "2021"
 
 [features]

--- a/crates/taskito-python/Cargo.toml
+++ b/crates/taskito-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-python"
-version = "0.14.1"
+version = "0.14.2"
 edition = "2021"
 
 [features]

--- a/crates/taskito-workflows/Cargo.toml
+++ b/crates/taskito-workflows/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-workflows"
-version = "0.14.1"
+version = "0.14.2"
 edition = "2021"
 
 [features]

--- a/docs/content/docs/more/changelog.mdx
+++ b/docs/content/docs/more/changelog.mdx
@@ -5,6 +5,15 @@ description: "Release history for taskito — every notable change, fix, and fea
 
 All notable changes to taskito are documented here.
 
+## 0.14.2
+
+### Fixed
+
+- **`wait()` no longer returns transient `FAILED` during saga startup.** `WorkflowRun.wait()`'s poll safety-net could observe the run in `Failed` state before the saga orchestrator transitioned it to `Compensating`. When a tracker event is registered but has not yet fired, `wait()` now defers to the event instead of returning the possibly-transient terminal state. The event is set only after the saga decision is fully resolved, so `wait()` can never prematurely return `Failed` for a run that is about to compensate.
+- **`_mark_run_compensating` retries on transient SQLite lock.** The `Failed` → `Compensating` storage write could silently fail under SQLite file contention, leaving the run stuck in `Failed`. The method now retries up to 5 times with backoff, matching the existing retry pattern in compensation job dispatch.
+
+---
+
 ## 0.14.1
 
 ### Fixed

--- a/docs/src/lib/landing-content.tsx
+++ b/docs/src/lib/landing-content.tsx
@@ -104,7 +104,7 @@ export type LandingCta = {
 };
 
 export const HERO: LandingHero = {
-  badge: "v0.12 — Rust core, native async, DAG workflows",
+  badge: "v0.14 — Rust core, native async, DAG workflows",
   headline: ["Task queue", "without the broker."],
   description:
     "Rust-powered task queue for Python. Replace Celery without Redis or RabbitMQ. Start with SQLite, scale to Postgres.",

--- a/py_src/taskito/__init__.py
+++ b/py_src/taskito/__init__.py
@@ -116,4 +116,4 @@ try:
 
     __version__ = _get_version("taskito")
 except PackageNotFoundError:
-    __version__ = "0.14.1"
+    __version__ = "0.14.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "taskito"
-version = "0.14.1"
+version = "0.14.2"
 description = "Rust-powered task queue for Python. No broker required."
 requires-python = ">=3.10"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary

- Bump version to 0.14.2 across all crates and Python package
- Add 0.14.2 changelog entry documenting the `wait()` race guard and `_mark_run_compensating` retry fixes (#203)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved transient "Failed" observations during workflow startup.
  * Added retries for brief database lock contention to prevent runs from getting stuck.

* **Chores**
  * Released v0.14.2 across packages.
  * Updated documentation and landing banner to reflect v0.14.2.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ByteVeda/taskito/pull/205?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->