### PR TITLE
test: add Rust coverage for workflow_ops + remove dead cache

### DIFF
--- a/crates/taskito-core/src/scheduler/mod.rs
+++ b/crates/taskito-core/src/scheduler/mod.rs
@@ -120,34 +120,6 @@ pub struct QueueConfig {
     pub max_concurrent: Option<i32>,
 }
 
-/// In-memory cache of average task execution duration.
-/// Updated on every `handle_result()` — no DB queries needed.
-struct TaskDurationCache {
-    durations: HashMap<String, (u64, i64)>, // (count, sum_ns)
-}
-
-impl TaskDurationCache {
-    fn new() -> Self {
-        Self {
-            durations: HashMap::new(),
-        }
-    }
-
-    fn record(&mut self, task_name: &str, wall_time_ns: i64) {
-        let entry = self.durations.entry(task_name.to_string()).or_default();
-        entry.0 += 1;
-        entry.1 = entry.1.saturating_add(wall_time_ns);
-    }
-
-    #[allow(dead_code)]
-    fn avg_ns(&self, task_name: &str) -> Option<i64> {
-        self.durations
-            .get(task_name)
-            .filter(|(count, _)| *count > 0)
-            .map(|(count, sum)| sum / *count as i64)
-    }
-}
-
 /// The central scheduler that coordinates job dispatch, retries, rate limiting, and circuit breakers.
 pub struct Scheduler {
     storage: StorageBackend,
@@ -161,7 +133,6 @@ pub struct Scheduler {
     shutdown: Arc<Notify>,
     paused_cache: Mutex<(HashSet<String>, Instant)>,
     namespace: Option<String>,
-    duration_cache: Mutex<TaskDurationCache>,
 }
 
 /// Counters for tick-based scheduling of periodic maintenance tasks.
@@ -195,7 +166,6 @@ impl Scheduler {
             shutdown: Arc::new(Notify::new()),
             paused_cache: Mutex::new((HashSet::new(), Instant::now())),
             namespace,
-            duration_cache: Mutex::new(TaskDurationCache::new()),
         }
     }
 

--- a/crates/taskito-core/src/scheduler/result_handler.rs
+++ b/crates/taskito-core/src/scheduler/result_handler.rs
@@ -36,11 +36,6 @@ impl Scheduler {
                     error!("circuit breaker error for {task_name}: {e}");
                 }
 
-                // Update in-memory duration cache for smart scheduling
-                if let Ok(mut cache) = self.duration_cache.lock() {
-                    cache.record(task_name, wall_time_ns);
-                }
-
                 Ok(ResultOutcome::Success {
                     job_id,
                     task_name: task_name.clone(),
@@ -74,11 +69,6 @@ impl Scheduler {
 
                 if let Err(e) = self.circuit_breaker.record_failure(&task_name) {
                     log::error!("circuit breaker error for {task_name}: {e}");
-                }
-
-                // Update in-memory duration cache for smart scheduling
-                if let Ok(mut cache) = self.duration_cache.lock() {
-                    cache.record(&task_name, wall_time_ns);
                 }
 
                 // One fetch serves both the queue-context lookup and any

--- a/crates/taskito-python/src/py_queue/workflow_ops/fan_out.rs
+++ b/crates/taskito-python/src/py_queue/workflow_ops/fan_out.rs
@@ -220,3 +220,290 @@ impl PyQueue {
         result.map_err(|e| PyRuntimeError::new_err(e.to_string()))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::py_queue::workflow_ops::test_helpers::*;
+
+    /// Mismatched lengths surface as a `PyValueError`. Caller-side bug, not a
+    /// silent partial expansion.
+    #[test]
+    fn expand_fan_out_rejects_mismatched_lengths() {
+        pyo3::prepare_freethreaded_python();
+        pyo3::Python::with_gil(|py| {
+            let queue = make_test_pyqueue();
+            let wf = wf_storage(&queue);
+            let run_id = seed_run(wf);
+            seed_node(wf, &run_id, "parent", WorkflowNodeStatus::Pending, None);
+
+            let result = queue.expand_fan_out(
+                py,
+                &run_id,
+                "parent",
+                vec!["child[0]".to_string()],
+                vec![vec![1u8, 2, 3], vec![4u8, 5, 6]],
+                "task_child",
+                "default",
+                3,
+                300_000,
+                0,
+            );
+            let err = match result {
+                Err(e) => e,
+                Ok(_) => panic!("expected PyValueError for length mismatch"),
+            };
+            assert!(err.to_string().contains("same length"));
+        });
+    }
+
+    /// Empty child list short-circuits to a `Completed` parent — there is
+    /// nothing to wait on. No child jobs are enqueued.
+    #[test]
+    fn expand_fan_out_completes_parent_immediately_on_empty_children() {
+        pyo3::prepare_freethreaded_python();
+        pyo3::Python::with_gil(|py| {
+            let queue = make_test_pyqueue();
+            let wf = wf_storage(&queue);
+            let run_id = seed_run(wf);
+            seed_node(wf, &run_id, "parent", WorkflowNodeStatus::Pending, None);
+
+            let ids = queue
+                .expand_fan_out(
+                    py,
+                    &run_id,
+                    "parent",
+                    Vec::new(),
+                    Vec::new(),
+                    "task_child",
+                    "default",
+                    3,
+                    300_000,
+                    0,
+                )
+                .unwrap();
+            assert!(ids.is_empty());
+
+            let parent = fetch_node(wf, &run_id, "parent");
+            assert_eq!(parent.status, WorkflowNodeStatus::Completed);
+            assert_eq!(parent.fan_out_count, Some(0));
+            assert!(parent.completed_at.is_some());
+        });
+    }
+
+    /// Non-empty fan-out creates a child node and job per entry, sets the
+    /// parent's `fan_out_count`, and returns the child job ids in order.
+    #[test]
+    fn expand_fan_out_creates_children_and_records_count() {
+        pyo3::prepare_freethreaded_python();
+        pyo3::Python::with_gil(|py| {
+            let queue = make_test_pyqueue();
+            let wf = wf_storage(&queue);
+            let run_id = seed_run(wf);
+            seed_node(wf, &run_id, "parent", WorkflowNodeStatus::Pending, None);
+
+            let child_names = vec!["parent[0]".to_string(), "parent[1]".to_string()];
+            let child_payloads = vec![vec![1u8], vec![2u8]];
+
+            let ids = queue
+                .expand_fan_out(
+                    py,
+                    &run_id,
+                    "parent",
+                    child_names.clone(),
+                    child_payloads,
+                    "task_child",
+                    "default",
+                    3,
+                    300_000,
+                    0,
+                )
+                .unwrap();
+            assert_eq!(ids.len(), 2);
+
+            let nodes = wf.get_workflow_nodes(&run_id).unwrap();
+            for name in &child_names {
+                let node = nodes
+                    .iter()
+                    .find(|n| &n.node_name == name)
+                    .unwrap_or_else(|| panic!("child node {name} missing"));
+                assert_eq!(node.status, WorkflowNodeStatus::Pending);
+                assert!(node.job_id.is_some());
+            }
+
+            // The parent's fan_out_count is updated; the parent stays in its
+            // prior status because the tracker is responsible for promoting it
+            // separately (mirrors the production path).
+            let parent = fetch_node(wf, &run_id, "parent");
+            assert_eq!(parent.fan_out_count, Some(2));
+        });
+    }
+
+    /// `create_deferred_job` enqueues a job and binds it to the named node.
+    #[test]
+    fn create_deferred_job_enqueues_and_attaches_to_node() {
+        pyo3::prepare_freethreaded_python();
+        pyo3::Python::with_gil(|py| {
+            let queue = make_test_pyqueue();
+            let wf = wf_storage(&queue);
+            let run_id = seed_run(wf);
+            seed_node(wf, &run_id, "deferred", WorkflowNodeStatus::Pending, None);
+
+            let job_id = queue
+                .create_deferred_job(
+                    py,
+                    &run_id,
+                    "deferred",
+                    vec![9u8, 9, 9],
+                    "task_deferred",
+                    "default",
+                    3,
+                    300_000,
+                    0,
+                )
+                .unwrap();
+
+            let job = queue.storage.get_job(&job_id).unwrap().unwrap();
+            assert_eq!(job.task_name, "task_deferred");
+            assert!(job
+                .metadata
+                .as_deref()
+                .unwrap_or("")
+                .contains("workflow_run_id"));
+
+            let node = fetch_node(wf, &run_id, "deferred");
+            assert_eq!(node.job_id.as_deref(), Some(job_id.as_str()));
+        });
+    }
+
+    /// `check_fan_out_completion` returns `None` while any child is still
+    /// non-terminal.
+    #[test]
+    fn check_fan_out_completion_returns_none_while_children_running() {
+        pyo3::prepare_freethreaded_python();
+        pyo3::Python::with_gil(|py| {
+            let queue = make_test_pyqueue();
+            let wf = wf_storage(&queue);
+            let run_id = seed_run(wf);
+            seed_node(wf, &run_id, "parent", WorkflowNodeStatus::Running, None);
+            seed_node(
+                wf,
+                &run_id,
+                "parent[0]",
+                WorkflowNodeStatus::Completed,
+                None,
+            );
+            seed_node(wf, &run_id, "parent[1]", WorkflowNodeStatus::Running, None);
+
+            let outcome = queue
+                .check_fan_out_completion(py, &run_id, "parent")
+                .unwrap();
+            assert!(outcome.is_none());
+        });
+    }
+
+    /// All-success children finalize the parent as `Completed` exactly once
+    /// and return `(true, child_job_ids)`.
+    #[test]
+    fn check_fan_out_completion_finalizes_parent_on_all_success() {
+        pyo3::prepare_freethreaded_python();
+        pyo3::Python::with_gil(|py| {
+            let queue = make_test_pyqueue();
+            let wf = wf_storage(&queue);
+            let run_id = seed_run(wf);
+            seed_node(wf, &run_id, "parent", WorkflowNodeStatus::Running, None);
+            let j0 = enqueue_test_job(&queue.storage, "task_child_0");
+            let j1 = enqueue_test_job(&queue.storage, "task_child_1");
+            seed_node(
+                wf,
+                &run_id,
+                "parent[0]",
+                WorkflowNodeStatus::Completed,
+                Some(j0.clone()),
+            );
+            seed_node(
+                wf,
+                &run_id,
+                "parent[1]",
+                WorkflowNodeStatus::Completed,
+                Some(j1.clone()),
+            );
+
+            let outcome = queue
+                .check_fan_out_completion(py, &run_id, "parent")
+                .unwrap()
+                .expect("first caller transitions the parent");
+            assert!(outcome.0, "all-success path returns true");
+            let mut ids = outcome.1;
+            ids.sort();
+            let mut expected = vec![j0, j1];
+            expected.sort();
+            assert_eq!(ids, expected);
+
+            // The second caller observes the parent already finalized and
+            // returns `None` rather than double-firing the success path.
+            let again = queue
+                .check_fan_out_completion(py, &run_id, "parent")
+                .unwrap();
+            assert!(again.is_none());
+        });
+    }
+
+    /// Any failed child finalizes the parent as `Failed` and reports
+    /// `(false, child_job_ids)`.
+    #[test]
+    fn check_fan_out_completion_finalizes_parent_as_failed_on_any_failure() {
+        pyo3::prepare_freethreaded_python();
+        pyo3::Python::with_gil(|py| {
+            let queue = make_test_pyqueue();
+            let wf = wf_storage(&queue);
+            let run_id = seed_run(wf);
+            seed_node(wf, &run_id, "parent", WorkflowNodeStatus::Running, None);
+            seed_node(
+                wf,
+                &run_id,
+                "parent[0]",
+                WorkflowNodeStatus::Completed,
+                Some(enqueue_test_job(&queue.storage, "task_child_0")),
+            );
+            seed_node(
+                wf,
+                &run_id,
+                "parent[1]",
+                WorkflowNodeStatus::Failed,
+                Some(enqueue_test_job(&queue.storage, "task_child_1")),
+            );
+
+            let outcome = queue
+                .check_fan_out_completion(py, &run_id, "parent")
+                .unwrap()
+                .expect("first caller transitions the parent");
+            assert!(!outcome.0, "failure path returns false");
+
+            let parent = fetch_node(wf, &run_id, "parent");
+            assert_eq!(parent.status, WorkflowNodeStatus::Failed);
+        });
+    }
+
+    /// A fan-out parent with no children yet (e.g. expansion not run) leaves
+    /// `check_fan_out_completion` returning `None` rather than promoting the
+    /// parent on a zero-child set.
+    #[test]
+    fn check_fan_out_completion_is_noop_when_no_children_exist() {
+        pyo3::prepare_freethreaded_python();
+        pyo3::Python::with_gil(|py| {
+            let queue = make_test_pyqueue();
+            let wf = wf_storage(&queue);
+            let run_id = seed_run(wf);
+            seed_node(wf, &run_id, "parent", WorkflowNodeStatus::Running, None);
+
+            let outcome = queue
+                .check_fan_out_completion(py, &run_id, "parent")
+                .unwrap();
+            assert!(outcome.is_none());
+
+            let parent = fetch_node(wf, &run_id, "parent");
+            assert_eq!(parent.status, WorkflowNodeStatus::Running);
+        });
+    }
+}

--- a/crates/taskito-python/src/py_queue/workflow_ops/lifecycle.rs
+++ b/crates/taskito-python/src/py_queue/workflow_ops/lifecycle.rs
@@ -352,3 +352,312 @@ impl PyQueue {
         result.map_err(|e| PyRuntimeError::new_err(e.to_string()))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::py_queue::workflow_ops::test_helpers::*;
+
+    /// Submitting a 2-node linear DAG inserts a node per step, enqueues a job
+    /// per step, and threads the predecessor's job id through the successor's
+    /// `depends_on` chain.
+    #[test]
+    fn submit_workflow_links_linear_dag_via_depends_on() {
+        pyo3::prepare_freethreaded_python();
+        pyo3::Python::with_gil(|_py| {
+            let queue = make_test_pyqueue();
+            let dag = make_dag_bytes(&["a", "b"], &[("a", "b")]);
+            let metadata = make_step_metadata_json(&[("a", "task_a"), ("b", "task_b")]);
+            let payloads = make_node_payloads(&["a", "b"]);
+
+            let handle = queue
+                .submit_workflow(
+                    "linear", 1, dag, &metadata, payloads, "default", None, None, None, None, None,
+                )
+                .unwrap();
+
+            let wf = wf_storage(&queue);
+            let mut nodes = wf.get_workflow_nodes(&handle.run_id).unwrap();
+            nodes.sort_by(|x, y| x.node_name.cmp(&y.node_name));
+            assert_eq!(nodes.len(), 2);
+            assert_eq!(nodes[0].node_name, "a");
+            assert_eq!(nodes[1].node_name, "b");
+
+            let a_job_id = nodes[0].job_id.clone().expect("node a has a job");
+            let b_job_id = nodes[1].job_id.clone().expect("node b has a job");
+
+            let b_deps = queue.storage.get_dependencies(&b_job_id).unwrap();
+            assert_eq!(b_deps, vec![a_job_id]);
+
+            let run = wf.get_workflow_run(&handle.run_id).unwrap().unwrap();
+            assert_eq!(run.state, WorkflowState::Running);
+        });
+    }
+
+    /// Nodes listed in `deferred_node_names` get a `WorkflowNode` but no job;
+    /// downstream successors omit the deferred predecessor from `depends_on`.
+    #[test]
+    fn submit_workflow_skips_job_creation_for_deferred_nodes() {
+        pyo3::prepare_freethreaded_python();
+        pyo3::Python::with_gil(|_py| {
+            let queue = make_test_pyqueue();
+            let dag = make_dag_bytes(&["a", "b"], &[("a", "b")]);
+            let metadata = make_step_metadata_json(&[("a", "task_a"), ("b", "task_b")]);
+            let payloads = make_node_payloads(&["a", "b"]);
+
+            let handle = queue
+                .submit_workflow(
+                    "deferred",
+                    1,
+                    dag,
+                    &metadata,
+                    payloads,
+                    "default",
+                    None,
+                    Some(vec!["a".to_string()]),
+                    None,
+                    None,
+                    None,
+                )
+                .unwrap();
+
+            let wf = wf_storage(&queue);
+            let nodes = wf.get_workflow_nodes(&handle.run_id).unwrap();
+            let a = nodes.iter().find(|n| n.node_name == "a").unwrap();
+            let b = nodes.iter().find(|n| n.node_name == "b").unwrap();
+
+            assert!(a.job_id.is_none(), "deferred node must not enqueue a job");
+            assert_eq!(a.status, WorkflowNodeStatus::Pending);
+
+            let b_job_id = b.job_id.clone().expect("non-deferred node enqueues a job");
+            let b_deps = queue.storage.get_dependencies(&b_job_id).unwrap();
+            assert!(
+                b_deps.is_empty(),
+                "successor must drop the deferred predecessor from depends_on"
+            );
+        });
+    }
+
+    /// Cache-hit nodes copy a `result_hash` from a previous run, skip job
+    /// creation, and land in `CacheHit` state with a `completed_at` timestamp.
+    /// The incremental layer only marks leaf-style nodes (no successors that
+    /// need a real job id) as cache hits, so the test mirrors that invariant.
+    #[test]
+    fn submit_workflow_marks_cache_hit_nodes_terminal_without_job() {
+        pyo3::prepare_freethreaded_python();
+        pyo3::Python::with_gil(|_py| {
+            let queue = make_test_pyqueue();
+            let dag = make_dag_bytes(&["a"], &[]);
+            let metadata = make_step_metadata_json(&[("a", "task_a")]);
+            let payloads = make_node_payloads(&["a"]);
+            let mut cache = HashMap::new();
+            cache.insert("a".to_string(), "hash-of-a".to_string());
+
+            let handle = queue
+                .submit_workflow(
+                    "cached",
+                    1,
+                    dag,
+                    &metadata,
+                    payloads,
+                    "default",
+                    None,
+                    None,
+                    None,
+                    None,
+                    Some(cache),
+                )
+                .unwrap();
+
+            let wf = wf_storage(&queue);
+            let nodes = wf.get_workflow_nodes(&handle.run_id).unwrap();
+            let a = nodes.iter().find(|n| n.node_name == "a").unwrap();
+
+            assert!(a.job_id.is_none());
+            assert_eq!(a.status, WorkflowNodeStatus::CacheHit);
+            assert_eq!(a.result_hash.as_deref(), Some("hash-of-a"));
+            assert!(a.completed_at.is_some());
+        });
+    }
+
+    /// A reused `(name, version)` returns the same definition id rather than
+    /// inserting a duplicate row.
+    #[test]
+    fn submit_workflow_reuses_existing_definition_by_name_and_version() {
+        pyo3::prepare_freethreaded_python();
+        pyo3::Python::with_gil(|_py| {
+            let queue = make_test_pyqueue();
+            let dag = make_dag_bytes(&["a"], &[]);
+            let metadata = make_step_metadata_json(&[("a", "task_a")]);
+
+            let first = queue
+                .submit_workflow(
+                    "reused",
+                    1,
+                    dag.clone(),
+                    &metadata,
+                    make_node_payloads(&["a"]),
+                    "default",
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                )
+                .unwrap();
+            let second = queue
+                .submit_workflow(
+                    "reused",
+                    1,
+                    dag,
+                    &metadata,
+                    make_node_payloads(&["a"]),
+                    "default",
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                )
+                .unwrap();
+
+            assert_eq!(first.definition_id, second.definition_id);
+            assert_ne!(first.run_id, second.run_id);
+        });
+    }
+
+    /// Missing `step_metadata` for a non-deferred, non-cached node is a
+    /// `PyValueError` — callers must supply per-step task config.
+    #[test]
+    fn submit_workflow_rejects_missing_step_metadata() {
+        pyo3::prepare_freethreaded_python();
+        pyo3::Python::with_gil(|_py| {
+            let queue = make_test_pyqueue();
+            let dag = make_dag_bytes(&["a", "b"], &[("a", "b")]);
+            // step_metadata only describes 'a' — 'b' is intentionally missing.
+            let metadata = make_step_metadata_json(&[("a", "task_a")]);
+            let payloads = make_node_payloads(&["a", "b"]);
+
+            let result = queue.submit_workflow(
+                "broken", 1, dag, &metadata, payloads, "default", None, None, None, None, None,
+            );
+            let err = match result {
+                Err(e) => e,
+                Ok(_) => panic!("expected PyValueError for missing step_metadata"),
+            };
+            assert!(err.to_string().contains("missing from step_metadata"));
+        });
+    }
+
+    /// Cancelling a run marks the run `Cancelled`, skips pending/ready nodes,
+    /// and cancels their underlying jobs.
+    #[test]
+    fn cancel_workflow_run_cancels_pending_jobs_and_marks_terminal() {
+        pyo3::prepare_freethreaded_python();
+        pyo3::Python::with_gil(|py| {
+            let queue = make_test_pyqueue();
+            let wf = wf_storage(&queue);
+            let run_id = seed_run(wf);
+            let job_id = enqueue_test_job(&queue.storage, "task_pending");
+            seed_node(
+                wf,
+                &run_id,
+                "p",
+                WorkflowNodeStatus::Pending,
+                Some(job_id.clone()),
+            );
+
+            queue.cancel_workflow_run(py, &run_id).unwrap();
+
+            let run = wf.get_workflow_run(&run_id).unwrap().unwrap();
+            assert_eq!(run.state, WorkflowState::Cancelled);
+            assert!(run.completed_at.is_some());
+            assert_eq!(
+                fetch_node(wf, &run_id, "p").status,
+                WorkflowNodeStatus::Skipped,
+            );
+            let job = queue.storage.get_job(&job_id).unwrap().unwrap();
+            assert_eq!(job.status.wire_name(), "Cancelled");
+        });
+    }
+
+    /// `finalize_run_if_terminal` returns `None` while any node is still
+    /// non-terminal and does not transition the run.
+    #[test]
+    fn finalize_run_if_terminal_is_noop_when_nodes_pending() {
+        pyo3::prepare_freethreaded_python();
+        pyo3::Python::with_gil(|py| {
+            let queue = make_test_pyqueue();
+            let wf = wf_storage(&queue);
+            let run_id = seed_run(wf);
+            seed_node(wf, &run_id, "p", WorkflowNodeStatus::Pending, None);
+            seed_node(wf, &run_id, "done", WorkflowNodeStatus::Completed, None);
+
+            let outcome = queue.finalize_run_if_terminal(py, &run_id).unwrap();
+            assert!(outcome.is_none());
+
+            let run = wf.get_workflow_run(&run_id).unwrap().unwrap();
+            assert_eq!(run.state, WorkflowState::Running);
+        });
+    }
+
+    /// All-success terminal nodes promote the run to `Completed`.
+    #[test]
+    fn finalize_run_if_terminal_promotes_run_to_completed_on_all_success() {
+        pyo3::prepare_freethreaded_python();
+        pyo3::Python::with_gil(|py| {
+            let queue = make_test_pyqueue();
+            let wf = wf_storage(&queue);
+            let run_id = seed_run(wf);
+            seed_node(wf, &run_id, "a", WorkflowNodeStatus::Completed, None);
+            seed_node(wf, &run_id, "b", WorkflowNodeStatus::Completed, None);
+
+            let outcome = queue.finalize_run_if_terminal(py, &run_id).unwrap();
+            assert_eq!(outcome.as_deref(), Some("completed"));
+
+            let run = wf.get_workflow_run(&run_id).unwrap().unwrap();
+            assert_eq!(run.state, WorkflowState::Completed);
+            assert!(run.completed_at.is_some());
+        });
+    }
+
+    /// Any failed terminal node demotes the run to `Failed`.
+    #[test]
+    fn finalize_run_if_terminal_promotes_run_to_failed_on_any_failure() {
+        pyo3::prepare_freethreaded_python();
+        pyo3::Python::with_gil(|py| {
+            let queue = make_test_pyqueue();
+            let wf = wf_storage(&queue);
+            let run_id = seed_run(wf);
+            seed_node(wf, &run_id, "a", WorkflowNodeStatus::Completed, None);
+            seed_node(wf, &run_id, "b", WorkflowNodeStatus::Failed, None);
+
+            let outcome = queue.finalize_run_if_terminal(py, &run_id).unwrap();
+            assert_eq!(outcome.as_deref(), Some("failed"));
+
+            let run = wf.get_workflow_run(&run_id).unwrap().unwrap();
+            assert_eq!(run.state, WorkflowState::Failed);
+        });
+    }
+
+    /// `set_workflow_run_completed_with_failures` flips an already-failed run
+    /// to `CompletedWithFailures` for `on_failure="continue"` semantics.
+    #[test]
+    fn set_workflow_run_completed_with_failures_overrides_failed_state() {
+        pyo3::prepare_freethreaded_python();
+        pyo3::Python::with_gil(|py| {
+            let queue = make_test_pyqueue();
+            let wf = wf_storage(&queue);
+            let run_id = seed_run(wf);
+            wf.update_workflow_run_state(&run_id, WorkflowState::Failed, Some("partial"))
+                .unwrap();
+
+            queue
+                .set_workflow_run_completed_with_failures(py, &run_id)
+                .unwrap();
+
+            let run = wf.get_workflow_run(&run_id).unwrap().unwrap();
+            assert_eq!(run.state, WorkflowState::CompletedWithFailures);
+        });
+    }
+}

--- a/crates/taskito-python/src/py_queue/workflow_ops/mod.rs
+++ b/crates/taskito-python/src/py_queue/workflow_ops/mod.rs
@@ -125,114 +125,12 @@ pub(super) fn cascade_skip_pending_nodes(
 }
 
 #[cfg(test)]
+pub(super) mod test_helpers;
+
+#[cfg(test)]
 mod tests {
+    use super::test_helpers::*;
     use super::*;
-
-    use taskito_core::job::{now_millis, NewJob};
-    use taskito_core::storage::sqlite::SqliteStorage;
-    use taskito_workflows::{
-        WorkflowDefinition, WorkflowRun, WorkflowSqliteStorage, WorkflowStorageBackend,
-    };
-
-    fn make_storages() -> (StorageBackend, WorkflowStorageBackend) {
-        let sql = SqliteStorage::in_memory().unwrap();
-        let backend = StorageBackend::Sqlite(sql.clone());
-        let wf = WorkflowSqliteStorage::new(sql).unwrap();
-        let wf_backend = WorkflowStorageBackend::Sqlite(wf);
-        (backend, wf_backend)
-    }
-
-    fn enqueue_test_job(storage: &StorageBackend, task_name: &str) -> String {
-        let job = storage
-            .enqueue(NewJob {
-                queue: "default".to_string(),
-                task_name: task_name.to_string(),
-                payload: vec![1, 2, 3],
-                priority: 0,
-                scheduled_at: now_millis(),
-                max_retries: 3,
-                timeout_ms: 300_000,
-                unique_key: None,
-                metadata: None,
-                notes: None,
-                depends_on: vec![],
-                expires_at: None,
-                result_ttl_ms: None,
-                namespace: None,
-            })
-            .unwrap();
-        job.id
-    }
-
-    fn seed_run(wf_storage: &WorkflowStorageBackend) -> String {
-        let now = now_millis();
-        let definition = WorkflowDefinition {
-            id: uuid::Uuid::now_v7().to_string(),
-            name: "audit_pipeline".to_string(),
-            version: 1,
-            dag_data: vec![],
-            step_metadata: HashMap::new(),
-            created_at: now,
-        };
-        wf_storage.create_workflow_definition(&definition).unwrap();
-
-        let run = WorkflowRun {
-            id: uuid::Uuid::now_v7().to_string(),
-            definition_id: definition.id,
-            params: None,
-            state: WorkflowState::Running,
-            started_at: Some(now),
-            completed_at: None,
-            error: None,
-            parent_run_id: None,
-            parent_node_name: None,
-            created_at: now,
-        };
-        let run_id = run.id.clone();
-        wf_storage.create_workflow_run(&run).unwrap();
-        run_id
-    }
-
-    fn seed_node(
-        wf_storage: &WorkflowStorageBackend,
-        run_id: &str,
-        node_name: &str,
-        status: WorkflowNodeStatus,
-        job_id: Option<String>,
-    ) -> WorkflowNode {
-        let node = WorkflowNode {
-            id: uuid::Uuid::now_v7().to_string(),
-            run_id: run_id.to_string(),
-            node_name: node_name.to_string(),
-            job_id,
-            status,
-            result_hash: None,
-            fan_out_count: None,
-            fan_in_data: None,
-            started_at: None,
-            completed_at: None,
-            error: None,
-            compensation_job_id: None,
-            compensation_started_at: None,
-            compensation_completed_at: None,
-            compensation_error: None,
-        };
-        wf_storage.create_workflow_node(&node).unwrap();
-        node
-    }
-
-    fn fetch_node(
-        wf_storage: &WorkflowStorageBackend,
-        run_id: &str,
-        node_name: &str,
-    ) -> WorkflowNode {
-        wf_storage
-            .get_workflow_nodes(run_id)
-            .unwrap()
-            .into_iter()
-            .find(|n| n.node_name == node_name)
-            .unwrap()
-    }
 
     #[test]
     fn build_metadata_json_round_trips_special_characters() {

--- a/crates/taskito-python/src/py_queue/workflow_ops/nodes.rs
+++ b/crates/taskito-python/src/py_queue/workflow_ops/nodes.rs
@@ -269,3 +269,332 @@ impl PyQueue {
         result.map_err(|e| PyRuntimeError::new_err(e.to_string()))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::py_queue::workflow_ops::test_helpers::*;
+
+    /// Mark a node successful when there is no matching workflow metadata on
+    /// the job. The method returns `None` (signalling a non-workflow job) and
+    /// leaves the run unchanged.
+    #[test]
+    fn mark_workflow_node_result_returns_none_for_non_workflow_job() {
+        pyo3::prepare_freethreaded_python();
+        pyo3::Python::with_gil(|py| {
+            let queue = make_test_pyqueue();
+            let job_id = enqueue_test_job(&queue.storage, "standalone_task");
+
+            let outcome = queue
+                .mark_workflow_node_result(py, &job_id, true, None, false, None)
+                .unwrap();
+            assert!(outcome.is_none());
+        });
+    }
+
+    /// Missing job id surfaces as a `PyValueError` rather than a silent no-op.
+    #[test]
+    fn mark_workflow_node_result_errors_on_unknown_job_id() {
+        pyo3::prepare_freethreaded_python();
+        pyo3::Python::with_gil(|py| {
+            let queue = make_test_pyqueue();
+            let result =
+                queue.mark_workflow_node_result(py, "no-such-job", true, None, false, None);
+            let err = match result {
+                Err(e) => e,
+                Ok(_) => panic!("expected PyValueError for missing job"),
+            };
+            assert!(err.to_string().contains("not found"));
+        });
+    }
+
+    /// Marking the last terminal node successful transitions the run to
+    /// `Completed` and reports the final state back to the caller.
+    #[test]
+    fn mark_workflow_node_result_finalizes_run_on_last_success() {
+        pyo3::prepare_freethreaded_python();
+        pyo3::Python::with_gil(|py| {
+            let queue = make_test_pyqueue();
+            let wf = wf_storage(&queue);
+            let run_id = seed_run(wf);
+            let job_id = enqueue_workflow_job(&queue.storage, &run_id, "leaf");
+            seed_node(
+                wf,
+                &run_id,
+                "leaf",
+                WorkflowNodeStatus::Running,
+                Some(job_id.clone()),
+            );
+
+            let outcome = queue
+                .mark_workflow_node_result(py, &job_id, true, None, false, None)
+                .unwrap()
+                .unwrap();
+            assert_eq!(outcome.0, run_id);
+            assert_eq!(outcome.1, "leaf");
+            assert_eq!(outcome.2.as_deref(), Some("completed"));
+
+            let run = wf.get_workflow_run(&run_id).unwrap().unwrap();
+            assert_eq!(run.state, WorkflowState::Completed);
+        });
+    }
+
+    /// On failure (without `skip_cascade`), siblings in `Pending`/`Ready`
+    /// status are skipped and the run finalizes as `Failed`.
+    #[test]
+    fn mark_workflow_node_result_cascades_failure_to_pending_siblings() {
+        pyo3::prepare_freethreaded_python();
+        pyo3::Python::with_gil(|py| {
+            let queue = make_test_pyqueue();
+            let wf = wf_storage(&queue);
+            let run_id = seed_run(wf);
+            let failing_job = enqueue_workflow_job(&queue.storage, &run_id, "fail");
+            let pending_job = enqueue_test_job(&queue.storage, "task_pending");
+            seed_node(
+                wf,
+                &run_id,
+                "fail",
+                WorkflowNodeStatus::Running,
+                Some(failing_job.clone()),
+            );
+            seed_node(
+                wf,
+                &run_id,
+                "pending",
+                WorkflowNodeStatus::Pending,
+                Some(pending_job.clone()),
+            );
+
+            let outcome = queue
+                .mark_workflow_node_result(
+                    py,
+                    &failing_job,
+                    false,
+                    Some("boom".to_string()),
+                    false,
+                    None,
+                )
+                .unwrap()
+                .unwrap();
+            assert_eq!(outcome.2.as_deref(), Some("failed"));
+
+            assert_eq!(
+                fetch_node(wf, &run_id, "pending").status,
+                WorkflowNodeStatus::Skipped,
+            );
+            let pending = queue.storage.get_job(&pending_job).unwrap().unwrap();
+            assert_eq!(pending.status.wire_name(), "Cancelled");
+        });
+    }
+
+    /// `skip_cascade=true` records the failure but leaves pending siblings
+    /// alone — the tracker handles the cascade for conditional/continue runs.
+    #[test]
+    fn mark_workflow_node_result_skips_cascade_when_requested() {
+        pyo3::prepare_freethreaded_python();
+        pyo3::Python::with_gil(|py| {
+            let queue = make_test_pyqueue();
+            let wf = wf_storage(&queue);
+            let run_id = seed_run(wf);
+            let failing_job = enqueue_workflow_job(&queue.storage, &run_id, "fail");
+            let pending_job = enqueue_test_job(&queue.storage, "task_pending");
+            seed_node(
+                wf,
+                &run_id,
+                "fail",
+                WorkflowNodeStatus::Running,
+                Some(failing_job.clone()),
+            );
+            seed_node(
+                wf,
+                &run_id,
+                "pending",
+                WorkflowNodeStatus::Pending,
+                Some(pending_job.clone()),
+            );
+
+            queue
+                .mark_workflow_node_result(py, &failing_job, false, None, true, None)
+                .unwrap();
+
+            assert_eq!(
+                fetch_node(wf, &run_id, "pending").status,
+                WorkflowNodeStatus::Pending,
+                "skip_cascade must leave pending siblings untouched",
+            );
+            let pending = queue.storage.get_job(&pending_job).unwrap().unwrap();
+            assert_ne!(pending.status.wire_name(), "Cancelled");
+        });
+    }
+
+    /// Success carries the `result_hash` through to the persisted node so the
+    /// incremental layer can resolve future cache hits.
+    #[test]
+    fn mark_workflow_node_result_persists_result_hash_on_success() {
+        pyo3::prepare_freethreaded_python();
+        pyo3::Python::with_gil(|py| {
+            let queue = make_test_pyqueue();
+            let wf = wf_storage(&queue);
+            let run_id = seed_run(wf);
+            let job_id = enqueue_workflow_job(&queue.storage, &run_id, "hashed");
+            seed_node(
+                wf,
+                &run_id,
+                "hashed",
+                WorkflowNodeStatus::Running,
+                Some(job_id.clone()),
+            );
+
+            queue
+                .mark_workflow_node_result(
+                    py,
+                    &job_id,
+                    true,
+                    None,
+                    false,
+                    Some("sha-of-result".to_string()),
+                )
+                .unwrap();
+
+            let node = fetch_node(wf, &run_id, "hashed");
+            assert_eq!(node.status, WorkflowNodeStatus::Completed);
+            assert_eq!(node.result_hash.as_deref(), Some("sha-of-result"));
+        });
+    }
+
+    /// Gate hand-off: the node flips to `WaitingApproval` and stays there
+    /// until externally resolved.
+    #[test]
+    fn set_workflow_node_waiting_approval_transitions_node() {
+        pyo3::prepare_freethreaded_python();
+        pyo3::Python::with_gil(|py| {
+            let queue = make_test_pyqueue();
+            let wf = wf_storage(&queue);
+            let run_id = seed_run(wf);
+            seed_node(wf, &run_id, "gate", WorkflowNodeStatus::Pending, None);
+
+            queue
+                .set_workflow_node_waiting_approval(py, &run_id, "gate")
+                .unwrap();
+
+            assert_eq!(
+                fetch_node(wf, &run_id, "gate").status,
+                WorkflowNodeStatus::WaitingApproval,
+            );
+        });
+    }
+
+    /// Sub-workflow parent promotion: the node flips to `Running` and gets a
+    /// non-null `started_at`.
+    #[test]
+    fn set_workflow_node_running_stamps_started_at() {
+        pyo3::prepare_freethreaded_python();
+        pyo3::Python::with_gil(|py| {
+            let queue = make_test_pyqueue();
+            let wf = wf_storage(&queue);
+            let run_id = seed_run(wf);
+            seed_node(wf, &run_id, "child", WorkflowNodeStatus::Pending, None);
+
+            queue
+                .set_workflow_node_running(py, &run_id, "child")
+                .unwrap();
+
+            let node = fetch_node(wf, &run_id, "child");
+            assert_eq!(node.status, WorkflowNodeStatus::Running);
+            assert!(node.started_at.is_some());
+        });
+    }
+
+    /// `set_workflow_node_fan_out_count` records the count and transitions
+    /// the parent to `Running`, gating downstream finalization on the count.
+    #[test]
+    fn set_workflow_node_fan_out_count_records_count_and_promotes() {
+        pyo3::prepare_freethreaded_python();
+        pyo3::Python::with_gil(|py| {
+            let queue = make_test_pyqueue();
+            let wf = wf_storage(&queue);
+            let run_id = seed_run(wf);
+            seed_node(wf, &run_id, "parent", WorkflowNodeStatus::Pending, None);
+
+            queue
+                .set_workflow_node_fan_out_count(py, &run_id, "parent", 5)
+                .unwrap();
+
+            let node = fetch_node(wf, &run_id, "parent");
+            assert_eq!(node.fan_out_count, Some(5));
+            assert_eq!(node.status, WorkflowNodeStatus::Running);
+        });
+    }
+
+    /// `fail_workflow_node` records the error message on the node and flips
+    /// the status to `Failed` without touching siblings.
+    #[test]
+    fn fail_workflow_node_marks_failed_with_error() {
+        pyo3::prepare_freethreaded_python();
+        pyo3::Python::with_gil(|py| {
+            let queue = make_test_pyqueue();
+            let wf = wf_storage(&queue);
+            let run_id = seed_run(wf);
+            seed_node(wf, &run_id, "broken", WorkflowNodeStatus::Pending, None);
+            seed_node(wf, &run_id, "sibling", WorkflowNodeStatus::Pending, None);
+
+            queue
+                .fail_workflow_node(py, &run_id, "broken", "compile error")
+                .unwrap();
+
+            let broken = fetch_node(wf, &run_id, "broken");
+            assert_eq!(broken.status, WorkflowNodeStatus::Failed);
+            assert_eq!(broken.error.as_deref(), Some("compile error"));
+            assert_eq!(
+                fetch_node(wf, &run_id, "sibling").status,
+                WorkflowNodeStatus::Pending,
+            );
+        });
+    }
+
+    /// `skip_workflow_node` cancels the backing job (if any) and marks the
+    /// node `Skipped`.
+    #[test]
+    fn skip_workflow_node_cancels_job_and_marks_skipped() {
+        pyo3::prepare_freethreaded_python();
+        pyo3::Python::with_gil(|py| {
+            let queue = make_test_pyqueue();
+            let wf = wf_storage(&queue);
+            let run_id = seed_run(wf);
+            let job_id = enqueue_test_job(&queue.storage, "task_to_skip");
+            seed_node(
+                wf,
+                &run_id,
+                "skipped",
+                WorkflowNodeStatus::Pending,
+                Some(job_id.clone()),
+            );
+
+            queue.skip_workflow_node(py, &run_id, "skipped").unwrap();
+
+            assert_eq!(
+                fetch_node(wf, &run_id, "skipped").status,
+                WorkflowNodeStatus::Skipped,
+            );
+            let job = queue.storage.get_job(&job_id).unwrap().unwrap();
+            assert_eq!(job.status.wire_name(), "Cancelled");
+        });
+    }
+
+    /// Skipping an unknown node name is a no-op rather than an error — the
+    /// tracker may race the storage and we accept that.
+    #[test]
+    fn skip_workflow_node_is_noop_for_unknown_node() {
+        pyo3::prepare_freethreaded_python();
+        pyo3::Python::with_gil(|py| {
+            let queue = make_test_pyqueue();
+            let wf = wf_storage(&queue);
+            let run_id = seed_run(wf);
+
+            queue
+                .skip_workflow_node(py, &run_id, "ghost")
+                .expect("missing node is a no-op, not an error");
+            assert!(wf.get_workflow_nodes(&run_id).unwrap().is_empty());
+        });
+    }
+}

--- a/crates/taskito-python/src/py_queue/workflow_ops/test_helpers.rs
+++ b/crates/taskito-python/src/py_queue/workflow_ops/test_helpers.rs
@@ -1,0 +1,247 @@
+//! Test helpers shared across `workflow_ops` submodule test blocks.
+//!
+//! Provides:
+//! * `make_test_pyqueue` — builds a `PyQueue` backed by an in-memory SQLite
+//!   storage with sane defaults, suitable for direct invocation of
+//!   `#[pymethods]` from Rust.
+//! * `make_storages` — bare storage pair (no `PyQueue`) for helper-level
+//!   tests that only exercise the free functions.
+//! * Seed helpers for definitions, runs, nodes, and pre-enqueued jobs.
+//! * DAG / step-metadata constructors that mirror what the Python builder
+//!   sends to `submit_workflow`.
+
+use std::collections::HashMap;
+use std::sync::atomic::AtomicBool;
+use std::sync::{Arc, Mutex};
+
+use serde_json::json;
+
+use taskito_core::job::{now_millis, NewJob};
+use taskito_core::storage::sqlite::SqliteStorage;
+use taskito_core::storage::{Storage, StorageBackend};
+use taskito_workflows::{
+    StepMetadata, WorkflowDefinition, WorkflowNode, WorkflowNodeStatus, WorkflowRun,
+    WorkflowSqliteStorage, WorkflowState, WorkflowStorage, WorkflowStorageBackend,
+};
+
+use crate::py_queue::PyQueue;
+
+/// Construct an in-memory SQLite storage pair (job storage + workflow storage)
+/// sharing a single underlying connection pool.
+pub(crate) fn make_storages() -> (StorageBackend, WorkflowStorageBackend) {
+    let sql = SqliteStorage::in_memory().unwrap();
+    let backend = StorageBackend::Sqlite(sql.clone());
+    let wf = WorkflowSqliteStorage::new(sql).unwrap();
+    (backend, WorkflowStorageBackend::Sqlite(wf))
+}
+
+/// Construct a `PyQueue` wired to in-memory SQLite, with workflow storage
+/// pre-initialized. Suitable for invoking `#[pymethods]` directly in Rust
+/// tests — no Python construction, just a struct literal.
+pub(crate) fn make_test_pyqueue() -> PyQueue {
+    let (storage, wf_backend) = make_storages();
+    let workflow_storage = std::sync::OnceLock::new();
+    workflow_storage.set(wf_backend).ok();
+    PyQueue {
+        storage,
+        db_path: ":memory:".to_string(),
+        num_workers: 1,
+        default_retry: 3,
+        default_timeout: 300,
+        default_priority: 0,
+        shutdown_flag: Arc::new(AtomicBool::new(false)),
+        result_ttl_ms: None,
+        scheduler_poll_interval_ms: 50,
+        scheduler_reap_interval: 100,
+        scheduler_cleanup_interval: 1200,
+        namespace: None,
+        dispatcher: Arc::new(Mutex::new(None)),
+        workflow_storage,
+    }
+}
+
+/// Resolve the workflow storage handle from a test `PyQueue`. Panics if
+/// `make_test_pyqueue` was not used to seed the `OnceLock` (it is).
+pub(crate) fn wf_storage(queue: &PyQueue) -> &WorkflowStorageBackend {
+    queue
+        .workflow_storage
+        .get()
+        .expect("workflow storage seeded by make_test_pyqueue")
+}
+
+/// Enqueue a throwaway job and return its id. Useful for seeding nodes that
+/// reference a real job, so that cancel-job assertions can observe the
+/// transition.
+pub(crate) fn enqueue_test_job(storage: &StorageBackend, task_name: &str) -> String {
+    storage
+        .enqueue(NewJob {
+            queue: "default".to_string(),
+            task_name: task_name.to_string(),
+            payload: vec![1, 2, 3],
+            priority: 0,
+            scheduled_at: now_millis(),
+            max_retries: 3,
+            timeout_ms: 300_000,
+            unique_key: None,
+            metadata: None,
+            notes: None,
+            depends_on: vec![],
+            expires_at: None,
+            result_ttl_ms: None,
+            namespace: None,
+        })
+        .unwrap()
+        .id
+}
+
+/// Enqueue a job whose metadata carries the workflow routing blob the
+/// tracker uses to associate `JOB_*` events with a node. Returns the job id.
+pub(crate) fn enqueue_workflow_job(
+    storage: &StorageBackend,
+    run_id: &str,
+    node_name: &str,
+) -> String {
+    let metadata = json!({
+        "workflow_run_id": run_id,
+        "workflow_node_name": node_name,
+    })
+    .to_string();
+    storage
+        .enqueue(NewJob {
+            queue: "default".to_string(),
+            task_name: format!("task_{node_name}"),
+            payload: vec![1, 2, 3],
+            priority: 0,
+            scheduled_at: now_millis(),
+            max_retries: 3,
+            timeout_ms: 300_000,
+            unique_key: None,
+            metadata: Some(metadata),
+            notes: None,
+            depends_on: vec![],
+            expires_at: None,
+            result_ttl_ms: None,
+            namespace: None,
+        })
+        .unwrap()
+        .id
+}
+
+/// Seed a workflow definition + a `Running` run and return the run id.
+pub(crate) fn seed_run(wf_storage: &WorkflowStorageBackend) -> String {
+    let now = now_millis();
+    let definition = WorkflowDefinition {
+        id: uuid::Uuid::now_v7().to_string(),
+        name: "audit_pipeline".to_string(),
+        version: 1,
+        dag_data: vec![],
+        step_metadata: HashMap::new(),
+        created_at: now,
+    };
+    wf_storage.create_workflow_definition(&definition).unwrap();
+
+    let run = WorkflowRun {
+        id: uuid::Uuid::now_v7().to_string(),
+        definition_id: definition.id,
+        params: None,
+        state: WorkflowState::Running,
+        started_at: Some(now),
+        completed_at: None,
+        error: None,
+        parent_run_id: None,
+        parent_node_name: None,
+        created_at: now,
+    };
+    let run_id = run.id.clone();
+    wf_storage.create_workflow_run(&run).unwrap();
+    run_id
+}
+
+/// Insert a node row directly via the workflow storage.
+pub(crate) fn seed_node(
+    wf_storage: &WorkflowStorageBackend,
+    run_id: &str,
+    node_name: &str,
+    status: WorkflowNodeStatus,
+    job_id: Option<String>,
+) -> WorkflowNode {
+    let node = WorkflowNode {
+        id: uuid::Uuid::now_v7().to_string(),
+        run_id: run_id.to_string(),
+        node_name: node_name.to_string(),
+        job_id,
+        status,
+        result_hash: None,
+        fan_out_count: None,
+        fan_in_data: None,
+        started_at: None,
+        completed_at: None,
+        error: None,
+        compensation_job_id: None,
+        compensation_started_at: None,
+        compensation_completed_at: None,
+        compensation_error: None,
+    };
+    wf_storage.create_workflow_node(&node).unwrap();
+    node
+}
+
+/// Look up a node by name and unwrap. Panics if missing — tests want the
+/// short-circuit on missing nodes.
+pub(crate) fn fetch_node(
+    wf_storage: &WorkflowStorageBackend,
+    run_id: &str,
+    node_name: &str,
+) -> WorkflowNode {
+    wf_storage
+        .get_workflow_nodes(run_id)
+        .unwrap()
+        .into_iter()
+        .find(|n| n.node_name == node_name)
+        .unwrap()
+}
+
+/// Serialize a `SerializableGraph`-compatible DAG payload from a list of
+/// nodes and `(from, to)` edges. Mirrors what the Python builder emits.
+pub(crate) fn make_dag_bytes(nodes: &[&str], edges: &[(&str, &str)]) -> Vec<u8> {
+    let nodes_json: Vec<_> = nodes.iter().map(|n| json!({"name": n})).collect();
+    let edges_json: Vec<_> = edges
+        .iter()
+        .map(|(from, to)| json!({"from": from, "to": to, "weight": 1.0}))
+        .collect();
+    serde_json::to_vec(&json!({"nodes": nodes_json, "edges": edges_json})).unwrap()
+}
+
+/// Build a `step_metadata` JSON blob mapping each `(node_name, task_name)`
+/// pair to a minimal `StepMetadata`. Mirrors what the Python builder emits.
+pub(crate) fn make_step_metadata_json(steps: &[(&str, &str)]) -> String {
+    let map: HashMap<String, StepMetadata> = steps
+        .iter()
+        .map(|(node, task)| {
+            (
+                (*node).to_string(),
+                StepMetadata {
+                    task_name: (*task).to_string(),
+                    queue: None,
+                    args_template: None,
+                    kwargs_template: None,
+                    max_retries: None,
+                    timeout_ms: None,
+                    priority: None,
+                    fan_out: None,
+                    fan_in: None,
+                    condition: None,
+                },
+            )
+        })
+        .collect();
+    serde_json::to_string(&map).unwrap()
+}
+
+/// Build `node_payloads` keyed by node name with throwaway bytes.
+pub(crate) fn make_node_payloads(nodes: &[&str]) -> HashMap<String, Vec<u8>> {
+    nodes
+        .iter()
+        .map(|n| ((*n).to_string(), vec![0u8; 4]))
+        .collect()
+}


### PR DESCRIPTION
## Summary

Two independent fixes from the 2026-05-29 health audit (`.claude/reports/health-2026-05-29.md`).

- **`refactor: remove unused TaskDurationCache from scheduler`** — `TaskDurationCache` recorded per-job wall-time samples but its only reader (`avg_ns`) was never called and lived behind `#[allow(dead_code)]`. The cache added a `Mutex` lock + `HashMap` entry on every `handle_result()` for zero downstream consumer. Removed the struct, the `duration_cache` field on `Scheduler`, and the two `cache.record(...)` call sites in `result_handler.rs`. No public API change.

- **`test: add Rust coverage for workflow_ops submodules`** — `crates/taskito-python/src/py_queue/workflow_ops/{lifecycle,nodes,fan_out}.rs` previously had no inline Rust tests. `submit_workflow` and friends were covered only by slow Python integration tests, so failures in the Rust orchestration surfaced as opaque test flake. Extracted the existing test helpers in `mod.rs` into a new `test_helpers.rs` (`pub(super)`) and added 30 inline tests across the three submodules.

  Coverage highlights:
  - `submit_workflow`: linear DAG depends_on linkage, deferred-node skip, cache-hit terminal state without job, definition reuse across `(name, version)`, missing `step_metadata` rejection.
  - `cancel_workflow_run`: cancels pending jobs + marks run terminal.
  - `finalize_run_if_terminal`: noop while pending, success and failure terminal paths.
  - `mark_workflow_node_result`: non-workflow job handling, unknown-job error, last-success run finalization, cascade vs `skip_cascade`, `result_hash` persistence.
  - `expand_fan_out`: mismatched-length rejection, empty short-circuit, child creation + count.
  - `check_fan_out_completion`: pending children, all-success transition with CAS idempotency, any-failure path, empty children noop.
  - Plus `set_workflow_node_waiting_approval`, `set_workflow_node_running`, `set_workflow_node_fan_out_count`, `fail_workflow_node`, `skip_workflow_node`, `create_deferred_job`.

Rust test count: 80 → 110 under `--features workflows`.

## Test plan

- [x] `cargo test --workspace --features workflows` — 110 passed, 0 failed
- [x] `cargo check --workspace --features postgres` / `--features redis` / `--features native-async` — all clean
- [x] `cargo clippy --workspace --features workflows --tests -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Pre-commit hooks pass on both commits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suites for workflow fan-out operations, workflow lifecycle management, and workflow node operations, including edge cases and error scenarios.
  * Refactored test infrastructure by extracting shared helpers into a dedicated module for improved maintainability.

* **Chores**
  * Removed internal task duration caching mechanism from the scheduler.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ByteVeda/taskito/pull/212?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->