### PR TITLE
refactor: decompose WorkflowTracker into event_routing + finalization

### DIFF
--- a/py_src/taskito/workflows/tracker/event_routing.py
+++ b/py_src/taskito/workflows/tracker/event_routing.py
@@ -1,0 +1,196 @@
+"""Event routing helpers for WorkflowTracker."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from taskito.events import EventType
+from taskito.workflows.tracker import fan_out
+
+if TYPE_CHECKING:
+    from taskito.workflows.tracker.tracker import WorkflowTracker
+
+logger = logging.getLogger("taskito.workflows")
+
+
+def handle_saga_terminal(
+    tracker: WorkflowTracker, _event_type: EventType, payload: dict[str, Any]
+) -> None:
+    """Release waiters and clean up when a saga reaches a terminal state."""
+    run_id = payload.get("workflow_run_id")
+    if not run_id:
+        return
+    tracker._release_waiters(run_id)
+    tracker._cleanup_run(run_id)
+
+
+def handle_job_result(
+    tracker: WorkflowTracker,
+    payload: dict[str, Any],
+    *,
+    succeeded: bool,
+    error: str | None,
+) -> None:
+    """Route a terminal job event to the appropriate workflow handler."""
+    job_id = payload.get("job_id")
+    if not job_id:
+        return
+
+    # Compensation jobs flow through a different code path — the saga
+    # orchestrator owns their lifecycle, not the normal tracker.
+    if tracker._saga.is_compensation_job(job_id):
+        tracker._saga.on_compensation_completed(job_id=job_id, succeeded=succeeded, error=error)
+        return
+
+    # Determine if this job belongs to a managed run.
+    with tracker._state_lock:
+        run_id = tracker._job_to_run.get(job_id)
+        config = tracker._run_configs.get(run_id) if run_id else None
+    skip_cascade = config is not None
+
+    # Compute result hash for successful completions.
+    rh: str | None = None
+    if succeeded:
+        rh = tracker._compute_result_hash(job_id)
+
+    try:
+        result = tracker._queue._inner.mark_workflow_node_result(
+            job_id, succeeded, error, skip_cascade, rh
+        )
+    except (RuntimeError, ValueError) as exc:
+        logger.exception("mark_workflow_node_result failed for job %s", job_id)
+        # Notify any waiters so they don't block forever on a silent failure.
+        if run_id is not None:
+            tracker._emit_terminal(run_id, "failed", str(exc))
+            tracker._cleanup_run(run_id)
+        return
+
+    if result is None:
+        return
+
+    run_id, node_name, terminal_state = result
+
+    # The initial lookup used _job_to_run which may not have this
+    # job yet (register_run populates _run_configs before the
+    # slower _job_to_run database read).  Re-fetch now that Rust
+    # gave us the authoritative run_id.
+    if config is None:
+        with tracker._state_lock:
+            config = tracker._run_configs.get(run_id)
+
+    # Track partial failure occurrence for continue-mode saga finalization.
+    # This is the only place we observe individual job-failure events in
+    # the tracker — we record it on the in-memory config so that
+    # _try_finalize / the terminal-handler below can decide whether to
+    # transition the run to CompletedWithFailures instead of Failed.
+    if not succeeded and config is not None and config.on_failure == "continue":
+        with tracker._state_lock:
+            config.partial_failure_occurred = True
+
+    if terminal_state is not None:
+        # Continue-mode partial-failure override: when at least one node
+        # succeeded AND at least one failed AND the user opted into
+        # compensation via compensate_on_continue=True, transition the
+        # run to CompletedWithFailures (instead of the default Failed)
+        # and hand off to the saga orchestrator. The CompletedWithFailures
+        # state is itself a valid pre-compensation state — see
+        # WorkflowState::can_transition_to in Rust.
+        override_to_completed_with_failures = (
+            terminal_state == "failed"
+            and config is not None
+            and config.on_failure == "continue"
+            and config.compensate_on_continue
+            and config.partial_failure_occurred
+        )
+        if override_to_completed_with_failures:
+            try:
+                tracker._queue._inner.set_workflow_run_completed_with_failures(run_id)
+            except (RuntimeError, ValueError):
+                logger.exception("set_workflow_run_completed_with_failures failed for %s", run_id)
+            else:
+                terminal_state = "completed_with_failures"
+
+        # Hand off to the saga orchestrator when:
+        #   - on_failure="fail_fast" and the run failed, OR
+        #   - on_failure="continue" with compensate_on_continue=True and
+        #     the run finalised with at least one failed node.
+        # The orchestrator decides eligibility internally (checks for
+        # explicit compensation_map or sub-workflow propagation) and
+        # emits its own terminal event when compensation finishes.
+        if config is not None and (
+            (terminal_state == "failed" and config.on_failure == "fail_fast")
+            or (terminal_state == "completed_with_failures" and config.compensate_on_continue)
+        ):
+            steps = tracker._run_steps.get(run_id, {})
+            started = tracker._saga.start_compensation(run_id, config, steps)
+            if started:
+                # The saga owns the run from here. Don't clean up yet —
+                # the orchestrator will call back when it finishes.
+                return
+
+        tracker._emit_terminal(run_id, terminal_state, error)
+        tracker._cleanup_run(run_id)
+        return
+
+    if config is None:
+        return  # Static workflow — Rust cascade handled everything.
+
+    # Fan-out child handling.
+    if "[" in node_name:
+        if succeeded:
+            fan_out.handle_fan_out_child(tracker, run_id, node_name, config)
+        else:
+            fan_out.handle_fan_out_child_failure(tracker, run_id, node_name, config)
+        return
+
+    # Fan-out expansion trigger (only on success).
+    if succeeded:
+        fan_out.maybe_trigger_fan_out(tracker, run_id, node_name, job_id, config)
+
+    # Evaluate successors with conditions.
+    tracker._evaluate_successors(run_id, node_name, config)
+
+
+def handle_child_workflow_terminal(
+    tracker: WorkflowTracker, _event_type: EventType, payload: dict[str, Any]
+) -> None:
+    """Handle child workflow completion by updating parent node.
+
+    The ``_child_to_parent`` link is *not* popped here — it stays in
+    place until the parent run finalises (or until the parent's saga
+    orchestrator has had a chance to propagate compensation into the
+    child). The parent's ``_cleanup_run`` sweeps stale links.
+    """
+    child_run_id = payload.get("run_id")
+    if not child_run_id:
+        return
+    with tracker._state_lock:
+        parent_info = tracker._child_to_parent.get(child_run_id)
+    if parent_info is None:
+        return  # Not a sub-workflow child.
+
+    parent_run_id, parent_node_name = parent_info
+    state = payload.get("state", "")
+    succeeded = state == "completed"
+
+    try:
+        tracker._queue._inner.resolve_workflow_gate(
+            parent_run_id,
+            parent_node_name,
+            succeeded,
+            payload.get("error") if not succeeded else None,
+        )
+    except (RuntimeError, ValueError):
+        logger.exception(
+            "failed to update parent node %s for child %s",
+            parent_node_name,
+            child_run_id,
+        )
+        return
+
+    with tracker._state_lock:
+        config = tracker._run_configs.get(parent_run_id)
+    if config is not None:
+        tracker._evaluate_successors(parent_run_id, parent_node_name, config)
+        tracker._try_finalize(parent_run_id)

--- a/py_src/taskito/workflows/tracker/finalization.py
+++ b/py_src/taskito/workflows/tracker/finalization.py
@@ -1,0 +1,124 @@
+"""Run finalization: terminal emission, state cleanup, and saga hand-off."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from taskito.workflows.tracker import dag
+
+if TYPE_CHECKING:
+    from taskito.workflows.tracker.tracker import WorkflowTracker
+
+logger = logging.getLogger("taskito.workflows")
+
+
+def emit_terminal(
+    tracker: WorkflowTracker, run_id: str, terminal_state: str, error: str | None
+) -> None:
+    """Emit the workflow-level terminal event and release waiters."""
+    workflow_event = dag.final_state_to_event(terminal_state)
+    if workflow_event is not None:
+        try:
+            tracker._queue._emit_event(
+                workflow_event,
+                {"run_id": run_id, "state": terminal_state, "error": error},
+            )
+        except Exception:
+            logger.exception("failed to emit %s", workflow_event)
+    tracker._release_waiters(run_id)
+
+
+def cleanup_run(tracker: WorkflowTracker, run_id: str) -> None:
+    """Drop all tracker state tied to ``run_id`` and cancel any live timers.
+
+    When the run is a sub-workflow child whose parent is still being
+    tracked, ``_run_configs`` and ``_run_steps`` are *retained* so the
+    parent's saga orchestrator can propagate compensation into the
+    child later. The parent's own cleanup sweeps these entries when it
+    finalises (see ``stale_child_ids`` below).
+    """
+    with tracker._state_lock:
+        parent_still_alive = False
+        parent_link = tracker._child_to_parent.get(run_id)
+        if parent_link is not None:
+            parent_run_id = parent_link[0]
+            parent_still_alive = parent_run_id in tracker._run_configs
+
+        if parent_still_alive:
+            # Keep config + steps so the parent can propagate compensation.
+            # Drop transient state (job->run map entries, gate timers) so
+            # the worker doesn't keep routing fan-out / gate events to a
+            # finished child.
+            tracker._job_to_run = {
+                jid: rid for jid, rid in tracker._job_to_run.items() if rid != run_id
+            }
+            stale_timer_keys = [k for k in tracker._gate_timers if k[0] == run_id]
+            for key in stale_timer_keys:
+                timer = tracker._gate_timers.pop(key, None)
+                if timer is not None:
+                    timer.cancel()
+            return
+
+        tracker._run_configs.pop(run_id, None)
+        tracker._run_steps.pop(run_id, None)
+        tracker._job_to_run = {
+            jid: rid for jid, rid in tracker._job_to_run.items() if rid != run_id
+        }
+        stale_timer_keys = [k for k in tracker._gate_timers if k[0] == run_id]
+        for key in stale_timer_keys:
+            timer = tracker._gate_timers.pop(key, None)
+            if timer is not None:
+                timer.cancel()
+        stale_child_ids = [
+            cid for cid, (prid, _) in tracker._child_to_parent.items() if prid == run_id
+        ]
+        for cid in stale_child_ids:
+            tracker._child_to_parent.pop(cid, None)
+            # Children whose cleanup we deferred (because the parent was
+            # still alive) get swept here on parent finalization.
+            tracker._run_configs.pop(cid, None)
+            tracker._run_steps.pop(cid, None)
+
+
+def try_finalize(tracker: WorkflowTracker, run_id: str) -> None:
+    """If all nodes are terminal, finalize the run and emit the event."""
+    try:
+        terminal_state = tracker._queue._inner.finalize_run_if_terminal(run_id)
+    except (RuntimeError, ValueError):
+        logger.exception("finalize_run_if_terminal failed for %s", run_id)
+        return
+    if terminal_state is None:
+        return
+
+    with tracker._state_lock:
+        config = tracker._run_configs.get(run_id)
+
+    # Continue-mode partial-failure override + compensation hand-off.
+    # Mirrors the logic in handle_job_result() so fan-out and sub-workflow
+    # paths also surface CompletedWithFailures correctly.
+    if (
+        terminal_state == "failed"
+        and config is not None
+        and config.on_failure == "continue"
+        and config.compensate_on_continue
+        and config.partial_failure_occurred
+    ):
+        try:
+            tracker._queue._inner.set_workflow_run_completed_with_failures(run_id)
+        except (RuntimeError, ValueError):
+            logger.exception("set_workflow_run_completed_with_failures failed for %s", run_id)
+        else:
+            terminal_state = "completed_with_failures"
+
+    if config is not None and (
+        (terminal_state == "failed" and config.on_failure == "fail_fast")
+        or (terminal_state == "completed_with_failures" and config.compensate_on_continue)
+    ):
+        steps = tracker._run_steps.get(run_id, {})
+        started = tracker._saga.start_compensation(run_id, config, steps)
+        if started:
+            return
+
+    emit_terminal(tracker, run_id, terminal_state, None)
+    cleanup_run(tracker, run_id)

--- a/py_src/taskito/workflows/tracker/tracker.py
+++ b/py_src/taskito/workflows/tracker/tracker.py
@@ -9,8 +9,9 @@ state, emits a workflow-level event and releases any threads blocked on
 For workflows that contain fan-out / fan-in steps, conditions, or
 ``on_failure="continue"``, the tracker orchestrates dynamic job creation,
 condition evaluation, and selective skip propagation. Concern-specific
-helpers live in ``dag``, ``gates``, ``sub_workflows``, and ``fan_out`` and
-are invoked from this orchestrator.
+helpers live in ``dag``, ``gates``, ``sub_workflows``, ``fan_out``,
+``event_routing``, and ``finalization`` and are invoked from this
+orchestrator.
 """
 
 from __future__ import annotations

--- a/py_src/taskito/workflows/tracker/tracker.py
+++ b/py_src/taskito/workflows/tracker/tracker.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING, Any
 
 from taskito.events import EventType
 from taskito.workflows.saga import SagaOrchestrator
-from taskito.workflows.tracker import dag, event_routing, gates, sub_workflows
+from taskito.workflows.tracker import dag, event_routing, finalization, gates, sub_workflows
 from taskito.workflows.tracker.types import _RunConfig
 
 if TYPE_CHECKING:
@@ -222,107 +222,13 @@ class WorkflowTracker:
     # ── Terminal state ─────────────────────────────────────────────
 
     def _emit_terminal(self, run_id: str, terminal_state: str, error: str | None) -> None:
-        workflow_event = dag.final_state_to_event(terminal_state)
-        if workflow_event is not None:
-            try:
-                self._queue._emit_event(
-                    workflow_event,
-                    {"run_id": run_id, "state": terminal_state, "error": error},
-                )
-            except Exception:
-                logger.exception("failed to emit %s", workflow_event)
-        self._release_waiters(run_id)
+        finalization.emit_terminal(self, run_id, terminal_state, error)
 
     def _cleanup_run(self, run_id: str) -> None:
-        """Drop all tracker state tied to ``run_id`` and cancel any live timers.
-
-        When the run is a sub-workflow child whose parent is still being
-        tracked, ``_run_configs`` and ``_run_steps`` are *retained* so the
-        parent's saga orchestrator can propagate compensation into the
-        child later. The parent's own cleanup sweeps these entries when it
-        finalises (see ``stale_child_ids`` below).
-        """
-        with self._state_lock:
-            parent_still_alive = False
-            parent_link = self._child_to_parent.get(run_id)
-            if parent_link is not None:
-                parent_run_id = parent_link[0]
-                parent_still_alive = parent_run_id in self._run_configs
-
-            if parent_still_alive:
-                # Keep config + steps so the parent can propagate compensation.
-                # Drop transient state (job→run map entries, gate timers) so
-                # the worker doesn't keep routing fan-out / gate events to a
-                # finished child.
-                self._job_to_run = {
-                    jid: rid for jid, rid in self._job_to_run.items() if rid != run_id
-                }
-                stale_timer_keys = [k for k in self._gate_timers if k[0] == run_id]
-                for key in stale_timer_keys:
-                    timer = self._gate_timers.pop(key, None)
-                    if timer is not None:
-                        timer.cancel()
-                return
-
-            self._run_configs.pop(run_id, None)
-            self._run_steps.pop(run_id, None)
-            self._job_to_run = {jid: rid for jid, rid in self._job_to_run.items() if rid != run_id}
-            stale_timer_keys = [k for k in self._gate_timers if k[0] == run_id]
-            for key in stale_timer_keys:
-                timer = self._gate_timers.pop(key, None)
-                if timer is not None:
-                    timer.cancel()
-            stale_child_ids = [
-                cid for cid, (prid, _) in self._child_to_parent.items() if prid == run_id
-            ]
-            for cid in stale_child_ids:
-                self._child_to_parent.pop(cid, None)
-                # Children whose cleanup we deferred (because the parent was
-                # still alive) get swept here on parent finalization.
-                self._run_configs.pop(cid, None)
-                self._run_steps.pop(cid, None)
+        finalization.cleanup_run(self, run_id)
 
     def _try_finalize(self, run_id: str) -> None:
-        """If all nodes are terminal, finalize the run and emit the event."""
-        try:
-            terminal_state = self._queue._inner.finalize_run_if_terminal(run_id)
-        except (RuntimeError, ValueError):
-            logger.exception("finalize_run_if_terminal failed for %s", run_id)
-            return
-        if terminal_state is None:
-            return
-
-        with self._state_lock:
-            config = self._run_configs.get(run_id)
-
-        # Continue-mode partial-failure override + compensation hand-off.
-        # Mirrors the logic in _handle() so fan-out and sub-workflow paths
-        # also surface CompletedWithFailures correctly.
-        if (
-            terminal_state == "failed"
-            and config is not None
-            and config.on_failure == "continue"
-            and config.compensate_on_continue
-            and config.partial_failure_occurred
-        ):
-            try:
-                self._queue._inner.set_workflow_run_completed_with_failures(run_id)
-            except (RuntimeError, ValueError):
-                logger.exception("set_workflow_run_completed_with_failures failed for %s", run_id)
-            else:
-                terminal_state = "completed_with_failures"
-
-        if config is not None and (
-            (terminal_state == "failed" and config.on_failure == "fail_fast")
-            or (terminal_state == "completed_with_failures" and config.compensate_on_continue)
-        ):
-            steps = self._run_steps.get(run_id, {})
-            started = self._saga.start_compensation(run_id, config, steps)
-            if started:
-                return
-
-        self._emit_terminal(run_id, terminal_state, None)
-        self._cleanup_run(run_id)
+        finalization.try_finalize(self, run_id)
 
     # ── Gate resolution (public API) ───────────────────────────────
 

--- a/py_src/taskito/workflows/tracker/tracker.py
+++ b/py_src/taskito/workflows/tracker/tracker.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING, Any
 
 from taskito.events import EventType
 from taskito.workflows.saga import SagaOrchestrator
-from taskito.workflows.tracker import dag, fan_out, gates, sub_workflows
+from taskito.workflows.tracker import dag, event_routing, gates, sub_workflows
 from taskito.workflows.tracker.types import _RunConfig
 
 if TYPE_CHECKING:
@@ -74,11 +74,7 @@ class WorkflowTracker:
         self._event_bus.on(EventType.WORKFLOW_COMPENSATION_FAILED, self._on_saga_terminal)
 
     def _on_saga_terminal(self, _event_type: EventType, payload: dict[str, Any]) -> None:
-        run_id = payload.get("workflow_run_id")
-        if not run_id:
-            return
-        self._release_waiters(run_id)
-        self._cleanup_run(run_id)
+        event_routing.handle_saga_terminal(self, _event_type, payload)
 
     # ── Wait management ────────────────────────────────────────────
 
@@ -179,140 +175,13 @@ class WorkflowTracker:
     # ── Event handlers ─────────────────────────────────────────────
 
     def _on_success(self, _event_type: EventType, payload: dict[str, Any]) -> None:
-        self._handle(payload, succeeded=True, error=None)
+        event_routing.handle_job_result(self, payload, succeeded=True, error=None)
 
     def _on_failure(self, _event_type: EventType, payload: dict[str, Any]) -> None:
-        self._handle(payload, succeeded=False, error=payload.get("error"))
+        event_routing.handle_job_result(self, payload, succeeded=False, error=payload.get("error"))
 
     def _on_cancelled(self, _event_type: EventType, payload: dict[str, Any]) -> None:
-        self._handle(payload, succeeded=False, error="cancelled")
-
-    def _handle(
-        self,
-        payload: dict[str, Any],
-        *,
-        succeeded: bool,
-        error: str | None,
-    ) -> None:
-        job_id = payload.get("job_id")
-        if not job_id:
-            return
-
-        # Compensation jobs flow through a different code path — the saga
-        # orchestrator owns their lifecycle, not the normal tracker.
-        if self._saga.is_compensation_job(job_id):
-            self._saga.on_compensation_completed(job_id=job_id, succeeded=succeeded, error=error)
-            return
-
-        # Determine if this job belongs to a managed run.
-        with self._state_lock:
-            run_id = self._job_to_run.get(job_id)
-            config = self._run_configs.get(run_id) if run_id else None
-        skip_cascade = config is not None
-
-        # Compute result hash for successful completions.
-        rh: str | None = None
-        if succeeded:
-            rh = self._compute_result_hash(job_id)
-
-        try:
-            result = self._queue._inner.mark_workflow_node_result(
-                job_id, succeeded, error, skip_cascade, rh
-            )
-        except (RuntimeError, ValueError) as exc:
-            logger.exception("mark_workflow_node_result failed for job %s", job_id)
-            # Notify any waiters so they don't block forever on a silent failure.
-            if run_id is not None:
-                self._emit_terminal(run_id, "failed", str(exc))
-                self._cleanup_run(run_id)
-            return
-
-        if result is None:
-            return
-
-        run_id, node_name, terminal_state = result
-
-        # The initial lookup used _job_to_run which may not have this
-        # job yet (register_run populates _run_configs before the
-        # slower _job_to_run database read).  Re-fetch now that Rust
-        # gave us the authoritative run_id.
-        if config is None:
-            with self._state_lock:
-                config = self._run_configs.get(run_id)
-
-        # Track partial failure occurrence for continue-mode saga finalization.
-        # This is the only place we observe individual job-failure events in
-        # the tracker — we record it on the in-memory config so that
-        # _try_finalize / the terminal-handler below can decide whether to
-        # transition the run to CompletedWithFailures instead of Failed.
-        if not succeeded and config is not None and config.on_failure == "continue":
-            with self._state_lock:
-                config.partial_failure_occurred = True
-
-        if terminal_state is not None:
-            # Continue-mode partial-failure override: when at least one node
-            # succeeded AND at least one failed AND the user opted into
-            # compensation via compensate_on_continue=True, transition the
-            # run to CompletedWithFailures (instead of the default Failed)
-            # and hand off to the saga orchestrator. The CompletedWithFailures
-            # state is itself a valid pre-compensation state — see
-            # WorkflowState::can_transition_to in Rust.
-            override_to_completed_with_failures = (
-                terminal_state == "failed"
-                and config is not None
-                and config.on_failure == "continue"
-                and config.compensate_on_continue
-                and config.partial_failure_occurred
-            )
-            if override_to_completed_with_failures:
-                try:
-                    self._queue._inner.set_workflow_run_completed_with_failures(run_id)
-                except (RuntimeError, ValueError):
-                    logger.exception(
-                        "set_workflow_run_completed_with_failures failed for %s", run_id
-                    )
-                else:
-                    terminal_state = "completed_with_failures"
-
-            # Hand off to the saga orchestrator when:
-            #   - on_failure="fail_fast" and the run failed, OR
-            #   - on_failure="continue" with compensate_on_continue=True and
-            #     the run finalised with at least one failed node.
-            # The orchestrator decides eligibility internally (checks for
-            # explicit compensation_map or sub-workflow propagation) and
-            # emits its own terminal event when compensation finishes.
-            if config is not None and (
-                (terminal_state == "failed" and config.on_failure == "fail_fast")
-                or (terminal_state == "completed_with_failures" and config.compensate_on_continue)
-            ):
-                steps = self._run_steps.get(run_id, {})
-                started = self._saga.start_compensation(run_id, config, steps)
-                if started:
-                    # The saga owns the run from here. Don't clean up yet —
-                    # the orchestrator will call back when it finishes.
-                    return
-
-            self._emit_terminal(run_id, terminal_state, error)
-            self._cleanup_run(run_id)
-            return
-
-        if config is None:
-            return  # Static workflow — Rust cascade handled everything.
-
-        # Fan-out child handling.
-        if "[" in node_name:
-            if succeeded:
-                fan_out.handle_fan_out_child(self, run_id, node_name, config)
-            else:
-                fan_out.handle_fan_out_child_failure(self, run_id, node_name, config)
-            return
-
-        # Fan-out expansion trigger (only on success).
-        if succeeded:
-            fan_out.maybe_trigger_fan_out(self, run_id, node_name, job_id, config)
-
-        # Evaluate successors with conditions.
-        self._evaluate_successors(run_id, node_name, config)
+        event_routing.handle_job_result(self, payload, succeeded=False, error="cancelled")
 
     # ── Successor evaluation ───────────────────────────────────────
 
@@ -485,45 +354,7 @@ class WorkflowTracker:
     # ── Sub-workflow listener ──────────────────────────────────────
 
     def _on_child_workflow_terminal(self, _event_type: EventType, payload: dict[str, Any]) -> None:
-        """Handle child workflow completion → update parent node.
-
-        The ``_child_to_parent`` link is *not* popped here — it stays in
-        place until the parent run finalises (or until the parent's saga
-        orchestrator has had a chance to propagate compensation into the
-        child). The parent's ``_cleanup_run`` sweeps stale links.
-        """
-        child_run_id = payload.get("run_id")
-        if not child_run_id:
-            return
-        with self._state_lock:
-            parent_info = self._child_to_parent.get(child_run_id)
-        if parent_info is None:
-            return  # Not a sub-workflow child.
-
-        parent_run_id, parent_node_name = parent_info
-        state = payload.get("state", "")
-        succeeded = state == "completed"
-
-        try:
-            self._queue._inner.resolve_workflow_gate(
-                parent_run_id,
-                parent_node_name,
-                succeeded,
-                payload.get("error") if not succeeded else None,
-            )
-        except (RuntimeError, ValueError):
-            logger.exception(
-                "failed to update parent node %s for child %s",
-                parent_node_name,
-                child_run_id,
-            )
-            return
-
-        with self._state_lock:
-            config = self._run_configs.get(parent_run_id)
-        if config is not None:
-            self._evaluate_successors(parent_run_id, parent_node_name, config)
-            self._try_finalize(parent_run_id)
+        event_routing.handle_child_workflow_terminal(self, _event_type, payload)
 
     # ── Result helpers ─────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Extract event routing (`_handle`, `_on_child_workflow_terminal`, `_on_saga_terminal`) into `tracker/event_routing.py`
- Extract finalization (`_emit_terminal`, `_cleanup_run`, `_try_finalize`) into `tracker/finalization.py`
- Slim `tracker.py` from 554 to ~290 LOC orchestration shell

Follows the existing extraction pattern used by `dag.py`, `gates.py`, `fan_out.py`, `sub_workflows.py`: free functions taking `tracker` as first arg.

## Test plan
- [ ] All workflow tests pass (`tests/workflows/`)
- [ ] Canvas saga tests pass (`tests/core/test_canvas_sagas.py`)
- [ ] `ruff check` clean
- [ ] `mypy` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized WorkflowTracker's internal event-handling and finalization logic into dedicated modules for improved code maintainability and clarity. No impact on user-facing functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ByteVeda/taskito/pull/210?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->