### PR TITLE
feat: wire autoscale subcommand in CLI

### DIFF
--- a/docs/content/docs/api-reference/cli.mdx
+++ b/docs/content/docs/api-reference/cli.mdx
@@ -1,6 +1,6 @@
 ---
 title: CLI Reference
-description: "The taskito command-line interface — worker, info, scaler."
+description: "The taskito command-line interface — worker, info, scaler, autoscale."
 ---
 
 taskito provides a command-line interface for running workers and inspecting
@@ -164,6 +164,38 @@ taskito scaler --app myapp:queue --port 9091 --target-queue-depth 5
 
 See the [KEDA Integration guide](/guides/operations) for Kubernetes deploy
 templates.
+
+### `taskito autoscale`
+
+Start a bare-metal autoscaler that spawns and drains worker processes based on
+queue depth and worker utilisation.
+
+```bash
+taskito autoscale --app <module:attribute> [options]
+```
+
+| Flag | Default | Description |
+|---|---|---|
+| `--app` | — | Python path to the `Queue` instance |
+| `--min-workers` | `1` | Minimum worker count |
+| `--max-workers` | `10` | Maximum worker count |
+| `--target-queue-depth` | `15` | Target queue depth per worker |
+| `--target-utilisation` | `0.75` | Target worker utilisation (0.0–1.0) |
+| `--scale-up-window` | `0` | Seconds of sustained demand before scaling up |
+| `--scale-down-window` | `300` | Seconds of low demand before scaling down |
+| `--tolerance` | `0.1` | Scaling tolerance band |
+| `--poll-interval` | `5` | Seconds between scaling decisions |
+| `--drain-timeout` | `30` | Seconds to wait for in-flight jobs during scale-down |
+| `--threads-per-worker` | `4` | Worker threads per spawned process |
+
+**Example:**
+
+```bash
+taskito autoscale --app myapp.tasks:queue --min-workers 2 --max-workers 20
+```
+
+See the [Autoscaler guide](/docs/guides/operations/autoscaler) for deployment
+patterns and tuning advice.
 
 ## Error messages
 

--- a/docs/content/docs/api-reference/cli.mdx
+++ b/docs/content/docs/api-reference/cli.mdx
@@ -194,7 +194,7 @@ taskito autoscale --app <module:attribute> [options]
 taskito autoscale --app myapp.tasks:queue --min-workers 2 --max-workers 20
 ```
 
-See the [Autoscaler guide](/docs/guides/operations/autoscaler) for deployment
+See the [Autoscaler guide](/guides/operations/autoscaler) for deployment
 patterns and tuning advice.
 
 ## Error messages

--- a/docs/content/docs/guides/operations/autoscaler.mdx
+++ b/docs/content/docs/guides/operations/autoscaler.mdx
@@ -34,6 +34,37 @@ serve_autoscaler(
 `serve_autoscaler` blocks until SIGTERM or SIGINT arrives, at which point it
 drains all worker processes gracefully before returning.
 
+## CLI
+
+The fastest way to run the autoscaler:
+
+```bash
+taskito autoscale --app myapp.tasks:queue
+```
+
+All `AutoscaleConfig` parameters are available as CLI flags:
+
+```bash
+taskito autoscale --app myapp.tasks:queue \
+  --min-workers 2 --max-workers 20 \
+  --target-queue-depth 25 --drain-timeout 60
+```
+
+**systemd unit** (using the CLI instead of a Python entry point):
+
+```ini
+[Unit]
+Description=taskito autoscaler
+After=network.target
+
+[Service]
+ExecStart=taskito autoscale --app myapp.tasks:queue --min-workers 2 --max-workers 20
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+```
+
 ## How it works
 
 Every `poll_interval_sec` seconds (default 5 s) the controller:

--- a/py_src/taskito/cli.py
+++ b/py_src/taskito/cli.py
@@ -339,19 +339,23 @@ def run_scaler(args: argparse.Namespace) -> None:
 def run_autoscale(args: argparse.Namespace) -> None:
     """Start the bare-metal autoscaler."""
     queue = _load_queue(args.app)
-    config = AutoscaleConfig(
-        app_path=args.app,
-        min_workers=args.min_workers,
-        max_workers=args.max_workers,
-        target_queue_depth_per_worker=args.target_queue_depth,
-        target_utilisation=args.target_utilisation,
-        scale_up_window_sec=args.scale_up_window,
-        scale_down_window_sec=args.scale_down_window,
-        tolerance=args.tolerance,
-        poll_interval_sec=args.poll_interval,
-        drain_timeout_sec=args.drain_timeout,
-        threads_per_worker=args.threads_per_worker,
-    )
+    try:
+        config = AutoscaleConfig(
+            app_path=args.app,
+            min_workers=args.min_workers,
+            max_workers=args.max_workers,
+            target_queue_depth_per_worker=args.target_queue_depth,
+            target_utilisation=args.target_utilisation,
+            scale_up_window_sec=args.scale_up_window,
+            scale_down_window_sec=args.scale_down_window,
+            tolerance=args.tolerance,
+            poll_interval_sec=args.poll_interval,
+            drain_timeout_sec=args.drain_timeout,
+            threads_per_worker=args.threads_per_worker,
+        )
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
     serve_autoscaler(queue, config)
 
 

--- a/py_src/taskito/cli.py
+++ b/py_src/taskito/cli.py
@@ -16,12 +16,8 @@ from taskito.log_config import configure as configure_logging
 from taskito.scaler import serve_scaler
 
 
-def main() -> None:
-    """Parse CLI arguments and dispatch to the appropriate subcommand."""
-    # Configure the central taskito logger before any subcommand runs so
-    # ``info``, ``dashboard``, ``scaler``, etc. all share the same sink.
-    configure_logging()
-
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the CLI argument parser with all subcommands."""
     parser = argparse.ArgumentParser(
         prog="taskito",
         description="taskito — Rust-powered task queue for Python",
@@ -193,6 +189,16 @@ def main() -> None:
         help="Reload a specific resource (default: all reloadable)",
     )
 
+    return parser
+
+
+def main() -> None:
+    """Parse CLI arguments and dispatch to the appropriate subcommand."""
+    # Configure the central taskito logger before any subcommand runs so
+    # ``info``, ``dashboard``, ``scaler``, etc. all share the same sink.
+    configure_logging()
+
+    parser = _build_parser()
     args = parser.parse_args()
 
     if args.command == "worker":

--- a/py_src/taskito/cli.py
+++ b/py_src/taskito/cli.py
@@ -10,6 +10,7 @@ import sys
 import time
 
 from taskito.app import Queue
+from taskito.autoscale import AutoscaleConfig, serve_autoscaler
 from taskito.dashboard import serve_dashboard
 from taskito.log_config import configure as configure_logging
 from taskito.scaler import serve_scaler
@@ -112,6 +113,65 @@ def main() -> None:
         help="Scaling target hint for KEDA (default: 10)",
     )
 
+    # autoscale subcommand
+    auto_parser = subparsers.add_parser("autoscale", help="Start the bare-metal autoscaler")
+    auto_parser.add_argument(
+        "--app",
+        required=True,
+        help="Python path to the Queue instance (e.g., 'myapp.tasks:queue')",
+    )
+    auto_parser.add_argument(
+        "--min-workers", type=int, default=1, help="Minimum worker count (default: 1)"
+    )
+    auto_parser.add_argument(
+        "--max-workers", type=int, default=10, help="Maximum worker count (default: 10)"
+    )
+    auto_parser.add_argument(
+        "--target-queue-depth",
+        type=int,
+        default=15,
+        help="Target queue depth per worker (default: 15)",
+    )
+    auto_parser.add_argument(
+        "--target-utilisation",
+        type=float,
+        default=0.75,
+        help="Target worker utilisation 0.0-1.0 (default: 0.75)",
+    )
+    auto_parser.add_argument(
+        "--scale-up-window",
+        type=int,
+        default=0,
+        help="Seconds of sustained demand before scaling up (default: 0)",
+    )
+    auto_parser.add_argument(
+        "--scale-down-window",
+        type=int,
+        default=300,
+        help="Seconds of low demand before scaling down (default: 300)",
+    )
+    auto_parser.add_argument(
+        "--tolerance", type=float, default=0.1, help="Scaling tolerance band (default: 0.1)"
+    )
+    auto_parser.add_argument(
+        "--poll-interval",
+        type=int,
+        default=5,
+        help="Seconds between scaling decisions (default: 5)",
+    )
+    auto_parser.add_argument(
+        "--drain-timeout",
+        type=int,
+        default=30,
+        help="Seconds to wait for in-flight jobs during scale-down (default: 30)",
+    )
+    auto_parser.add_argument(
+        "--threads-per-worker",
+        type=int,
+        default=4,
+        help="Worker threads per process (default: 4)",
+    )
+
     # resources subcommand
     res_parser = subparsers.add_parser("resources", help="Show registered resources")
     res_parser.add_argument(
@@ -151,6 +211,8 @@ def main() -> None:
         print(f"Queue '{args.queue_name}' resumed")
     elif args.command == "scaler":
         run_scaler(args)
+    elif args.command == "autoscale":
+        run_autoscale(args)
     elif args.command == "resources":
         run_resources(args)
     elif args.command == "reload":
@@ -266,6 +328,25 @@ def run_scaler(args: argparse.Namespace) -> None:
         port=args.port,
         target_queue_depth=args.target_queue_depth,
     )
+
+
+def run_autoscale(args: argparse.Namespace) -> None:
+    """Start the bare-metal autoscaler."""
+    queue = _load_queue(args.app)
+    config = AutoscaleConfig(
+        app_path=args.app,
+        min_workers=args.min_workers,
+        max_workers=args.max_workers,
+        target_queue_depth_per_worker=args.target_queue_depth,
+        target_utilisation=args.target_utilisation,
+        scale_up_window_sec=args.scale_up_window,
+        scale_down_window_sec=args.scale_down_window,
+        tolerance=args.tolerance,
+        poll_interval_sec=args.poll_interval,
+        drain_timeout_sec=args.drain_timeout,
+        threads_per_worker=args.threads_per_worker,
+    )
+    serve_autoscaler(queue, config)
 
 
 def run_resources(args: argparse.Namespace) -> None:

--- a/tests/integrations/test_cli.py
+++ b/tests/integrations/test_cli.py
@@ -1,10 +1,11 @@
 """Tests for CLI info command."""
 
+import argparse
 from pathlib import Path
 
 import pytest
 
-from taskito.cli import _build_parser, _load_queue, _print_stats
+from taskito.cli import _build_parser, _load_queue, _print_stats, run_autoscale
 
 
 def test_load_queue_invalid_format() -> None:
@@ -107,3 +108,38 @@ def test_autoscale_custom_flags() -> None:
     assert args.poll_interval == 10
     assert args.drain_timeout == 60
     assert args.threads_per_worker == 8
+
+
+def test_autoscale_invalid_config_exits_cleanly(
+    capsys: pytest.CaptureFixture[str], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """run_autoscale prints a clean error and exits 1 on invalid flag values."""
+    from taskito import Queue
+
+    queue_module = tmp_path / "queue_app.py"
+    queue_module.write_text(
+        f"from taskito import Queue\nqueue = Queue(db_path={str(tmp_path / 'q.db')!r})\n"
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    assert isinstance(_load_queue("queue_app:queue"), Queue)
+
+    args = argparse.Namespace(
+        app="queue_app:queue",
+        min_workers=5,
+        max_workers=2,
+        target_queue_depth=15,
+        target_utilisation=0.75,
+        scale_up_window=0,
+        scale_down_window=300,
+        tolerance=0.1,
+        poll_interval=5,
+        drain_timeout=30,
+        threads_per_worker=4,
+    )
+    with pytest.raises(SystemExit) as exc_info:
+        run_autoscale(args)
+    assert exc_info.value.code == 1
+    err = capsys.readouterr().err
+    assert "Error:" in err
+    assert "max_workers" in err  # the failing constraint is named in the message
+    assert "Traceback" not in err  # no raw traceback leaked to the user

--- a/tests/integrations/test_cli.py
+++ b/tests/integrations/test_cli.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from taskito.cli import _load_queue, _print_stats
+from taskito.cli import _build_parser, _load_queue, _print_stats
 
 
 def test_load_queue_invalid_format() -> None:
@@ -39,3 +39,71 @@ def test_print_stats_format(capsys: pytest.CaptureFixture[str], tmp_path: Path) 
     assert "taskito queue statistics" in output
     assert "pending" in output
     assert "total" in output
+
+
+def test_autoscale_requires_app() -> None:
+    """autoscale subcommand fails without --app."""
+    parser = _build_parser()
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args(["autoscale"])
+    assert exc_info.value.code == 2
+
+
+def test_autoscale_default_config() -> None:
+    """autoscale subcommand maps flags to AutoscaleConfig defaults."""
+    parser = _build_parser()
+    args = parser.parse_args(["autoscale", "--app", "myapp:queue"])
+    assert args.command == "autoscale"
+    assert args.app == "myapp:queue"
+    assert args.min_workers == 1
+    assert args.max_workers == 10
+    assert args.target_queue_depth == 15
+    assert args.target_utilisation == 0.75
+    assert args.scale_up_window == 0
+    assert args.scale_down_window == 300
+    assert args.tolerance == 0.1
+    assert args.poll_interval == 5
+    assert args.drain_timeout == 30
+    assert args.threads_per_worker == 4
+
+
+def test_autoscale_custom_flags() -> None:
+    """autoscale subcommand accepts all custom flags."""
+    parser = _build_parser()
+    args = parser.parse_args(
+        [
+            "autoscale",
+            "--app",
+            "myapp:queue",
+            "--min-workers",
+            "2",
+            "--max-workers",
+            "20",
+            "--target-queue-depth",
+            "25",
+            "--target-utilisation",
+            "0.8",
+            "--scale-up-window",
+            "30",
+            "--scale-down-window",
+            "600",
+            "--tolerance",
+            "0.2",
+            "--poll-interval",
+            "10",
+            "--drain-timeout",
+            "60",
+            "--threads-per-worker",
+            "8",
+        ]
+    )
+    assert args.min_workers == 2
+    assert args.max_workers == 20
+    assert args.target_queue_depth == 25
+    assert args.target_utilisation == 0.8
+    assert args.scale_up_window == 30
+    assert args.scale_down_window == 600
+    assert args.tolerance == 0.2
+    assert args.poll_interval == 10
+    assert args.drain_timeout == 60
+    assert args.threads_per_worker == 8


### PR DESCRIPTION
## Summary
- Add `taskito autoscale` subcommand exposing all `AutoscaleConfig` parameters as CLI flags
- Extract `_build_parser()` from `main()` for testability
- Add CLI integration tests for parser defaults, custom flags, and required args
- Document the command in CLI reference and autoscaler guide

The autoscaler feature (`serve_autoscaler`, `AutoscaleConfig`, `AutoscaleController`) was already implemented — this wires it into the CLI so users can run `taskito autoscale --app myapp:queue` instead of writing a Python script.

## Test plan
- [ ] `uv run python -m pytest tests/integrations/test_cli.py -v`
- [ ] `uv run ruff check py_src/taskito/cli.py tests/integrations/test_cli.py`
- [ ] `uv run mypy py_src/taskito/ --no-incremental`
- [ ] `pnpm --dir docs build` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `autoscale` CLI command to run the bare-metal autoscaler with configurable min/max workers, queue depth/utilization targets, scaling windows, tolerance, poll/drain settings, and threads-per-worker.

* **Documentation**
  * Updated CLI reference with `autoscale` flags, syntax, and example.
  * Added CLI usage section to the Autoscaler guide with a systemd ExecStart example.

* **Tests**
  * Added tests for `autoscale` parsing, defaults, flag overrides, and validation/error exit behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ByteVeda/taskito/pull/208?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->