### PR TITLE
perf(redis): compute job stats with SINTERCARD instead of O(N) scans

### DIFF
--- a/crates/taskito-core/src/storage/redis_backend/jobs/query.rs
+++ b/crates/taskito-core/src/storage/redis_backend/jobs/query.rs
@@ -119,68 +119,99 @@ impl RedisStorage {
         Ok(stats)
     }
 
+    /// `SINTERCARD` of a membership set with a per-status set — the count of
+    /// jobs that are both in `membership_key` and in the given status, computed
+    /// server-side without transferring or deserializing any job. Redis starts
+    /// from the smaller set, so e.g. intersecting against the (small) running
+    /// set stays cheap regardless of how large the membership set has grown.
+    fn count_in_status(
+        &self,
+        conn: &mut redis::Connection,
+        membership_key: &str,
+        status: JobStatus,
+    ) -> Result<i64> {
+        let status_key = self.key(&["jobs", "status", &(status as i32).to_string()]);
+        redis::cmd("SINTERCARD")
+            .arg(2)
+            .arg(membership_key)
+            .arg(&status_key)
+            .query::<i64>(conn)
+            .map_err(map_err)
+    }
+
+    /// Per-status breakdown for the jobs in `membership_key` (a per-queue or
+    /// per-task set), one `SINTERCARD` per status.
+    fn status_breakdown(
+        &self,
+        conn: &mut redis::Connection,
+        membership_key: &str,
+    ) -> Result<QueueStats> {
+        let mut stats = QueueStats::default();
+        for (status, field) in [
+            (JobStatus::Pending, &mut stats.pending),
+            (JobStatus::Running, &mut stats.running),
+            (JobStatus::Complete, &mut stats.completed),
+            (JobStatus::Failed, &mut stats.failed),
+            (JobStatus::Dead, &mut stats.dead),
+            (JobStatus::Cancelled, &mut stats.cancelled),
+        ] {
+            *field = self.count_in_status(conn, membership_key, status)?;
+        }
+        Ok(stats)
+    }
+
     /// Count running jobs for a specific task name (for per-task concurrency limiting).
     pub fn count_running_by_task(&self, task_name: &str) -> Result<i64> {
         let mut conn = self.conn()?;
         let by_task_key = self.key(&["jobs", "by_task", task_name]);
-        let job_ids: Vec<String> = conn.smembers(&by_task_key).map_err(map_err)?;
-
-        let mut count: i64 = 0;
-        for id in &job_ids {
-            if let Some(job) = self.load_job(&mut conn, id)? {
-                if job.status == JobStatus::Running {
-                    count += 1;
-                }
-            }
-        }
-
-        Ok(count)
+        self.count_in_status(&mut conn, &by_task_key, JobStatus::Running)
     }
 
     pub fn stats_by_queue(&self, queue_name: &str) -> Result<QueueStats> {
         let mut conn = self.conn()?;
         let by_queue_key = self.key(&["jobs", "by_queue", queue_name]);
-        let job_ids: Vec<String> = conn.smembers(&by_queue_key).map_err(map_err)?;
-
-        let mut stats = QueueStats::default();
-        for id in &job_ids {
-            if let Some(job) = self.load_job(&mut conn, id)? {
-                match job.status as i32 {
-                    0 => stats.pending += 1,
-                    1 => stats.running += 1,
-                    2 => stats.completed += 1,
-                    3 => stats.failed += 1,
-                    4 => stats.dead += 1,
-                    5 => stats.cancelled += 1,
-                    _ => {}
-                }
-            }
-        }
-
-        Ok(stats)
+        self.status_breakdown(&mut conn, &by_queue_key)
     }
 
     pub fn stats_all_queues(&self) -> Result<std::collections::HashMap<String, QueueStats>> {
         let mut conn = self.conn()?;
-        let all_key = self.key(&["jobs", "all"]);
-        let job_ids: Vec<String> = conn.zrange(&all_key, 0, -1).map_err(map_err)?;
 
-        let mut map = std::collections::HashMap::<String, QueueStats>::new();
-        for id in &job_ids {
-            if let Some(job) = self.load_job(&mut conn, id)? {
-                let stats = map.entry(job.queue.clone()).or_default();
-                match job.status as i32 {
-                    0 => stats.pending += 1,
-                    1 => stats.running += 1,
-                    2 => stats.completed += 1,
-                    3 => stats.failed += 1,
-                    4 => stats.dead += 1,
-                    5 => stats.cancelled += 1,
-                    _ => {}
+        // Enumerate queues by scanning the per-queue membership keys (one per
+        // queue with at least one job — empty sets are auto-removed by Redis).
+        // This is bounded by the number of queues, not the job population.
+        let pattern = self.key(&["jobs", "by_queue", "*"]);
+        let strip = self.key(&["jobs", "by_queue", ""]);
+        let mut queues: Vec<String> = Vec::new();
+        let mut cursor = 0u64;
+        loop {
+            let (next, batch): (u64, Vec<String>) = redis::cmd("SCAN")
+                .arg(cursor)
+                .arg("MATCH")
+                .arg(&pattern)
+                .arg("COUNT")
+                .arg(100)
+                .query(&mut conn)
+                .map_err(map_err)?;
+            for key in batch {
+                if let Some(name) = key.strip_prefix(&strip) {
+                    queues.push(name.to_string());
                 }
             }
+            cursor = next;
+            if cursor == 0 {
+                break;
+            }
         }
+        // SCAN may return duplicates across iterations.
+        queues.sort_unstable();
+        queues.dedup();
 
+        let mut map = std::collections::HashMap::<String, QueueStats>::new();
+        for queue in queues {
+            let by_queue_key = self.key(&["jobs", "by_queue", &queue]);
+            let stats = self.status_breakdown(&mut conn, &by_queue_key)?;
+            map.insert(queue, stats);
+        }
         Ok(map)
     }
 

--- a/crates/taskito-core/tests/rust/storage_tests.rs
+++ b/crates/taskito-core/tests/rust/storage_tests.rs
@@ -104,6 +104,43 @@ fn test_stats(s: &impl Storage) {
     assert!(stats.pending >= 2);
 }
 
+fn test_stats_by_queue_and_task(s: &impl Storage) {
+    let q = "q-stats-breakdown";
+    let task = "stats_breakdown_task";
+    s.enqueue(make_job(q, task)).unwrap();
+    s.enqueue(make_job(q, task)).unwrap();
+    s.enqueue(make_job(q, task)).unwrap();
+
+    // 3 pending, none running yet.
+    let st = s.stats_by_queue(q).unwrap();
+    assert_eq!(st.pending, 3);
+    assert_eq!(st.running, 0);
+    assert_eq!(s.count_running_by_task(task).unwrap(), 0);
+
+    // Run two of them.
+    let d1 = s.dequeue(q, now_millis() + 1000, None).unwrap().unwrap();
+    s.dequeue(q, now_millis() + 1000, None).unwrap().unwrap();
+    assert_eq!(s.count_running_by_task(task).unwrap(), 2);
+    let st = s.stats_by_queue(q).unwrap();
+    assert_eq!(st.running, 2);
+    assert_eq!(st.pending, 1);
+
+    // Complete one — running drops, completed rises.
+    s.complete(&d1.id, None).unwrap();
+    assert_eq!(s.count_running_by_task(task).unwrap(), 1);
+    let st = s.stats_by_queue(q).unwrap();
+    assert_eq!(st.pending, 1);
+    assert_eq!(st.running, 1);
+    assert_eq!(st.completed, 1);
+
+    // stats_all_queues reports the same breakdown for this queue.
+    let all = s.stats_all_queues().unwrap();
+    let qs = all.get(q).expect("queue should appear in stats_all_queues");
+    assert_eq!(qs.pending, 1);
+    assert_eq!(qs.running, 1);
+    assert_eq!(qs.completed, 1);
+}
+
 fn test_unique_key_dedup(s: &impl Storage) {
     let mut job1 = make_job("q-unique", "unique_task");
     job1.unique_key = Some("dedup-key".to_string());
@@ -308,6 +345,7 @@ fn run_storage_tests(s: &impl Storage) {
     test_retry(s);
     test_cancel_job(s);
     test_stats(s);
+    test_stats_by_queue_and_task(s);
     test_unique_key_dedup(s);
     test_enqueue_batch(s);
     test_dead_letter_queue(s);


### PR DESCRIPTION
Follow-up to #213 — the remaining Redis hot-path item.

`count_running_by_task`, `stats_by_queue`, and `stats_all_queues` each loaded **every** job id in the relevant set (`jobs:by_task:{t}` / `jobs:by_queue:{q}` / `jobs:all`) and issued one `GET` + JSON deserialize per job just to bucket by status. On a busy queue with lifetime-accumulated terminal jobs, that's O(N) round trips on a path the scheduler poller hits per dispatch (per-task / per-queue concurrency checks).

## Approach
The per-status sets (`jobs:status:{n}`) and per-queue/per-task membership sets are already maintained correctly on every transition. So the counts are just set intersections — computed **server-side** with `SINTERCARD` (Redis 7.0+), which starts from the smaller set:

- `count_running_by_task` → `SINTERCARD jobs:by_task:{t} jobs:status:1` (the running set is bounded by worker concurrency, so this stays cheap).
- `stats_by_queue` → one `SINTERCARD` per status against `jobs:by_queue:{q}`.
- `stats_all_queues` → enumerate queues with a bounded `SCAN MATCH jobs:by_queue:*` (cursor-based; bounded by queue count, not job count), then the per-queue breakdown.

No job blobs are transferred or deserialized.

## Why not maintained counters
Counter hashes would need hooks at 5 write sites plus a one-time backfill, and there's no Redis migration hook — pre-existing in-flight jobs would drive `HINCRBY` counters negative on their next transition. Intersecting the existing, authoritative sets needs **no new keys, no write-path changes, and no backfill**, and can't drift.

## Compatibility
`SINTERCARD` is Redis 7.0+. CI already runs `redis:7-alpine`.

## Verification
- SQLite contract suite (reference impl) + full workspace tests pass; clippy clean (default + redis).
- New backend-agnostic contract test `test_stats_by_queue_and_task` covers all three methods (pending→running→completed transitions); validated against a live Redis 7 locally and runs in CI's Redis job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized job statistics computation to reduce data fetching and improve performance.

* **Tests**
  * Added comprehensive test coverage for job queue and task statistics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ByteVeda/taskito/pull/214?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->