### PR TITLE
fix: re-fetch run config before terminal check in _handle

### DIFF
--- a/py_src/taskito/workflows/tracker/tracker.py
+++ b/py_src/taskito/workflows/tracker/tracker.py
@@ -232,6 +232,14 @@ class WorkflowTracker:
 
         run_id, node_name, terminal_state = result
 
+        # The initial lookup used _job_to_run which may not have this
+        # job yet (register_run populates _run_configs before the
+        # slower _job_to_run database read).  Re-fetch now that Rust
+        # gave us the authoritative run_id.
+        if config is None:
+            with self._state_lock:
+                config = self._run_configs.get(run_id)
+
         # Track partial failure occurrence for continue-mode saga finalization.
         # This is the only place we observe individual job-failure events in
         # the tracker — we record it on the in-memory config so that
@@ -288,10 +296,6 @@ class WorkflowTracker:
             self._cleanup_run(run_id)
             return
 
-        # Re-fetch config now that we have the definitive run_id.
-        if config is None:
-            with self._state_lock:
-                config = self._run_configs.get(run_id)
         if config is None:
             return  # Static workflow — Rust cascade handled everything.
 


### PR DESCRIPTION
## Summary

Root-cause fix for the persistent saga CI flake on Windows.

`register_run` populates `_run_configs` (in-memory dict, instant) **before** `_job_to_run` (requires a `get_workflow_run_status` database read that can block under SQLite contention). When the worker thread processes and fails a job in that gap, `_handle` looked up the job in `_job_to_run` → got `None` → set `config = None`. The terminal-state branch then skipped the saga check entirely and called `_emit_terminal(FAILED)`, setting the waiter event. `wait()` returned `FAILED` immediately.

The fix moves the config re-fetch (which was already present but only reachable on the non-terminal path at line 291) to **before** the terminal check, so the saga orchestrator sees the config regardless of `_job_to_run` timing.

## Test plan

- [x] All 16 saga tests pass
- [x] All 98 workflow tests pass
- [x] Full suite: 998 passed, 6 skipped
- [x] ruff + mypy clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced workflow tracking robustness by improving configuration retrieval in edge cases, ensuring the system maintains accurate tracking state when initial lookups are incomplete.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ByteVeda/taskito/pull/206?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->