### PR TITLE
test: replace bare time.sleep with poll_until fixture

### DIFF
--- a/tests/core/test_batching.py
+++ b/tests/core/test_batching.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import threading
-import time
+from typing import Any
 
 import pytest
 
 from taskito import Queue
 from taskito.batching import BatchConfig, BatchedJobResult
+
+PollUntil = Any  # the conftest fixture's runtime type
 
 
 def test_batch_config_normalize_true_uses_defaults() -> None:
@@ -121,7 +123,9 @@ def test_cross_task_isolation(queue: Queue, run_worker: threading.Thread) -> Non
     assert sorted(b_received[0]) == [100, 200]
 
 
-def test_concurrent_adds_no_loss(queue: Queue, run_worker: threading.Thread) -> None:
+def test_concurrent_adds_no_loss(
+    queue: Queue, run_worker: threading.Thread, poll_until: PollUntil
+) -> None:
     """10 threads each enqueue 5 items; all 50 must reach the batch."""
     _ = run_worker
     received: list[int] = []
@@ -142,10 +146,7 @@ def test_concurrent_adds_no_loss(queue: Queue, run_worker: threading.Thread) -> 
     for t in threads:
         t.join()
 
-    deadline = time.time() + 5
-    while time.time() < deadline and len(received) < 50:
-        time.sleep(0.05)
-
+    poll_until(lambda: len(received) >= 50, timeout=5)
     queue.close()
     assert len(received) == 50
 

--- a/tests/core/test_canvas_sagas.py
+++ b/tests/core/test_canvas_sagas.py
@@ -3,12 +3,16 @@
 from __future__ import annotations
 
 import threading
+import time
 from collections.abc import Generator
 from pathlib import Path
+from typing import Any
 
 import pytest
 
 from taskito import MaxRetriesExceededError, Queue, TaskFailedError, chain, chord, group
+
+PollUntil = Any  # the conftest fixture's runtime type
 
 
 @pytest.fixture
@@ -91,7 +95,7 @@ def test_chain_with_compensation_rejects_invalid_compensator(queue: Queue) -> No
 # ── chain compensation ────────────────────────────────────────────────────
 
 
-def test_chain_failure_compensates_in_reverse_order(queue: Queue) -> None:
+def test_chain_failure_compensates_in_reverse_order(queue: Queue, poll_until: PollUntil) -> None:
     """3 steps; step 3 fails → compensators for step 2 and step 1 run in reverse."""
     lock = threading.Lock()
     order: list[str] = []
@@ -129,20 +133,7 @@ def test_chain_failure_compensates_in_reverse_order(queue: Queue) -> None:
         c.apply(queue)
 
     # Wait for compensator jobs to land (they're async dispatches).
-    deadline_lock = threading.Lock()
-
-    def wait_for_comps() -> None:
-        import time
-
-        for _ in range(60):
-            with deadline_lock:
-                pass
-            with lock:
-                if "comp_a" in order and "comp_b" in order:
-                    return
-            time.sleep(0.1)
-
-    wait_for_comps()
+    poll_until(lambda: "comp_a" in order and "comp_b" in order, timeout=6)
 
     with lock:
         assert "a" in order
@@ -185,8 +176,6 @@ def test_chain_success_runs_no_compensators(queue: Queue) -> None:
     assert result_job.result(timeout=30) == 2
 
     # Give the worker a moment to confirm no compensators dispatch.
-    import time
-
     time.sleep(0.5)
     with lock:
         assert comp_calls == [], f"no compensators should run on success: {comp_calls}"
@@ -195,7 +184,9 @@ def test_chain_success_runs_no_compensators(queue: Queue) -> None:
 # ── group compensation ────────────────────────────────────────────────────
 
 
-def test_group_member_failure_compensates_succeeded_members(queue: Queue) -> None:
+def test_group_member_failure_compensates_succeeded_members(
+    queue: Queue, poll_until: PollUntil
+) -> None:
     """3-member group; member 0 fails → comp for members 1 and 2 run."""
     lock = threading.Lock()
     order: list[str] = []
@@ -237,10 +228,8 @@ def test_group_member_failure_compensates_succeeded_members(queue: Queue) -> Non
     with pytest.raises((TaskFailedError, MaxRetriesExceededError)):
         g.apply(queue)
 
-    # Give compensators time to dispatch.
-    import time
-
-    time.sleep(2)
+    # Wait for compensators to dispatch.
+    poll_until(lambda: "comp_b" in order and "comp_c" in order, timeout=5)
     with lock:
         assert "m_fail" in order
         assert "m_ok_1" in order
@@ -253,7 +242,9 @@ def test_group_member_failure_compensates_succeeded_members(queue: Queue) -> Non
 # ── chord compensation ────────────────────────────────────────────────────
 
 
-def test_chord_callback_failure_compensates_group_members(queue: Queue) -> None:
+def test_chord_callback_failure_compensates_group_members(
+    queue: Queue, poll_until: PollUntil
+) -> None:
     """Group succeeds, callback fails → group compensators dispatch."""
     lock = threading.Lock()
     order: list[str] = []
@@ -296,9 +287,7 @@ def test_chord_callback_failure_compensates_group_members(queue: Queue) -> None:
     with pytest.raises((TaskFailedError, MaxRetriesExceededError)):
         ch.apply(queue)
 
-    import time
-
-    time.sleep(2)
+    poll_until(lambda: "comp_a" in order and "comp_b" in order, timeout=5)
     with lock:
         assert "m1" in order and "m2" in order, f"group must run: {order}"
         assert "cb" in order, f"callback must run: {order}"
@@ -339,8 +328,6 @@ def test_chord_group_failure_skips_callback_compensator(queue: Queue) -> None:
     with pytest.raises((TaskFailedError, MaxRetriesExceededError)):
         ch.apply(queue)
 
-    import time
-
     time.sleep(2)
     with lock:
         assert "cb" not in order, f"callback must not run on group failure: {order}"
@@ -352,7 +339,7 @@ def test_chord_group_failure_skips_callback_compensator(queue: Queue) -> None:
 # ── Idempotency (dedup via unique_key) ────────────────────────────────────
 
 
-def test_chain_compensator_idempotency_key_format(queue: Queue) -> None:
+def test_chain_compensator_idempotency_key_format(queue: Queue, poll_until: PollUntil) -> None:
     """Compensator enqueues use canvas_compensation:{run_id}:{slot} as unique_key.
 
     This isn't directly observable on a single apply() call (each apply
@@ -380,8 +367,6 @@ def test_chain_compensator_idempotency_key_format(queue: Queue) -> None:
     with pytest.raises((TaskFailedError, MaxRetriesExceededError)):
         c.apply(queue)
 
-    import time
-
-    time.sleep(2)
+    poll_until(lambda: comp_calls >= 1, timeout=5)
     with lock:
         assert comp_calls == 1, f"compensator must fire exactly once: {comp_calls}"

--- a/tests/core/test_rate_limit.py
+++ b/tests/core/test_rate_limit.py
@@ -2,11 +2,14 @@
 
 import threading
 import time
+from typing import Any
 
 from taskito import Queue
 
+PollUntil = Any  # the conftest fixture's runtime type
 
-def test_rate_limit_throttles(queue: Queue) -> None:
+
+def test_rate_limit_throttles(queue: Queue, poll_until: PollUntil) -> None:
     """Rate-limited tasks should be throttled."""
     timestamps: list[float] = []
 
@@ -26,7 +29,7 @@ def test_rate_limit_throttles(queue: Queue) -> None:
     worker_thread.start()
 
     # Wait for all tasks
-    time.sleep(5)
+    poll_until(lambda: len(timestamps) == 4, timeout=10)
 
     # Should have all 4 results
     assert len(timestamps) == 4

--- a/tests/observability/test_hooks.py
+++ b/tests/observability/test_hooks.py
@@ -7,6 +7,8 @@ from typing import Any
 
 from taskito import Queue
 
+PollUntil = Any  # the conftest fixture's runtime type
+
 
 def test_before_and_after_hooks(queue: Queue) -> None:
     """before_task and after_task hooks fire around task execution."""
@@ -59,7 +61,7 @@ def test_on_success_hook(queue: Queue) -> None:
     assert 12 in success_results
 
 
-def test_on_failure_hook(queue: Queue) -> None:
+def test_on_failure_hook(queue: Queue, poll_until: PollUntil) -> None:
     """on_failure hook fires when task raises."""
     failure_errors: list[str] = []
 
@@ -76,8 +78,5 @@ def test_on_failure_hook(queue: Queue) -> None:
     worker_thread = threading.Thread(target=queue.run_worker, daemon=True)
     worker_thread.start()
 
-    import time
-
-    time.sleep(3)
-
+    poll_until(lambda: len(failure_errors) > 0, timeout=5)
     assert any("boom" in e for e in failure_errors)

--- a/tests/python/test_predicates_enqueue.py
+++ b/tests/python/test_predicates_enqueue.py
@@ -16,6 +16,8 @@ from taskito.predicates import (
     PredicateContext,
 )
 
+PollUntil = Any  # the conftest fixture's runtime type
+
 
 @dataclass(frozen=True)
 class _Const(Predicate):
@@ -151,7 +153,7 @@ def test_metrics_record_outcomes(queue: Queue) -> None:
     assert snap["deferred"] == 1
 
 
-def test_defer_emits_predicate_deferred_event(queue: Queue) -> None:
+def test_defer_emits_predicate_deferred_event(queue: Queue, poll_until: PollUntil) -> None:
     from taskito.events import EventType
 
     received: list[dict] = []
@@ -163,17 +165,12 @@ def test_defer_emits_predicate_deferred_event(queue: Queue) -> None:
 
     t.delay()
     # Event bus dispatches in a thread pool — give it a moment.
-    import time
-
-    for _ in range(20):
-        if received:
-            break
-        time.sleep(0.05)
-    assert received and received[0]["defer_seconds"] == 99.0
+    poll_until(lambda: len(received) >= 1, timeout=2)
+    assert received[0]["defer_seconds"] == 99.0
     assert received[0]["phase"] == "enqueue"
 
 
-def test_cancel_emits_predicate_rejected_event(queue: Queue) -> None:
+def test_cancel_emits_predicate_rejected_event(queue: Queue, poll_until: PollUntil) -> None:
     from taskito.events import EventType
 
     received: list[dict] = []
@@ -186,10 +183,5 @@ def test_cancel_emits_predicate_rejected_event(queue: Queue) -> None:
     with pytest.raises(PredicateRejectedError):
         t.delay()
 
-    import time
-
-    for _ in range(20):
-        if received:
-            break
-        time.sleep(0.05)
-    assert received and received[0]["reason"] == "no good"
+    poll_until(lambda: len(received) >= 1, timeout=2)
+    assert received[0]["reason"] == "no good"


### PR DESCRIPTION
## Summary
- Replace 9 bare `time.sleep()` sites with the existing `poll_until` fixture across 5 test files
- Tests complete faster in the happy path while keeping hard timeouts for slow CI
- 2 `time.sleep` sites intentionally kept (negative assertions where we must wait a fixed period to confirm something did *not* happen)

## Test plan
- [ ] All modified tests pass individually
- [ ] Full test suite passes (`uv run python -m pytest tests/ -v`)
- [ ] `ruff check tests/` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by replacing fixed delays with dynamic polling mechanisms across concurrent batching, canvas saga compensation, rate limiting, hook failure, and event predicate tests, ensuring more robust asynchronous assertion handling with configurable timeouts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ByteVeda/taskito/pull/209?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->