### PR TITLE
ci: add workflow_dispatch trigger to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
   rust-test:
     name: Rust Tests (SQLite)
     needs: changes
-    if: needs.changes.outputs.rust == 'true' || github.event_name == 'push'
+    if: needs.changes.outputs.rust == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
@@ -134,7 +134,7 @@ jobs:
   rust-test-postgres:
     name: Rust Tests (PostgreSQL)
     needs: changes
-    if: needs.changes.outputs.rust == 'true' || github.event_name == 'push'
+    if: needs.changes.outputs.rust == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -178,7 +178,7 @@ jobs:
   rust-test-redis:
     name: Rust Tests (Redis)
     needs: changes
-    if: needs.changes.outputs.rust == 'true' || github.event_name == 'push'
+    if: needs.changes.outputs.rust == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     services:
       redis:
@@ -218,7 +218,7 @@ jobs:
   test:
     name: Python Tests (${{ matrix.os }} / Python ${{ matrix.python-version }})
     needs: [lint, changes]
-    if: needs.changes.outputs.python == 'true' || github.event_name == 'push'
+    if: needs.changes.outputs.python == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ${{ matrix.os }}
     env:
       # setup-python on macOS upgrades certifi via pip; pip's HTTP cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+  # Allow manual re-triggers from the GitHub UI or `gh workflow run` —
+  # useful when master squash-merges arrive back-to-back and concurrency
+  # cancellations leave the latest master HEAD without a CI run.
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
- Add \`workflow_dispatch\` trigger to \`.github/workflows/ci.yml\` so CI can be re-run manually from the GitHub UI or via \`gh workflow run\`. Useful when back-to-back squash merges land on master and the concurrency cancellation policy leaves master HEAD without a green CI run.
- Drop the pin on \`PyO3/maturin-action@v1.51.0\` (back to floating \`v1\`) and remove the \`maturin-version: v1.13.3\` override now that upstream is stable.

## Test plan
- [ ] CI passes on this PR (the workflow_dispatch addition does not affect pull_request or push triggers)
- [ ] After merge, manually trigger via \`gh workflow run ci.yml -r master\` and confirm a green run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow updated to support manual triggering and to allow backend and Python test suites to run when manually triggered.
  * Documentation comments added to clarify manual re-run usage.

Note: Internal infrastructure change with no user-facing impact.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ByteVeda/taskito/pull/211?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->