### PR TITLE
perf(storage): archive terminal jobs on transition

### DIFF
--- a/crates/taskito-core/src/job.rs
+++ b/crates/taskito-core/src/job.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use uuid::Uuid;
 
-use crate::storage::models::JobRow;
+use crate::storage::models::{ArchivedJobRow, JobRow};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[repr(i32)]
@@ -122,6 +122,38 @@ impl From<JobRow> for Job {
             result_ttl_ms: row.result_ttl_ms,
             namespace: row.namespace,
             has_deps: row.has_deps,
+        }
+    }
+}
+
+impl From<ArchivedJobRow> for Job {
+    fn from(row: ArchivedJobRow) -> Self {
+        Self {
+            id: row.id,
+            queue: row.queue,
+            task_name: row.task_name,
+            payload: row.payload,
+            status: JobStatus::from_i32(row.status).unwrap_or(JobStatus::Pending),
+            priority: row.priority,
+            created_at: row.created_at,
+            scheduled_at: row.scheduled_at,
+            started_at: row.started_at,
+            completed_at: row.completed_at,
+            retry_count: row.retry_count,
+            max_retries: row.max_retries,
+            result: row.result,
+            error: row.error,
+            timeout_ms: row.timeout_ms,
+            unique_key: row.unique_key,
+            progress: row.progress,
+            metadata: row.metadata,
+            notes: row.notes,
+            cancel_requested: row.cancel_requested != 0,
+            expires_at: row.expires_at,
+            result_ttl_ms: row.result_ttl_ms,
+            namespace: row.namespace,
+            // Archived jobs are terminal and never re-dequeued.
+            has_deps: false,
         }
     }
 }

--- a/crates/taskito-core/src/storage/diesel_common/archival.rs
+++ b/crates/taskito-core/src/storage/diesel_common/archival.rs
@@ -16,36 +16,7 @@ macro_rules! impl_diesel_archival_ops {
                     .select(ArchivedJobRow::as_select())
                     .load(&mut conn)?;
 
-                Ok(rows
-                    .into_iter()
-                    .map(|row| Job {
-                        id: row.id,
-                        queue: row.queue,
-                        task_name: row.task_name,
-                        payload: row.payload,
-                        status: JobStatus::from_i32(row.status).unwrap_or(JobStatus::Pending),
-                        priority: row.priority,
-                        created_at: row.created_at,
-                        scheduled_at: row.scheduled_at,
-                        started_at: row.started_at,
-                        completed_at: row.completed_at,
-                        retry_count: row.retry_count,
-                        max_retries: row.max_retries,
-                        result: row.result,
-                        error: row.error,
-                        timeout_ms: row.timeout_ms,
-                        unique_key: row.unique_key,
-                        progress: row.progress,
-                        metadata: row.metadata,
-                        notes: row.notes,
-                        cancel_requested: row.cancel_requested != 0,
-                        expires_at: row.expires_at,
-                        result_ttl_ms: row.result_ttl_ms,
-                        namespace: row.namespace,
-                        // Archived jobs are terminal and never re-dequeued.
-                        has_deps: false,
-                    })
-                    .collect())
+                Ok(rows.into_iter().map(Job::from).collect())
             }
         }
     };

--- a/crates/taskito-core/src/storage/diesel_common/dead_letter.rs
+++ b/crates/taskito-core/src/storage/diesel_common/dead_letter.rs
@@ -14,10 +14,12 @@ macro_rules! impl_diesel_dead_letter_ops {
             ) -> Result<()> {
                 let now = now_millis();
                 let dlq_id = uuid::Uuid::now_v7().to_string();
-                let mut conn = self.conn()?;
                 let job_id = job.id.clone();
 
-                conn.transaction(|conn| {
+                // Write-priority transaction: this reads the job row then writes
+                // it to `archived_jobs`, which would deadlock under SQLite's
+                // deferred lock-upgrade. See `archive_transaction`.
+                self.archive_transaction(|conn| {
                     let dlq_row = NewDeadLetterRow {
                         id: &dlq_id,
                         original_job_id: &job.id,
@@ -40,22 +42,28 @@ macro_rules! impl_diesel_dead_letter_ops {
                         .values(&dlq_row)
                         .execute(conn)?;
 
-                    diesel::update(jobs::table)
-                        .filter(jobs::id.eq(&job.id))
-                        .set((
-                            jobs::status.eq(JobStatus::Dead as i32),
-                            jobs::error.eq(error),
-                            jobs::completed_at.eq(now),
-                        ))
-                        .execute(conn)?;
+                    // Archive the now-Dead job: move it out of the live `jobs`
+                    // table into `archived_jobs` so the dequeue index and stats
+                    // scans no longer see it. The row may already be absent if a
+                    // prior terminal transition archived it; only archive when
+                    // it is still live.
+                    if let Some(mut row) = jobs::table
+                        .find(&job.id)
+                        .select(JobRow::as_select())
+                        .first(conn)
+                        .optional()?
+                    {
+                        row.status = JobStatus::Dead as i32;
+                        row.error = Some(error.to_string());
+                        row.completed_at = Some(now);
+                        <$storage_type>::archive_job_row(conn, &row)?;
+                    }
 
-                    Ok::<(), diesel::result::Error>(())
+                    Ok::<(), QueueError>(())
                 })?;
 
-                // Drop connection before cascade (needed for single-connection pools).
-                drop(conn);
-
-                // Cascade cancel dependents.
+                // Cascade cancel dependents (opens its own connection, so the
+                // archive transaction above must already be committed).
                 self.cascade_cancel(&job_id, "dependency failed")?;
 
                 Ok(())

--- a/crates/taskito-core/src/storage/diesel_common/jobs.rs
+++ b/crates/taskito-core/src/storage/diesel_common/jobs.rs
@@ -35,6 +35,47 @@ macro_rules! impl_diesel_job_ops {
                 Ok(())
             }
 
+            /// Move an already-loaded job row into `archived_jobs` and delete it
+            /// from `jobs`, inside the caller's transaction. Terminal jobs live
+            /// in `archived_jobs` so the live `jobs` table only ever holds
+            /// pending/running rows that the dequeue index must scan.
+            pub(crate) fn archive_job_row(
+                conn: &mut $conn_type,
+                row: &JobRow,
+            ) -> diesel::result::QueryResult<()> {
+                let archived = NewArchivedJobRow {
+                    id: &row.id,
+                    queue: &row.queue,
+                    task_name: &row.task_name,
+                    payload: &row.payload,
+                    status: row.status,
+                    priority: row.priority,
+                    created_at: row.created_at,
+                    scheduled_at: row.scheduled_at,
+                    started_at: row.started_at,
+                    completed_at: row.completed_at,
+                    retry_count: row.retry_count,
+                    max_retries: row.max_retries,
+                    result: row.result.as_deref(),
+                    error: row.error.as_deref(),
+                    timeout_ms: row.timeout_ms,
+                    unique_key: row.unique_key.as_deref(),
+                    progress: row.progress,
+                    metadata: row.metadata.as_deref(),
+                    notes: row.notes.as_deref(),
+                    cancel_requested: row.cancel_requested,
+                    expires_at: row.expires_at,
+                    result_ttl_ms: row.result_ttl_ms,
+                    namespace: row.namespace.as_deref(),
+                };
+
+                diesel::insert_into(archived_jobs::table)
+                    .values(&archived)
+                    .execute(conn)?;
+                diesel::delete(jobs::table.filter(jobs::id.eq(&row.id))).execute(conn)?;
+                Ok(())
+            }
+
             fn deps_satisfied(
                 conn: &mut $conn_type,
                 job_id: &str,
@@ -304,19 +345,14 @@ macro_rules! impl_diesel_job_ops {
 
                     let candidates: Vec<JobRow> = query.select(JobRow::as_select()).load(conn)?;
 
-                    for row in candidates {
-                        // Skip expired jobs
+                    for mut row in candidates {
+                        // Skip expired jobs — archive them as cancelled.
                         if let Some(expires_at) = row.expires_at {
                             if now > expires_at {
-                                // Mark as cancelled (expired)
-                                diesel::update(jobs::table)
-                                    .filter(jobs::id.eq(&row.id))
-                                    .set((
-                                        jobs::status.eq(JobStatus::Cancelled as i32),
-                                        jobs::completed_at.eq(now),
-                                        jobs::error.eq("expired before execution"),
-                                    ))
-                                    .execute(conn)?;
+                                row.status = JobStatus::Cancelled as i32;
+                                row.completed_at = Some(now);
+                                row.error = Some("expired before execution".to_string());
+                                Self::archive_job_row(conn, &row)?;
                                 continue;
                             }
                         }
@@ -485,46 +521,54 @@ macro_rules! impl_diesel_job_ops {
                 Ok(claimed)
             }
 
-            /// Mark a job as complete with the given result.
+            /// Mark a job as complete with the given result. The job moves from
+            /// `jobs` into `archived_jobs` in a single transaction.
             pub fn complete(&self, id: &str, result_bytes: Option<Vec<u8>>) -> Result<()> {
                 let now = now_millis();
-                let mut conn = self.conn()?;
 
-                let affected = diesel::update(jobs::table)
-                    .filter(jobs::id.eq(id))
-                    .filter(jobs::status.eq(JobStatus::Running as i32))
-                    .set((
-                        jobs::status.eq(JobStatus::Complete as i32),
-                        jobs::completed_at.eq(now),
-                        jobs::result.eq(result_bytes),
-                    ))
-                    .execute(&mut conn)?;
+                self.archive_transaction(|conn| {
+                    let mut row: JobRow = match jobs::table
+                        .find(id)
+                        .filter(jobs::status.eq(JobStatus::Running as i32))
+                        .select(JobRow::as_select())
+                        .first(conn)
+                        .optional()?
+                    {
+                        Some(row) => row,
+                        None => return Err(QueueError::JobNotFound(id.to_string())),
+                    };
 
-                if affected == 0 {
-                    return Err(QueueError::JobNotFound(id.to_string()));
-                }
-                Ok(())
+                    row.status = JobStatus::Complete as i32;
+                    row.completed_at = Some(now);
+                    row.result = result_bytes;
+                    Self::archive_job_row(conn, &row)?;
+                    Ok(())
+                })
             }
 
-            /// Mark a job as failed with the given error message.
+            /// Mark a job as failed with the given error message. The job moves
+            /// from `jobs` into `archived_jobs` in a single transaction.
             pub fn fail(&self, id: &str, error: &str) -> Result<()> {
                 let now = now_millis();
-                let mut conn = self.conn()?;
 
-                let affected = diesel::update(jobs::table)
-                    .filter(jobs::id.eq(id))
-                    .filter(jobs::status.eq(JobStatus::Running as i32))
-                    .set((
-                        jobs::status.eq(JobStatus::Failed as i32),
-                        jobs::completed_at.eq(now),
-                        jobs::error.eq(error),
-                    ))
-                    .execute(&mut conn)?;
+                self.archive_transaction(|conn| {
+                    let mut row: JobRow = match jobs::table
+                        .find(id)
+                        .filter(jobs::status.eq(JobStatus::Running as i32))
+                        .select(JobRow::as_select())
+                        .first(conn)
+                        .optional()?
+                    {
+                        Some(row) => row,
+                        None => return Err(QueueError::JobNotFound(id.to_string())),
+                    };
 
-                if affected == 0 {
-                    return Err(QueueError::JobNotFound(id.to_string()));
-                }
-                Ok(())
+                    row.status = JobStatus::Failed as i32;
+                    row.completed_at = Some(now);
+                    row.error = Some(error.to_string());
+                    Self::archive_job_row(conn, &row)?;
+                    Ok(())
+                })
             }
 
             /// Re-schedule a job for retry.
@@ -549,26 +593,34 @@ macro_rules! impl_diesel_job_ops {
                 Ok(())
             }
 
-            /// Cancel a pending job and cascade-cancel its dependents.
+            /// Cancel a pending job and cascade-cancel its dependents. The
+            /// cancelled job moves from `jobs` into `archived_jobs`.
             pub fn cancel_job(&self, id: &str) -> Result<bool> {
                 let now = now_millis();
-                let mut conn = self.conn()?;
 
-                let affected = diesel::update(jobs::table)
-                    .filter(jobs::id.eq(id))
-                    .filter(jobs::status.eq(JobStatus::Pending as i32))
-                    .set((
-                        jobs::status.eq(JobStatus::Cancelled as i32),
-                        jobs::completed_at.eq(now),
-                    ))
-                    .execute(&mut conn)?;
+                let archived = self.archive_transaction(|conn| {
+                    let mut row: JobRow = match jobs::table
+                        .find(id)
+                        .filter(jobs::status.eq(JobStatus::Pending as i32))
+                        .select(JobRow::as_select())
+                        .first(conn)
+                        .optional()?
+                    {
+                        Some(row) => row,
+                        None => return Ok(false),
+                    };
 
-                drop(conn);
-                if affected > 0 {
+                    row.status = JobStatus::Cancelled as i32;
+                    row.completed_at = Some(now);
+                    Self::archive_job_row(conn, &row)?;
+                    Ok(true)
+                })?;
+
+                if archived {
                     self.cascade_cancel(id, "dependency cancelled")?;
                 }
 
-                Ok(affected > 0)
+                Ok(archived)
             }
 
             /// Request cancellation of a running job. The task must check for this.
@@ -597,21 +649,28 @@ macro_rules! impl_diesel_job_ops {
                 Ok(val.unwrap_or(0) != 0)
             }
 
-            /// Mark a job as cancelled (used when a running job detects cancellation).
+            /// Mark a job as cancelled (used when a running job detects
+            /// cancellation). The job moves from `jobs` into `archived_jobs`.
             pub fn mark_cancelled(&self, id: &str) -> Result<()> {
                 let now = now_millis();
-                let mut conn = self.conn()?;
 
-                diesel::update(jobs::table)
-                    .filter(jobs::id.eq(id))
-                    .set((
-                        jobs::status.eq(JobStatus::Cancelled as i32),
-                        jobs::completed_at.eq(now),
-                        jobs::error.eq("cancelled by request"),
-                    ))
-                    .execute(&mut conn)?;
+                self.archive_transaction(|conn| {
+                    let mut row: JobRow = match jobs::table
+                        .find(id)
+                        .select(JobRow::as_select())
+                        .first(conn)
+                        .optional()?
+                    {
+                        Some(row) => row,
+                        None => return Ok(()),
+                    };
 
-                Ok(())
+                    row.status = JobStatus::Cancelled as i32;
+                    row.completed_at = Some(now);
+                    row.error = Some("cancelled by request".to_string());
+                    Self::archive_job_row(conn, &row)?;
+                    Ok(())
+                })
             }
 
             /// Cascade-cancel all pending jobs that depend (directly or transitively)
@@ -645,18 +704,27 @@ macro_rules! impl_diesel_job_ops {
                 if !queue.is_empty() {
                     queue.remove(0);
                 }
+                // Release the BFS connection before the write transaction grabs
+                // its own (single-connection pools would otherwise deadlock).
+                drop(conn);
 
                 if !queue.is_empty() {
                     let error_msg = format!("{reason}: {failed_job_id}");
-                    diesel::update(jobs::table)
-                        .filter(jobs::id.eq_any(&queue))
-                        .filter(jobs::status.eq(JobStatus::Pending as i32))
-                        .set((
-                            jobs::status.eq(JobStatus::Cancelled as i32),
-                            jobs::completed_at.eq(now),
-                            jobs::error.eq(&error_msg),
-                        ))
-                        .execute(&mut conn)?;
+                    self.archive_transaction(|conn| {
+                        let rows: Vec<JobRow> = jobs::table
+                            .filter(jobs::id.eq_any(&queue))
+                            .filter(jobs::status.eq(JobStatus::Pending as i32))
+                            .select(JobRow::as_select())
+                            .load(conn)?;
+
+                        for mut row in rows {
+                            row.status = JobStatus::Cancelled as i32;
+                            row.completed_at = Some(now);
+                            row.error = Some(error_msg.clone());
+                            Self::archive_job_row(conn, &row)?;
+                        }
+                        Ok(())
+                    })?;
                 }
 
                 Ok(())
@@ -714,33 +782,25 @@ macro_rules! impl_diesel_job_ops {
                 offset: i64,
                 namespace: Option<&str>,
             ) -> Result<Vec<Job>> {
-                let mut conn = self.conn()?;
-
-                let mut query = jobs::table.into_boxed().order(jobs::created_at.desc());
-
-                if let Some(s) = status {
-                    query = query.filter(jobs::status.eq(s));
-                }
-                if let Some(q) = queue_name {
-                    query = query.filter(jobs::queue.eq(q));
-                }
-                if let Some(t) = task_name {
-                    query = query.filter(jobs::task_name.eq(t));
-                }
-                if let Some(ns) = namespace {
-                    query = query.filter(jobs::namespace.eq(ns));
-                }
-
-                let rows: Vec<JobRow> = query
-                    .limit(limit)
-                    .offset(offset)
-                    .select(JobRow::as_select())
-                    .load(&mut conn)?;
-
-                Ok(rows.into_iter().map(Job::from).collect())
+                self.list_jobs_filtered(
+                    status, queue_name, task_name, None, None, None, None, limit, offset, namespace,
+                )
             }
 
-            /// Get a job by ID.
+            /// True when `status` is a terminal status whose rows now live in
+            /// `archived_jobs` rather than the live `jobs` table.
+            fn is_terminal_status(status: i32) -> bool {
+                matches!(
+                    JobStatus::from_i32(status),
+                    Some(JobStatus::Complete)
+                        | Some(JobStatus::Failed)
+                        | Some(JobStatus::Dead)
+                        | Some(JobStatus::Cancelled)
+                )
+            }
+
+            /// Get a job by ID. Checks the live `jobs` table first, then falls
+            /// back to `archived_jobs` for terminal jobs.
             pub fn get_job(&self, id: &str) -> Result<Option<Job>> {
                 let mut conn = self.conn()?;
 
@@ -750,86 +810,111 @@ macro_rules! impl_diesel_job_ops {
                     .first(&mut conn)
                     .optional()?;
 
-                Ok(row.map(Job::from))
+                if let Some(row) = row {
+                    return Ok(Some(Job::from(row)));
+                }
+
+                let archived: Option<ArchivedJobRow> = archived_jobs::table
+                    .find(id)
+                    .select(ArchivedJobRow::as_select())
+                    .first(&mut conn)
+                    .optional()?;
+
+                Ok(archived.map(Job::from))
             }
 
-            /// Get queue statistics.
+            /// Get queue statistics. Pending/Running counts come from the live
+            /// `jobs` table; terminal counts come from `archived_jobs`.
             pub fn stats(&self) -> Result<QueueStats> {
                 let mut conn = self.conn()?;
 
-                let rows: Vec<(i32, i64)> = jobs::table
+                let live_rows: Vec<(i32, i64)> = jobs::table
                     .group_by(jobs::status)
                     .select((jobs::status, diesel::dsl::count(jobs::id)))
                     .load(&mut conn)?;
 
-                let mut stats = QueueStats::default();
-                for (status, count) in rows {
-                    match JobStatus::from_i32(status) {
-                        Some(JobStatus::Pending) => stats.pending = count,
-                        Some(JobStatus::Running) => stats.running = count,
-                        Some(JobStatus::Complete) => stats.completed = count,
-                        Some(JobStatus::Failed) => stats.failed = count,
-                        Some(JobStatus::Dead) => stats.dead = count,
-                        Some(JobStatus::Cancelled) => stats.cancelled = count,
-                        None => {}
-                    }
-                }
+                let archived_rows: Vec<(i32, i64)> = archived_jobs::table
+                    .group_by(archived_jobs::status)
+                    .select((archived_jobs::status, diesel::dsl::count(archived_jobs::id)))
+                    .load(&mut conn)?;
 
+                let mut stats = QueueStats::default();
+                Self::apply_status_count(&mut stats, live_rows);
+                Self::apply_status_count(&mut stats, archived_rows);
                 Ok(stats)
             }
 
-            /// Get queue statistics for a specific queue.
+            /// Get queue statistics for a specific queue. Pending/Running counts
+            /// come from `jobs`; terminal counts come from `archived_jobs`.
             pub fn stats_by_queue(&self, queue_name: &str) -> Result<QueueStats> {
                 let mut conn = self.conn()?;
 
-                let rows: Vec<(i32, i64)> = jobs::table
+                let live_rows: Vec<(i32, i64)> = jobs::table
                     .filter(jobs::queue.eq(queue_name))
                     .group_by(jobs::status)
                     .select((jobs::status, diesel::dsl::count(jobs::id)))
                     .load(&mut conn)?;
 
-                let mut stats = QueueStats::default();
-                for (status, count) in rows {
-                    match JobStatus::from_i32(status) {
-                        Some(JobStatus::Pending) => stats.pending = count,
-                        Some(JobStatus::Running) => stats.running = count,
-                        Some(JobStatus::Complete) => stats.completed = count,
-                        Some(JobStatus::Failed) => stats.failed = count,
-                        Some(JobStatus::Dead) => stats.dead = count,
-                        Some(JobStatus::Cancelled) => stats.cancelled = count,
-                        None => {}
-                    }
-                }
+                let archived_rows: Vec<(i32, i64)> = archived_jobs::table
+                    .filter(archived_jobs::queue.eq(queue_name))
+                    .group_by(archived_jobs::status)
+                    .select((archived_jobs::status, diesel::dsl::count(archived_jobs::id)))
+                    .load(&mut conn)?;
 
+                let mut stats = QueueStats::default();
+                Self::apply_status_count(&mut stats, live_rows);
+                Self::apply_status_count(&mut stats, archived_rows);
                 Ok(stats)
             }
 
-            /// Get queue statistics broken down by queue name.
+            /// Get queue statistics broken down by queue name. Pending/Running
+            /// counts come from `jobs`; terminal counts from `archived_jobs`.
             pub fn stats_all_queues(
                 &self,
             ) -> Result<std::collections::HashMap<String, QueueStats>> {
                 let mut conn = self.conn()?;
 
-                let rows: Vec<(String, i32, i64)> = jobs::table
+                let live_rows: Vec<(String, i32, i64)> = jobs::table
                     .group_by((jobs::queue, jobs::status))
                     .select((jobs::queue, jobs::status, diesel::dsl::count(jobs::id)))
                     .load(&mut conn)?;
 
+                let archived_rows: Vec<(String, i32, i64)> = archived_jobs::table
+                    .group_by((archived_jobs::queue, archived_jobs::status))
+                    .select((
+                        archived_jobs::queue,
+                        archived_jobs::status,
+                        diesel::dsl::count(archived_jobs::id),
+                    ))
+                    .load(&mut conn)?;
+
                 let mut map = std::collections::HashMap::<String, QueueStats>::new();
-                for (queue, status, count) in rows {
+                for (queue, status, count) in live_rows.into_iter().chain(archived_rows) {
                     let stats = map.entry(queue).or_default();
-                    match JobStatus::from_i32(status) {
-                        Some(JobStatus::Pending) => stats.pending = count,
-                        Some(JobStatus::Running) => stats.running = count,
-                        Some(JobStatus::Complete) => stats.completed = count,
-                        Some(JobStatus::Failed) => stats.failed = count,
-                        Some(JobStatus::Dead) => stats.dead = count,
-                        Some(JobStatus::Cancelled) => stats.cancelled = count,
-                        None => {}
-                    }
+                    Self::set_status_count(stats, status, count);
                 }
 
                 Ok(map)
+            }
+
+            /// Merge a `(status, count)` GROUP BY result into a `QueueStats`.
+            fn apply_status_count(stats: &mut QueueStats, rows: Vec<(i32, i64)>) {
+                for (status, count) in rows {
+                    Self::set_status_count(stats, status, count);
+                }
+            }
+
+            /// Assign a per-status count into the matching `QueueStats` field.
+            fn set_status_count(stats: &mut QueueStats, status: i32, count: i64) {
+                match JobStatus::from_i32(status) {
+                    Some(JobStatus::Pending) => stats.pending = count,
+                    Some(JobStatus::Running) => stats.running = count,
+                    Some(JobStatus::Complete) => stats.completed = count,
+                    Some(JobStatus::Failed) => stats.failed = count,
+                    Some(JobStatus::Dead) => stats.dead = count,
+                    Some(JobStatus::Cancelled) => stats.cancelled = count,
+                    None => {}
+                }
             }
 
             /// List jobs with extended filters.
@@ -837,6 +922,86 @@ macro_rules! impl_diesel_job_ops {
             /// When `None`, all jobs are returned regardless of namespace.
             #[allow(clippy::too_many_arguments)]
             pub fn list_jobs_filtered(
+                &self,
+                status: Option<i32>,
+                queue_name: Option<&str>,
+                task_name: Option<&str>,
+                metadata_like: Option<&str>,
+                error_like: Option<&str>,
+                created_after: Option<i64>,
+                created_before: Option<i64>,
+                limit: i64,
+                offset: i64,
+                namespace: Option<&str>,
+            ) -> Result<Vec<Job>> {
+                // Terminal statuses now live in `archived_jobs`; live statuses in
+                // `jobs`. With no status filter, both tables are merged.
+                match status {
+                    Some(s) if Self::is_terminal_status(s) => self.list_archived_filtered(
+                        Some(s),
+                        queue_name,
+                        task_name,
+                        metadata_like,
+                        error_like,
+                        created_after,
+                        created_before,
+                        limit,
+                        offset,
+                        namespace,
+                    ),
+                    Some(_) => self.list_live_filtered(
+                        status,
+                        queue_name,
+                        task_name,
+                        metadata_like,
+                        error_like,
+                        created_after,
+                        created_before,
+                        limit,
+                        offset,
+                        namespace,
+                    ),
+                    None => {
+                        // Fetch enough from each table to satisfy limit+offset,
+                        // then merge by created_at desc and paginate in memory.
+                        let take = limit.saturating_add(offset).max(0);
+                        let mut live = self.list_live_filtered(
+                            None,
+                            queue_name,
+                            task_name,
+                            metadata_like,
+                            error_like,
+                            created_after,
+                            created_before,
+                            take,
+                            0,
+                            namespace,
+                        )?;
+                        let archived = self.list_archived_filtered(
+                            None,
+                            queue_name,
+                            task_name,
+                            metadata_like,
+                            error_like,
+                            created_after,
+                            created_before,
+                            take,
+                            0,
+                            namespace,
+                        )?;
+                        live.extend(archived);
+                        live.sort_by_key(|j| std::cmp::Reverse(j.created_at));
+
+                        let start = (offset.max(0) as usize).min(live.len());
+                        let end = start.saturating_add(limit.max(0) as usize).min(live.len());
+                        Ok(live[start..end].to_vec())
+                    }
+                }
+            }
+
+            /// Query the live `jobs` table with the shared filter set.
+            #[allow(clippy::too_many_arguments)]
+            fn list_live_filtered(
                 &self,
                 status: Option<i32>,
                 queue_name: Option<&str>,
@@ -887,60 +1052,118 @@ macro_rules! impl_diesel_job_ops {
                 Ok(rows.into_iter().map(Job::from).collect())
             }
 
-            /// Purge completed jobs older than the given timestamp.
-            pub fn purge_completed(&self, older_than_ms: i64) -> Result<u64> {
+            /// Query the `archived_jobs` table with the shared filter set.
+            #[allow(clippy::too_many_arguments)]
+            fn list_archived_filtered(
+                &self,
+                status: Option<i32>,
+                queue_name: Option<&str>,
+                task_name: Option<&str>,
+                metadata_like: Option<&str>,
+                error_like: Option<&str>,
+                created_after: Option<i64>,
+                created_before: Option<i64>,
+                limit: i64,
+                offset: i64,
+                namespace: Option<&str>,
+            ) -> Result<Vec<Job>> {
                 let mut conn = self.conn()?;
 
-                conn.transaction(|conn| {
-                    let job_ids: Vec<String> = jobs::table
-                        .filter(jobs::status.eq(JobStatus::Complete as i32))
-                        .filter(jobs::completed_at.lt(older_than_ms))
-                        .select(jobs::id)
+                let mut query = archived_jobs::table
+                    .into_boxed()
+                    .order(archived_jobs::created_at.desc());
+
+                if let Some(s) = status {
+                    query = query.filter(archived_jobs::status.eq(s));
+                }
+                if let Some(q) = queue_name {
+                    query = query.filter(archived_jobs::queue.eq(q));
+                }
+                if let Some(t) = task_name {
+                    query = query.filter(archived_jobs::task_name.eq(t));
+                }
+                if let Some(m) = metadata_like {
+                    query = query.filter(archived_jobs::metadata.like(format!("%{m}%")));
+                }
+                if let Some(e) = error_like {
+                    query = query.filter(archived_jobs::error.like(format!("%{e}%")));
+                }
+                if let Some(after) = created_after {
+                    query = query.filter(archived_jobs::created_at.ge(after));
+                }
+                if let Some(before) = created_before {
+                    query = query.filter(archived_jobs::created_at.le(before));
+                }
+                if let Some(ns) = namespace {
+                    query = query.filter(archived_jobs::namespace.eq(ns));
+                }
+
+                let rows: Vec<ArchivedJobRow> = query
+                    .limit(limit)
+                    .offset(offset)
+                    .select(ArchivedJobRow::as_select())
+                    .load(&mut conn)?;
+
+                Ok(rows.into_iter().map(Job::from).collect())
+            }
+
+            /// Purge completed jobs older than the given timestamp. Terminal
+            /// jobs live in `archived_jobs`, so the purge targets that table.
+            pub fn purge_completed(&self, older_than_ms: i64) -> Result<u64> {
+                self.archive_transaction(|conn| {
+                    let job_ids: Vec<String> = archived_jobs::table
+                        .filter(archived_jobs::status.eq(JobStatus::Complete as i32))
+                        .filter(archived_jobs::completed_at.lt(older_than_ms))
+                        .select(archived_jobs::id)
                         .load(conn)?;
 
                     Self::delete_job_children(conn, &job_ids)?;
 
-                    let affected = diesel::delete(jobs::table.filter(jobs::id.eq_any(&job_ids)))
-                        .execute(conn)?;
+                    let affected = diesel::delete(
+                        archived_jobs::table.filter(archived_jobs::id.eq_any(&job_ids)),
+                    )
+                    .execute(conn)?;
 
                     Ok(affected as u64)
                 })
             }
 
-            /// Purge completed jobs respecting per-job result_ttl_ms.
+            /// Purge completed jobs respecting per-job result_ttl_ms. Terminal
+            /// jobs live in `archived_jobs`, so the purge targets that table.
             pub fn purge_completed_with_ttl(&self, global_cutoff_ms: i64) -> Result<u64> {
                 let now = now_millis();
-                let mut conn = self.conn()?;
 
-                conn.transaction(|conn| {
-                    let global_ids: Vec<String> = jobs::table
-                        .filter(jobs::status.eq(JobStatus::Complete as i32))
-                        .filter(jobs::result_ttl_ms.is_null())
-                        .filter(jobs::completed_at.lt(global_cutoff_ms))
-                        .select(jobs::id)
+                self.archive_transaction(|conn| {
+                    let global_ids: Vec<String> = archived_jobs::table
+                        .filter(archived_jobs::status.eq(JobStatus::Complete as i32))
+                        .filter(archived_jobs::result_ttl_ms.is_null())
+                        .filter(archived_jobs::completed_at.lt(global_cutoff_ms))
+                        .select(archived_jobs::id)
                         .load(conn)?;
 
                     // Push the per-job `completed_at + result_ttl_ms < now`
                     // check into SQL and select only the id — avoids loading
                     // full rows (payload + result blobs) just to filter them.
-                    let per_job_ids: Vec<String> = jobs::table
-                        .filter(jobs::status.eq(JobStatus::Complete as i32))
-                        .filter(jobs::result_ttl_ms.is_not_null())
-                        .filter(jobs::completed_at.is_not_null())
+                    let per_job_ids: Vec<String> = archived_jobs::table
+                        .filter(archived_jobs::status.eq(JobStatus::Complete as i32))
+                        .filter(archived_jobs::result_ttl_ms.is_not_null())
+                        .filter(archived_jobs::completed_at.is_not_null())
                         .filter(
-                            (jobs::completed_at.assume_not_null()
-                                + jobs::result_ttl_ms.assume_not_null())
+                            (archived_jobs::completed_at.assume_not_null()
+                                + archived_jobs::result_ttl_ms.assume_not_null())
                             .lt(now),
                         )
-                        .select(jobs::id)
+                        .select(archived_jobs::id)
                         .load(conn)?;
 
                     let all_ids: Vec<String> = global_ids.into_iter().chain(per_job_ids).collect();
 
                     Self::delete_job_children(conn, &all_ids)?;
 
-                    let affected = diesel::delete(jobs::table.filter(jobs::id.eq_any(&all_ids)))
-                        .execute(conn)?;
+                    let affected = diesel::delete(
+                        archived_jobs::table.filter(archived_jobs::id.eq_any(&all_ids)),
+                    )
+                    .execute(conn)?;
 
                     Ok(affected as u64)
                 })
@@ -997,58 +1220,66 @@ macro_rules! impl_diesel_job_ops {
                 Ok(rows)
             }
 
+            /// Archive a set of pending job rows as cancelled with the given
+            /// error, moving each from `jobs` to `archived_jobs`.
+            fn archive_pending_rows(
+                conn: &mut $conn_type,
+                rows: Vec<JobRow>,
+                now: i64,
+                error: &str,
+            ) -> diesel::result::QueryResult<u64> {
+                let count = rows.len() as u64;
+                for mut row in rows {
+                    row.status = JobStatus::Cancelled as i32;
+                    row.completed_at = Some(now);
+                    row.error = Some(error.to_string());
+                    Self::archive_job_row(conn, &row)?;
+                }
+                Ok(count)
+            }
+
             /// Expire pending jobs that have passed their expires_at.
             pub fn expire_pending_jobs(&self, now: i64) -> Result<u64> {
-                let mut conn = self.conn()?;
+                self.archive_transaction(|conn| {
+                    let rows: Vec<JobRow> = jobs::table
+                        .filter(jobs::status.eq(JobStatus::Pending as i32))
+                        .filter(jobs::expires_at.is_not_null())
+                        .filter(jobs::expires_at.lt(now))
+                        .select(JobRow::as_select())
+                        .load(conn)?;
 
-                let affected = diesel::update(jobs::table)
-                    .filter(jobs::status.eq(JobStatus::Pending as i32))
-                    .filter(jobs::expires_at.is_not_null())
-                    .filter(jobs::expires_at.lt(now))
-                    .set((
-                        jobs::status.eq(JobStatus::Cancelled as i32),
-                        jobs::completed_at.eq(now),
-                        jobs::error.eq("expired"),
-                    ))
-                    .execute(&mut conn)?;
-
-                Ok(affected as u64)
+                    Ok(Self::archive_pending_rows(conn, rows, now, "expired")?)
+                })
             }
 
             /// Cancel all pending jobs in a specific queue.
             pub fn cancel_pending_by_queue(&self, queue: &str) -> Result<u64> {
-                let mut conn = self.conn()?;
                 let now = now_millis();
 
-                let affected = diesel::update(jobs::table)
-                    .filter(jobs::status.eq(JobStatus::Pending as i32))
-                    .filter(jobs::queue.eq(queue))
-                    .set((
-                        jobs::status.eq(JobStatus::Cancelled as i32),
-                        jobs::completed_at.eq(now),
-                        jobs::error.eq("purged"),
-                    ))
-                    .execute(&mut conn)?;
+                self.archive_transaction(|conn| {
+                    let rows: Vec<JobRow> = jobs::table
+                        .filter(jobs::status.eq(JobStatus::Pending as i32))
+                        .filter(jobs::queue.eq(queue))
+                        .select(JobRow::as_select())
+                        .load(conn)?;
 
-                Ok(affected as u64)
+                    Ok(Self::archive_pending_rows(conn, rows, now, "purged")?)
+                })
             }
 
             /// Cancel all pending jobs for a specific task name.
             pub fn cancel_pending_by_task(&self, task_name: &str) -> Result<u64> {
-                let mut conn = self.conn()?;
                 let now = now_millis();
 
-                let affected = diesel::update(jobs::table)
-                    .filter(jobs::status.eq(JobStatus::Pending as i32))
-                    .filter(jobs::task_name.eq(task_name))
-                    .set((
-                        jobs::status.eq(JobStatus::Cancelled as i32),
-                        jobs::completed_at.eq(now),
-                        jobs::error.eq("revoked"),
-                    ))
-                    .execute(&mut conn)?;
+                self.archive_transaction(|conn| {
+                    let rows: Vec<JobRow> = jobs::table
+                        .filter(jobs::status.eq(JobStatus::Pending as i32))
+                        .filter(jobs::task_name.eq(task_name))
+                        .select(JobRow::as_select())
+                        .load(conn)?;
 
-                Ok(affected as u64)
+                    Ok(Self::archive_pending_rows(conn, rows, now, "revoked")?)
+                })
             }
 
             /// Count running jobs for a specific task name (for per-task concurrency limiting).

--- a/crates/taskito-core/src/storage/diesel_common/jobs.rs
+++ b/crates/taskito-core/src/storage/diesel_common/jobs.rs
@@ -89,13 +89,62 @@ macro_rules! impl_diesel_job_ops {
                     return Ok(true);
                 }
 
-                let incomplete: i64 = jobs::table
+                // A dependency is incomplete if it is non-Complete in the live
+                // `jobs` table OR non-Complete in `archived_jobs` (a terminal
+                // parent that was cancelled/failed/dead has been archived and
+                // must still block its dependents; an archived-Complete parent
+                // is counted as satisfied).
+                let live_incomplete: i64 = jobs::table
                     .filter(jobs::id.eq_any(&dep_job_ids))
                     .filter(jobs::status.ne(JobStatus::Complete as i32))
                     .count()
                     .get_result(conn)?;
 
-                Ok(incomplete == 0)
+                let archived_incomplete: i64 = archived_jobs::table
+                    .filter(archived_jobs::id.eq_any(&dep_job_ids))
+                    .filter(archived_jobs::status.ne(JobStatus::Complete as i32))
+                    .count()
+                    .get_result(conn)?;
+
+                Ok(live_incomplete + archived_incomplete == 0)
+            }
+
+            /// Validate that a dependency exists and is in an acceptable state.
+            /// A live (pending/running) or archived-complete dependency is
+            /// accepted; a dead/cancelled/failed dependency or a missing one is
+            /// rejected via `RollbackTransaction`. Terminal deps live in
+            /// `archived_jobs`, so a missing live row falls back to the archive.
+            fn validate_dependency(
+                conn: &mut $conn_type,
+                dep_id: &str,
+            ) -> diesel::result::QueryResult<()> {
+                let dep: Option<JobRow> = jobs::table
+                    .find(dep_id)
+                    .select(JobRow::as_select())
+                    .first(conn)
+                    .optional()?;
+
+                match dep {
+                    Some(d)
+                        if d.status == JobStatus::Dead as i32
+                            || d.status == JobStatus::Cancelled as i32 =>
+                    {
+                        Err(diesel::result::Error::RollbackTransaction)
+                    }
+                    Some(_) => Ok(()),
+                    None => {
+                        let archived: Option<ArchivedJobRow> = archived_jobs::table
+                            .find(dep_id)
+                            .select(ArchivedJobRow::as_select())
+                            .first(conn)
+                            .optional()?;
+
+                        match archived {
+                            Some(a) if a.status == JobStatus::Complete as i32 => Ok(()),
+                            _ => Err(diesel::result::Error::RollbackTransaction),
+                        }
+                    }
+                }
             }
 
             /// Insert a new job into the queue. Returns the job.
@@ -105,24 +154,11 @@ macro_rules! impl_diesel_job_ops {
                 let mut conn = self.conn()?;
 
                 conn.transaction(|conn| {
-                    // Validate dependencies exist and aren't dead/cancelled
+                    // Validate dependencies exist and aren't dead/cancelled.
+                    // Terminal deps live in `archived_jobs`, so a missing live
+                    // row falls back to the archive.
                     for dep_id in &depends_on {
-                        let dep: Option<JobRow> = jobs::table
-                            .find(dep_id)
-                            .select(JobRow::as_select())
-                            .first(conn)
-                            .optional()?;
-
-                        match dep {
-                            None => return Err(diesel::result::Error::RollbackTransaction),
-                            Some(d)
-                                if d.status == JobStatus::Dead as i32
-                                    || d.status == JobStatus::Cancelled as i32 =>
-                            {
-                                return Err(diesel::result::Error::RollbackTransaction);
-                            }
-                            _ => {}
-                        }
+                        Self::validate_dependency(conn, dep_id)?;
                     }
 
                     let row = NewJobRow {

--- a/crates/taskito-core/src/storage/diesel_common/migrations.rs
+++ b/crates/taskito-core/src/storage/diesel_common/migrations.rs
@@ -285,6 +285,9 @@ pub fn create_indexes() -> &'static [&'static str] {
         "CREATE INDEX IF NOT EXISTS idx_task_logs_job_id ON task_logs(job_id)",
         "CREATE INDEX IF NOT EXISTS idx_task_logs_recorded ON task_logs(logged_at)",
         "CREATE INDEX IF NOT EXISTS idx_archived_jobs_completed ON archived_jobs(completed_at)",
+        "CREATE INDEX IF NOT EXISTS idx_archived_jobs_status ON archived_jobs(status)",
+        "CREATE INDEX IF NOT EXISTS idx_archived_jobs_queue_status
+                ON archived_jobs(queue, status)",
         "CREATE INDEX IF NOT EXISTS idx_distributed_locks_expires ON distributed_locks(expires_at)",
         "CREATE INDEX IF NOT EXISTS idx_execution_claims_claimed ON execution_claims(claimed_at)",
     ]

--- a/crates/taskito-core/src/storage/models.rs
+++ b/crates/taskito-core/src/storage/models.rs
@@ -423,3 +423,36 @@ pub struct ArchivedJobRow {
     pub result_ttl_ms: Option<i64>,
     pub namespace: Option<String>,
 }
+
+/// Insertable struct for archived job entries.
+///
+/// Mirrors [`ArchivedJobRow`] with borrowed fields. The `archived_jobs` table
+/// has no `has_deps` column (terminal jobs are never re-dequeued), so it is
+/// absent here.
+#[derive(Insertable, Debug)]
+#[diesel(table_name = archived_jobs)]
+pub struct NewArchivedJobRow<'a> {
+    pub id: &'a str,
+    pub queue: &'a str,
+    pub task_name: &'a str,
+    pub payload: &'a [u8],
+    pub status: i32,
+    pub priority: i32,
+    pub created_at: i64,
+    pub scheduled_at: i64,
+    pub started_at: Option<i64>,
+    pub completed_at: Option<i64>,
+    pub retry_count: i32,
+    pub max_retries: i32,
+    pub result: Option<&'a [u8]>,
+    pub error: Option<&'a str>,
+    pub timeout_ms: i64,
+    pub unique_key: Option<&'a str>,
+    pub progress: Option<i32>,
+    pub metadata: Option<&'a str>,
+    pub notes: Option<&'a str>,
+    pub cancel_requested: i32,
+    pub expires_at: Option<i64>,
+    pub result_ttl_ms: Option<i64>,
+    pub namespace: Option<&'a str>,
+}

--- a/crates/taskito-core/src/storage/postgres/archival.rs
+++ b/crates/taskito-core/src/storage/postgres/archival.rs
@@ -20,8 +20,18 @@ impl PostgresStorage {
         );
 
         conn.transaction(|conn| {
+            // Explicit column lists: `jobs` has a `has_deps` column that
+            // `archived_jobs` lacks, so `SELECT *` would misalign columns.
             let affected = diesel::sql_query(format!(
-                "INSERT INTO archived_jobs SELECT * FROM jobs \
+                "INSERT INTO archived_jobs \
+                 (id, queue, task_name, payload, status, priority, created_at, scheduled_at, \
+                  started_at, completed_at, retry_count, max_retries, result, error, timeout_ms, \
+                  unique_key, progress, metadata, notes, cancel_requested, expires_at, \
+                  result_ttl_ms, namespace) \
+                 SELECT id, queue, task_name, payload, status, priority, created_at, scheduled_at, \
+                  started_at, completed_at, retry_count, max_retries, result, error, timeout_ms, \
+                  unique_key, progress, metadata, notes, cancel_requested, expires_at, \
+                  result_ttl_ms, namespace FROM jobs \
                  WHERE status IN ({archivable_statuses}) AND completed_at IS NOT NULL AND completed_at < $1 \
                  ON CONFLICT (id) DO NOTHING",
             ))

--- a/crates/taskito-core/src/storage/postgres/jobs.rs
+++ b/crates/taskito-core/src/storage/postgres/jobs.rs
@@ -3,7 +3,7 @@ use diesel::prelude::*;
 
 use super::super::models::*;
 use super::super::schema::{
-    job_dependencies, job_errors, jobs, replay_history, task_logs, task_metrics,
+    archived_jobs, job_dependencies, job_errors, jobs, replay_history, task_logs, task_metrics,
 };
 use super::PostgresStorage;
 use crate::error::{QueueError, Result};
@@ -11,3 +11,18 @@ use crate::job::{now_millis, Job, JobStatus, NewJob};
 use crate::storage::QueueStats;
 
 crate::storage::diesel_common::impl_diesel_job_ops!(PostgresStorage, PgConnection);
+
+impl PostgresStorage {
+    /// Run a read-then-write unit of work in a transaction. Postgres serializes
+    /// row-level writes without the SQLite lock-upgrade deadlock, so a regular
+    /// transaction suffices; this mirrors [`SqliteStorage::archive_transaction`]
+    /// so the shared job-ops macro can call one name on both backends.
+    pub(crate) fn archive_transaction<T, F>(&self, f: F) -> Result<T>
+    where
+        F: FnOnce(&mut PgConnection) -> std::result::Result<T, QueueError>,
+    {
+        let mut pooled = self.conn()?;
+        let conn: &mut PgConnection = &mut pooled;
+        conn.transaction(f)
+    }
+}

--- a/crates/taskito-core/src/storage/postgres/mod.rs
+++ b/crates/taskito-core/src/storage/postgres/mod.rs
@@ -144,6 +144,12 @@ impl PostgresStorage {
         for sql in common_migrations::backfill_statements() {
             diesel::sql_query(*sql).execute(&mut conn)?;
         }
+        drop(conn);
+
+        // Drain any pre-existing terminal jobs left in `jobs` by older
+        // versions into `archived_jobs`. Terminal jobs now live there from the
+        // moment they transition; this one-time sweep migrates the backlog.
+        self.archive_old_jobs(i64::MAX)?;
 
         Ok(())
     }

--- a/crates/taskito-core/src/storage/redis_backend/archival.rs
+++ b/crates/taskito-core/src/storage/redis_backend/archival.rs
@@ -20,19 +20,11 @@ impl RedisStorage {
                 if let Some(job) = self.load_job(&mut conn, id)? {
                     if let Some(completed_at) = job.completed_at {
                         if completed_at < cutoff_ms {
-                            // Store in archive
-                            let archived_key = self.key(&["archived", id]);
-                            let archived_all = self.key(&["archived", "all"]);
-                            let job_json = serde_json::to_string(&job)
-                                .map_err(|e| QueueError::Other(e.to_string()))?;
-
-                            let pipe = &mut redis::pipe();
-                            pipe.set(&archived_key, &job_json);
-                            pipe.zadd(&archived_all, id, completed_at as f64);
-                            pipe.query::<()>(&mut conn).map_err(map_err)?;
-
-                            // Delete original job
-                            self.delete_job_fully(&mut conn, &job)?;
+                            // Move the job out of every live index and into the
+                            // archive (including the per-status archive set used
+                            // by stats and list_jobs).
+                            let old_status = job.status;
+                            self.archive_job_immediately(&mut conn, &job, old_status)?;
                             count += 1;
                         }
                     }

--- a/crates/taskito-core/src/storage/redis_backend/dead_letter.rs
+++ b/crates/taskito-core/src/storage/redis_backend/dead_letter.rs
@@ -83,13 +83,13 @@ impl RedisStorage {
         pipe.zadd(&dlq_all, &dlq_id, now as f64);
         pipe.query::<()>(&mut conn).map_err(map_err)?;
 
-        // Update job status to Dead
+        // Archive the now-Dead job out of the live indices.
         let mut dead_job = job.clone();
         let old_status = dead_job.status;
         dead_job.status = JobStatus::Dead;
         dead_job.error = Some(error.to_string());
         dead_job.completed_at = Some(now);
-        self.save_job_and_move_status(&mut conn, &dead_job, old_status)?;
+        self.archive_job_immediately(&mut conn, &dead_job, old_status)?;
 
         // Cascade cancel dependents
         drop(conn);

--- a/crates/taskito-core/src/storage/redis_backend/jobs/dequeue.rs
+++ b/crates/taskito-core/src/storage/redis_backend/jobs/dequeue.rs
@@ -64,9 +64,9 @@ impl RedisStorage {
                     job.status = JobStatus::Cancelled;
                     job.completed_at = Some(now);
                     job.error = Some("expired before execution".to_string());
-                    self.save_job_and_move_status(&mut conn, &job, JobStatus::Pending)?;
                     conn.zrem::<_, _, ()>(&queue_key, &job_id)
                         .map_err(map_err)?;
+                    self.archive_job_immediately(&mut conn, &job, JobStatus::Pending)?;
                     continue;
                 }
             }

--- a/crates/taskito-core/src/storage/redis_backend/jobs/dequeue.rs
+++ b/crates/taskito-core/src/storage/redis_backend/jobs/dequeue.rs
@@ -80,14 +80,19 @@ impl RedisStorage {
                 if !dep_ids.is_empty() {
                     let mut all_complete = true;
                     for dep_id in &dep_ids {
-                        if let Some(dep_job) = self.load_job(&mut conn, dep_id)? {
-                            if dep_job.status != JobStatus::Complete {
+                        // A completed dep has been archived out of the live
+                        // indices, so fall back to the archive before deciding
+                        // the dep is unsatisfied.
+                        let dep_job = match self.load_job(&mut conn, dep_id)? {
+                            Some(j) => Some(j),
+                            None => self.load_archived_job(&mut conn, dep_id)?,
+                        };
+                        match dep_job {
+                            Some(dep_job) if dep_job.status == JobStatus::Complete => {}
+                            _ => {
                                 all_complete = false;
                                 break;
                             }
-                        } else {
-                            all_complete = false;
-                            break;
                         }
                     }
                     if !all_complete {
@@ -214,14 +219,19 @@ impl RedisStorage {
                 if !dep_ids.is_empty() {
                     let mut all_complete = true;
                     for dep_id in &dep_ids {
-                        if let Some(dep_job) = self.load_job(&mut conn, dep_id)? {
-                            if dep_job.status != JobStatus::Complete {
+                        // A completed dep has been archived out of the live
+                        // indices, so fall back to the archive before deciding
+                        // the dep is unsatisfied.
+                        let dep_job = match self.load_job(&mut conn, dep_id)? {
+                            Some(j) => Some(j),
+                            None => self.load_archived_job(&mut conn, dep_id)?,
+                        };
+                        match dep_job {
+                            Some(dep_job) if dep_job.status == JobStatus::Complete => {}
+                            _ => {
                                 all_complete = false;
                                 break;
                             }
-                        } else {
-                            all_complete = false;
-                            break;
                         }
                     }
                     if !all_complete {

--- a/crates/taskito-core/src/storage/redis_backend/jobs/enqueue.rs
+++ b/crates/taskito-core/src/storage/redis_backend/jobs/enqueue.rs
@@ -24,13 +24,19 @@ impl RedisStorage {
             if skip.is_some_and(|s| s.contains(dep_id.as_str())) {
                 continue;
             }
+            // A live dep is read from `job:<id>`; a terminal dep has been
+            // archived, so a missing live row falls back to `archived:<id>`.
+            // A completed archived dep is valid; any other state is rejected.
             let dep_key = self.key(&["job", dep_id]);
             let data: Option<String> = conn.get(&dep_key).map_err(map_err)?;
             let dep_job: Job = match data {
-                None => return Err(QueueError::DependencyNotFound(DEP_MISSING.to_string())),
                 Some(d) => {
                     serde_json::from_str(&d).map_err(|e| QueueError::Other(e.to_string()))?
                 }
+                None => match self.load_archived_job(conn, dep_id)? {
+                    Some(archived) if archived.status == JobStatus::Complete => continue,
+                    _ => return Err(QueueError::DependencyNotFound(DEP_MISSING.to_string())),
+                },
             };
             if dep_job.status == JobStatus::Dead || dep_job.status == JobStatus::Cancelled {
                 return Err(QueueError::DependencyNotFound(DEP_MISSING.to_string()));

--- a/crates/taskito-core/src/storage/redis_backend/jobs/helpers.rs
+++ b/crates/taskito-core/src/storage/redis_backend/jobs/helpers.rs
@@ -24,6 +24,23 @@ impl RedisStorage {
         }
     }
 
+    pub(in crate::storage::redis_backend) fn load_archived_job(
+        &self,
+        conn: &mut redis::Connection,
+        id: &str,
+    ) -> Result<Option<Job>> {
+        let archived_key = self.key(&["archived", id]);
+        let data: Option<String> = conn.get(&archived_key).map_err(map_err)?;
+        match data {
+            Some(d) => {
+                let job: Job =
+                    serde_json::from_str(&d).map_err(|e| QueueError::Other(e.to_string()))?;
+                Ok(Some(job))
+            }
+            None => Ok(None),
+        }
+    }
+
     pub(super) fn get_job_required(&self, id: &str) -> Result<Job> {
         self.get_job(id)?
             .ok_or_else(|| QueueError::JobNotFound(id.to_string()))
@@ -52,28 +69,73 @@ impl RedisStorage {
         Ok(())
     }
 
-    /// Delete a job and all its associated data.
-    pub(in crate::storage::redis_backend) fn delete_job_fully(
+    /// Move a terminal job out of the live indices into the archive in a single
+    /// pipeline. Removes it from `job:<id>`, the live status / by_queue /
+    /// by_task sets and the `jobs:all` zset, then writes `archived:<id>`, adds
+    /// it to `archived:status:<n>` and scores it into `archived:all` by
+    /// completed_at.
+    ///
+    /// `old_status` is the status the job held in the live `jobs:status:<n>`
+    /// set; the caller must have already set the job's terminal `status`,
+    /// `completed_at` (and `error`/`result` as appropriate).
+    pub(in crate::storage::redis_backend) fn archive_job_immediately(
+        &self,
+        conn: &mut redis::Connection,
+        job: &Job,
+        old_status: JobStatus,
+    ) -> Result<()> {
+        let job_json = serde_json::to_string(job).map_err(|e| QueueError::Other(e.to_string()))?;
+        let completed_at = job.completed_at.unwrap_or_else(crate::job::now_millis);
+
+        let job_key = self.key(&["job", &job.id]);
+        let status_key = self.key(&["jobs", "status", &(old_status as i32).to_string()]);
+        let by_queue_key = self.key(&["jobs", "by_queue", &job.queue]);
+        let by_task_key = self.key(&["jobs", "by_task", &job.task_name]);
+        let all_key = self.key(&["jobs", "all"]);
+        let archived_key = self.key(&["archived", &job.id]);
+        let archived_status_key =
+            self.key(&["archived", "status", &(job.status as i32).to_string()]);
+        let archived_by_queue = self.key(&["archived", "by_queue", &job.queue]);
+        let archived_all = self.key(&["archived", "all"]);
+
+        let pipe = &mut redis::pipe();
+        pipe.del(&job_key);
+        pipe.srem(&status_key, &job.id);
+        pipe.srem(&by_queue_key, &job.id);
+        pipe.srem(&by_task_key, &job.id);
+        pipe.zrem(&all_key, &job.id);
+        pipe.set(&archived_key, &job_json);
+        pipe.sadd(&archived_status_key, &job.id);
+        pipe.sadd(&archived_by_queue, &job.id);
+        pipe.zadd(&archived_all, &job.id, completed_at as f64);
+        pipe.query::<()>(conn).map_err(map_err)?;
+
+        Ok(())
+    }
+
+    /// Delete an archived job and all its associated data: `archived:<id>`,
+    /// `archived:status:<n>`, `archived:all`, plus per-job error/dependency
+    /// keys (which are keyed by job id regardless of which table holds it).
+    pub(in crate::storage::redis_backend) fn delete_archived_job(
         &self,
         conn: &mut redis::Connection,
         job: &Job,
     ) -> Result<()> {
         let pipe = &mut redis::pipe();
 
-        let job_key = self.key(&["job", &job.id]);
-        let status_key = self.key(&["jobs", "status", &(job.status as i32).to_string()]);
-        let by_queue_key = self.key(&["jobs", "by_queue", &job.queue]);
-        let by_task_key = self.key(&["jobs", "by_task", &job.task_name]);
-        let all_key = self.key(&["jobs", "all"]);
+        let archived_key = self.key(&["archived", &job.id]);
+        let archived_status_key =
+            self.key(&["archived", "status", &(job.status as i32).to_string()]);
+        let archived_by_queue = self.key(&["archived", "by_queue", &job.queue]);
+        let archived_all = self.key(&["archived", "all"]);
         let errors_key = self.key(&["job_errors", &job.id]);
         let deps_key = self.key(&["job", &job.id, "depends_on"]);
         let dependents_key = self.key(&["job", &job.id, "dependents"]);
 
-        pipe.del(&job_key);
-        pipe.srem(&status_key, &job.id);
-        pipe.srem(&by_queue_key, &job.id);
-        pipe.srem(&by_task_key, &job.id);
-        pipe.zrem(&all_key, &job.id);
+        pipe.del(&archived_key);
+        pipe.srem(&archived_status_key, &job.id);
+        pipe.srem(&archived_by_queue, &job.id);
+        pipe.zrem(&archived_all, &job.id);
         pipe.del(&errors_key);
         pipe.del(&deps_key);
         pipe.del(&dependents_key);

--- a/crates/taskito-core/src/storage/redis_backend/jobs/helpers.rs
+++ b/crates/taskito-core/src/storage/redis_backend/jobs/helpers.rs
@@ -41,8 +41,13 @@ impl RedisStorage {
         }
     }
 
+    /// Live-only required lookup for write/mutator paths. Resolves `job:<id>`
+    /// directly without the archived fallback, so a mutator never operates on a
+    /// terminal job that has already left the live indices (which would leave
+    /// the reindex partial). Read paths must use `get_job` instead.
     pub(super) fn get_job_required(&self, id: &str) -> Result<Job> {
-        self.get_job(id)?
+        let mut conn = self.conn()?;
+        self.load_job(&mut conn, id)?
             .ok_or_else(|| QueueError::JobNotFound(id.to_string()))
     }
 
@@ -92,18 +97,27 @@ impl RedisStorage {
         let by_queue_key = self.key(&["jobs", "by_queue", &job.queue]);
         let by_task_key = self.key(&["jobs", "by_task", &job.task_name]);
         let all_key = self.key(&["jobs", "all"]);
+        let pending_key = self.key(&["queue", &job.queue, "pending"]);
         let archived_key = self.key(&["archived", &job.id]);
         let archived_status_key =
             self.key(&["archived", "status", &(job.status as i32).to_string()]);
         let archived_by_queue = self.key(&["archived", "by_queue", &job.queue]);
         let archived_all = self.key(&["archived", "all"]);
 
+        // `.atomic()` wraps the live→archive move in MULTI/EXEC so the job is
+        // never observable in both the live and archived indices at once.
         let pipe = &mut redis::pipe();
+        pipe.atomic();
         pipe.del(&job_key);
         pipe.srem(&status_key, &job.id);
         pipe.srem(&by_queue_key, &job.id);
         pipe.srem(&by_task_key, &job.id);
         pipe.zrem(&all_key, &job.id);
+        // Pending jobs still sit in the per-queue pending zset; running jobs
+        // were removed at dequeue, so only remove on a Pending→terminal move.
+        if old_status == JobStatus::Pending {
+            pipe.zrem(&pending_key, &job.id);
+        }
         pipe.set(&archived_key, &job_json);
         pipe.sadd(&archived_status_key, &job.id);
         pipe.sadd(&archived_by_queue, &job.id);
@@ -140,9 +154,16 @@ impl RedisStorage {
         pipe.del(&deps_key);
         pipe.del(&dependents_key);
 
+        // Only release the unique-key pointer if it still points at THIS job.
+        // `enqueue_unique` stores the job id at `jobs:unique:<uk>`; a newer live
+        // job may have reused the same `unique_key` after this row was archived,
+        // and deleting the pointer would clobber the new job's lock.
         if let Some(ref uk) = job.unique_key {
             let unique_key = self.key(&["jobs", "unique", uk]);
-            pipe.del(&unique_key);
+            let owner: Option<String> = conn.get(&unique_key).map_err(map_err)?;
+            if owner.as_deref() == Some(job.id.as_str()) {
+                pipe.del(&unique_key);
+            }
         }
 
         pipe.query::<()>(conn).map_err(map_err)?;

--- a/crates/taskito-core/src/storage/redis_backend/jobs/maintenance.rs
+++ b/crates/taskito-core/src/storage/redis_backend/jobs/maintenance.rs
@@ -10,15 +10,20 @@ use crate::storage::redis_backend::{map_err, RedisStorage};
 impl RedisStorage {
     pub fn purge_completed(&self, older_than_ms: i64) -> Result<u64> {
         let mut conn = self.conn()?;
-        let status_key = self.key(&["jobs", "status", &(JobStatus::Complete as i32).to_string()]);
+        // Completed jobs are terminal and live in the archive.
+        let status_key = self.key(&[
+            "archived",
+            "status",
+            &(JobStatus::Complete as i32).to_string(),
+        ]);
         let job_ids: Vec<String> = conn.smembers(&status_key).map_err(map_err)?;
 
         let mut count = 0u64;
         for id in &job_ids {
-            if let Some(job) = self.load_job(&mut conn, id)? {
+            if let Some(job) = self.load_archived_job(&mut conn, id)? {
                 if let Some(completed_at) = job.completed_at {
                     if completed_at < older_than_ms {
-                        self.delete_job_fully(&mut conn, &job)?;
+                        self.delete_archived_job(&mut conn, &job)?;
                         count += 1;
                     }
                 }
@@ -31,12 +36,17 @@ impl RedisStorage {
     pub fn purge_completed_with_ttl(&self, global_cutoff_ms: i64) -> Result<u64> {
         let now = now_millis();
         let mut conn = self.conn()?;
-        let status_key = self.key(&["jobs", "status", &(JobStatus::Complete as i32).to_string()]);
+        // Completed jobs are terminal and live in the archive.
+        let status_key = self.key(&[
+            "archived",
+            "status",
+            &(JobStatus::Complete as i32).to_string(),
+        ]);
         let job_ids: Vec<String> = conn.smembers(&status_key).map_err(map_err)?;
 
         let mut count = 0u64;
         for id in &job_ids {
-            if let Some(job) = self.load_job(&mut conn, id)? {
+            if let Some(job) = self.load_archived_job(&mut conn, id)? {
                 let should_purge = match (job.completed_at, job.result_ttl_ms) {
                     (Some(completed), Some(ttl)) => completed
                         .checked_add(ttl)
@@ -45,7 +55,7 @@ impl RedisStorage {
                     _ => false,
                 };
                 if should_purge {
-                    self.delete_job_fully(&mut conn, &job)?;
+                    self.delete_archived_job(&mut conn, &job)?;
                     count += 1;
                 }
             }
@@ -91,11 +101,11 @@ impl RedisStorage {
                         job.status = JobStatus::Cancelled;
                         job.completed_at = Some(now);
                         job.error = Some("expired".to_string());
-                        self.save_job_and_move_status(&mut conn, &job, old_status)?;
 
                         let queue_key = self.key(&["queue", &job.queue, "pending"]);
                         conn.zrem::<_, _, ()>(&queue_key, &job.id)
                             .map_err(map_err)?;
+                        self.archive_job_immediately(&mut conn, &job, old_status)?;
                         count += 1;
                     }
                 }
@@ -119,11 +129,11 @@ impl RedisStorage {
                     job.status = JobStatus::Cancelled;
                     job.completed_at = Some(now);
                     job.error = Some("purged".to_string());
-                    self.save_job_and_move_status(&mut conn, &job, old_status)?;
 
                     let queue_key = self.key(&["queue", &job.queue, "pending"]);
                     conn.zrem::<_, _, ()>(&queue_key, &job.id)
                         .map_err(map_err)?;
+                    self.archive_job_immediately(&mut conn, &job, old_status)?;
                     count += 1;
                 }
             }
@@ -146,11 +156,11 @@ impl RedisStorage {
                     job.status = JobStatus::Cancelled;
                     job.completed_at = Some(now);
                     job.error = Some("revoked".to_string());
-                    self.save_job_and_move_status(&mut conn, &job, old_status)?;
 
                     let queue_key = self.key(&["queue", &job.queue, "pending"]);
                     conn.zrem::<_, _, ()>(&queue_key, &job.id)
                         .map_err(map_err)?;
+                    self.archive_job_immediately(&mut conn, &job, old_status)?;
                     count += 1;
                 }
             }

--- a/crates/taskito-core/src/storage/redis_backend/jobs/query.rs
+++ b/crates/taskito-core/src/storage/redis_backend/jobs/query.rs
@@ -171,7 +171,11 @@ impl RedisStorage {
         Ok(QueueStats {
             pending: self.count_in_status(conn, &by_queue, JobStatus::Pending)?,
             running: self.count_in_status(conn, &by_queue, JobStatus::Running)?,
-            completed: self.count_in_archived_status(conn, &archived_by_queue, JobStatus::Complete)?,
+            completed: self.count_in_archived_status(
+                conn,
+                &archived_by_queue,
+                JobStatus::Complete,
+            )?,
             failed: self.count_in_archived_status(conn, &archived_by_queue, JobStatus::Failed)?,
             dead: self.count_in_archived_status(conn, &archived_by_queue, JobStatus::Dead)?,
             cancelled: self.count_in_archived_status(

--- a/crates/taskito-core/src/storage/redis_backend/jobs/query.rs
+++ b/crates/taskito-core/src/storage/redis_backend/jobs/query.rs
@@ -19,99 +19,104 @@ impl RedisStorage {
     ) -> Result<Vec<Job>> {
         let mut conn = self.conn()?;
 
-        // Get candidate job IDs based on filters
-        let job_ids: Vec<String> = if let Some(s) = status {
-            let key = self.key(&["jobs", "status", &s.to_string()]);
-            conn.smembers(&key).map_err(map_err)?
-        } else if let Some(q) = queue_name {
-            let key = self.key(&["jobs", "by_queue", q]);
-            conn.smembers(&key).map_err(map_err)?
-        } else if let Some(t) = task_name {
-            let key = self.key(&["jobs", "by_task", t]);
-            conn.smembers(&key).map_err(map_err)?
-        } else {
-            // All jobs sorted by created_at desc
-            let all_key = self.key(&["jobs", "all"]);
-            let ids: Vec<String> = conn
-                .zrangebyscore_limit(
-                    &all_key,
-                    "-inf",
-                    "+inf",
-                    offset.max(0) as isize,
-                    limit.max(0) as isize,
-                )
-                .map_err(map_err)?;
-            // Load and return directly since already paginated
-            let mut jobs = Vec::new();
-            for id in &ids {
-                if let Some(job) = self.load_job(&mut conn, id)? {
-                    if let Some(ns) = namespace {
-                        if job.namespace.as_deref() != Some(ns) {
-                            continue;
-                        }
-                    }
-                    jobs.push(job);
-                }
+        // Load the candidate jobs from the table(s) that can hold the requested
+        // status: terminal statuses live in the archive, live statuses in the
+        // active sets, and an unfiltered status spans both.
+        let mut jobs: Vec<Job> = match status {
+            Some(s) if Self::is_terminal_status(s) => {
+                let key = self.key(&["archived", "status", &s.to_string()]);
+                let ids: Vec<String> = conn.smembers(&key).map_err(map_err)?;
+                self.load_archived_jobs(&mut conn, &ids)?
             }
-            return Ok(jobs);
+            Some(s) => {
+                let key = self.key(&["jobs", "status", &s.to_string()]);
+                let ids: Vec<String> = conn.smembers(&key).map_err(map_err)?;
+                self.load_live_jobs(&mut conn, &ids)?
+            }
+            None => {
+                let live_key = self.key(&["jobs", "all"]);
+                let live_ids: Vec<String> = conn.zrange(&live_key, 0, -1).map_err(map_err)?;
+                let mut all = self.load_live_jobs(&mut conn, &live_ids)?;
+
+                let archived_key = self.key(&["archived", "all"]);
+                let archived_ids: Vec<String> =
+                    conn.zrange(&archived_key, 0, -1).map_err(map_err)?;
+                all.extend(self.load_archived_jobs(&mut conn, &archived_ids)?);
+                all
+            }
         };
 
-        // Load all matching jobs and apply additional filters
-        let mut jobs = Vec::new();
-        for id in &job_ids {
-            if let Some(job) = self.load_job(&mut conn, id)? {
-                // Apply all filters
-                if let Some(s) = status {
-                    if job.status as i32 != s {
-                        continue;
-                    }
-                }
-                if let Some(q) = queue_name {
-                    if job.queue != q {
-                        continue;
-                    }
-                }
-                if let Some(t) = task_name {
-                    if job.task_name != t {
-                        continue;
-                    }
-                }
-                if let Some(ns) = namespace {
-                    if job.namespace.as_deref() != Some(ns) {
-                        continue;
-                    }
-                }
-                jobs.push(job);
-            }
-        }
+        // Apply the remaining filters in memory.
+        jobs.retain(|job| {
+            queue_name.is_none_or(|q| job.queue == q)
+                && task_name.is_none_or(|t| job.task_name == t)
+                && namespace.is_none_or(|ns| job.namespace.as_deref() == Some(ns))
+        });
 
-        // Sort by created_at desc
         jobs.sort_by_key(|j| std::cmp::Reverse(j.created_at));
 
-        // Apply pagination
         let start = (offset.max(0) as usize).min(jobs.len());
         let end = start.saturating_add(limit.max(0) as usize).min(jobs.len());
         Ok(jobs[start..end].to_vec())
     }
 
+    /// True when `status` is a terminal status whose jobs live in the archive.
+    fn is_terminal_status(status: i32) -> bool {
+        matches!(
+            JobStatus::from_i32(status),
+            Some(JobStatus::Complete)
+                | Some(JobStatus::Failed)
+                | Some(JobStatus::Dead)
+                | Some(JobStatus::Cancelled)
+        )
+    }
+
+    fn load_live_jobs(&self, conn: &mut redis::Connection, ids: &[String]) -> Result<Vec<Job>> {
+        let mut jobs = Vec::new();
+        for id in ids {
+            if let Some(job) = self.load_job(conn, id)? {
+                jobs.push(job);
+            }
+        }
+        Ok(jobs)
+    }
+
+    fn load_archived_jobs(&self, conn: &mut redis::Connection, ids: &[String]) -> Result<Vec<Job>> {
+        let mut jobs = Vec::new();
+        for id in ids {
+            if let Some(job) = self.load_archived_job(conn, id)? {
+                jobs.push(job);
+            }
+        }
+        Ok(jobs)
+    }
+
     pub fn get_job(&self, id: &str) -> Result<Option<Job>> {
         let mut conn = self.conn()?;
-        self.load_job(&mut conn, id)
+        match self.load_job(&mut conn, id)? {
+            Some(job) => Ok(Some(job)),
+            None => self.load_archived_job(&mut conn, id),
+        }
     }
 
     pub fn stats(&self) -> Result<QueueStats> {
         let mut conn = self.conn()?;
         let mut stats = QueueStats::default();
 
+        // Pending/Running stay in the live `jobs:status:<n>` sets; terminal
+        // jobs are archived, so their counts come from `archived:status:<n>`.
+        let live_pending = self.key(&["jobs", "status", "0"]);
+        let live_running = self.key(&["jobs", "status", "1"]);
+        stats.pending = conn.scard(&live_pending).map_err(map_err)?;
+        stats.running = conn.scard(&live_running).map_err(map_err)?;
+
         for (status_int, field) in [
-            (0, &mut stats.pending),
-            (1, &mut stats.running),
             (2, &mut stats.completed),
             (3, &mut stats.failed),
             (4, &mut stats.dead),
             (5, &mut stats.cancelled),
         ] {
-            let key = self.key(&["jobs", "status", &status_int.to_string()]);
+            let key = self.key(&["archived", "status", &status_int.to_string()]);
             let count: i64 = conn.scard(&key).map_err(map_err)?;
             *field = count;
         }
@@ -139,25 +144,42 @@ impl RedisStorage {
             .map_err(map_err)
     }
 
-    /// Per-status breakdown for the jobs in `membership_key` (a per-queue or
-    /// per-task set), one `SINTERCARD` per status.
-    fn status_breakdown(
+    /// `SINTERCARD` of a per-queue archived set with a terminal status set —
+    /// the count of archived jobs for that queue in the given status, computed
+    /// server-side without transferring any job.
+    fn count_in_archived_status(
         &self,
         conn: &mut redis::Connection,
         membership_key: &str,
-    ) -> Result<QueueStats> {
-        let mut stats = QueueStats::default();
-        for (status, field) in [
-            (JobStatus::Pending, &mut stats.pending),
-            (JobStatus::Running, &mut stats.running),
-            (JobStatus::Complete, &mut stats.completed),
-            (JobStatus::Failed, &mut stats.failed),
-            (JobStatus::Dead, &mut stats.dead),
-            (JobStatus::Cancelled, &mut stats.cancelled),
-        ] {
-            *field = self.count_in_status(conn, membership_key, status)?;
-        }
-        Ok(stats)
+        status: JobStatus,
+    ) -> Result<i64> {
+        let status_key = self.key(&["archived", "status", &(status as i32).to_string()]);
+        redis::cmd("SINTERCARD")
+            .arg(2)
+            .arg(membership_key)
+            .arg(&status_key)
+            .query::<i64>(conn)
+            .map_err(map_err)
+    }
+
+    /// Full breakdown for one queue: live pending/running from `jobs:by_queue`,
+    /// terminal counts from `archived:by_queue` — all `SINTERCARD`, bounded by
+    /// the status count rather than the job population.
+    fn queue_stats(&self, conn: &mut redis::Connection, queue_name: &str) -> Result<QueueStats> {
+        let by_queue = self.key(&["jobs", "by_queue", queue_name]);
+        let archived_by_queue = self.key(&["archived", "by_queue", queue_name]);
+        Ok(QueueStats {
+            pending: self.count_in_status(conn, &by_queue, JobStatus::Pending)?,
+            running: self.count_in_status(conn, &by_queue, JobStatus::Running)?,
+            completed: self.count_in_archived_status(conn, &archived_by_queue, JobStatus::Complete)?,
+            failed: self.count_in_archived_status(conn, &archived_by_queue, JobStatus::Failed)?,
+            dead: self.count_in_archived_status(conn, &archived_by_queue, JobStatus::Dead)?,
+            cancelled: self.count_in_archived_status(
+                conn,
+                &archived_by_queue,
+                JobStatus::Cancelled,
+            )?,
+        })
     }
 
     /// Count running jobs for a specific task name (for per-task concurrency limiting).
@@ -169,47 +191,49 @@ impl RedisStorage {
 
     pub fn stats_by_queue(&self, queue_name: &str) -> Result<QueueStats> {
         let mut conn = self.conn()?;
-        let by_queue_key = self.key(&["jobs", "by_queue", queue_name]);
-        self.status_breakdown(&mut conn, &by_queue_key)
+        self.queue_stats(&mut conn, queue_name)
     }
 
     pub fn stats_all_queues(&self) -> Result<std::collections::HashMap<String, QueueStats>> {
         let mut conn = self.conn()?;
 
-        // Enumerate queues by scanning the per-queue membership keys (one per
-        // queue with at least one job — empty sets are auto-removed by Redis).
-        // This is bounded by the number of queues, not the job population.
-        let pattern = self.key(&["jobs", "by_queue", "*"]);
-        let strip = self.key(&["jobs", "by_queue", ""]);
+        // Enumerate queues by scanning the live and archived per-queue membership
+        // keys (one per queue with at least one job — empty sets are auto-removed
+        // by Redis). A queue with only terminal jobs lives solely in the archived
+        // set, so both prefixes must be scanned. Bounded by the number of queues,
+        // not the job population.
         let mut queues: Vec<String> = Vec::new();
-        let mut cursor = 0u64;
-        loop {
-            let (next, batch): (u64, Vec<String>) = redis::cmd("SCAN")
-                .arg(cursor)
-                .arg("MATCH")
-                .arg(&pattern)
-                .arg("COUNT")
-                .arg(100)
-                .query(&mut conn)
-                .map_err(map_err)?;
-            for key in batch {
-                if let Some(name) = key.strip_prefix(&strip) {
-                    queues.push(name.to_string());
+        for prefix in [["jobs", "by_queue"], ["archived", "by_queue"]] {
+            let pattern = self.key(&[prefix[0], prefix[1], "*"]);
+            let strip = self.key(&[prefix[0], prefix[1], ""]);
+            let mut cursor = 0u64;
+            loop {
+                let (next, batch): (u64, Vec<String>) = redis::cmd("SCAN")
+                    .arg(cursor)
+                    .arg("MATCH")
+                    .arg(&pattern)
+                    .arg("COUNT")
+                    .arg(100)
+                    .query(&mut conn)
+                    .map_err(map_err)?;
+                for key in batch {
+                    if let Some(name) = key.strip_prefix(&strip) {
+                        queues.push(name.to_string());
+                    }
+                }
+                cursor = next;
+                if cursor == 0 {
+                    break;
                 }
             }
-            cursor = next;
-            if cursor == 0 {
-                break;
-            }
         }
-        // SCAN may return duplicates across iterations.
+        // SCAN may return duplicates, and a queue can appear in both sets.
         queues.sort_unstable();
         queues.dedup();
 
         let mut map = std::collections::HashMap::<String, QueueStats>::new();
         for queue in queues {
-            let by_queue_key = self.key(&["jobs", "by_queue", &queue]);
-            let stats = self.status_breakdown(&mut conn, &by_queue_key)?;
+            let stats = self.queue_stats(&mut conn, &queue)?;
             map.insert(queue, stats);
         }
         Ok(map)
@@ -231,24 +255,36 @@ impl RedisStorage {
     ) -> Result<Vec<Job>> {
         let mut conn = self.conn()?;
 
-        // Get candidate job IDs from the narrowest index available
-        let job_ids: Vec<String> = if let Some(s) = status {
-            let key = self.key(&["jobs", "status", &s.to_string()]);
-            conn.smembers(&key).map_err(map_err)?
-        } else if let Some(q) = queue_name {
-            let key = self.key(&["jobs", "by_queue", q]);
-            conn.smembers(&key).map_err(map_err)?
-        } else if let Some(t) = task_name {
-            let key = self.key(&["jobs", "by_task", t]);
-            conn.smembers(&key).map_err(map_err)?
-        } else {
-            let all_key = self.key(&["jobs", "all"]);
-            conn.zrange(&all_key, 0, -1).map_err(map_err)?
+        // Source candidates from the table(s) that can hold the requested
+        // status: terminal statuses live in the archive, live statuses in the
+        // active sets, and an unfiltered status spans both.
+        let candidates: Vec<Job> = match status {
+            Some(s) if Self::is_terminal_status(s) => {
+                let key = self.key(&["archived", "status", &s.to_string()]);
+                let ids: Vec<String> = conn.smembers(&key).map_err(map_err)?;
+                self.load_archived_jobs(&mut conn, &ids)?
+            }
+            Some(s) => {
+                let key = self.key(&["jobs", "status", &s.to_string()]);
+                let ids: Vec<String> = conn.smembers(&key).map_err(map_err)?;
+                self.load_live_jobs(&mut conn, &ids)?
+            }
+            None => {
+                let live_key = self.key(&["jobs", "all"]);
+                let live_ids: Vec<String> = conn.zrange(&live_key, 0, -1).map_err(map_err)?;
+                let mut all = self.load_live_jobs(&mut conn, &live_ids)?;
+
+                let archived_key = self.key(&["archived", "all"]);
+                let archived_ids: Vec<String> =
+                    conn.zrange(&archived_key, 0, -1).map_err(map_err)?;
+                all.extend(self.load_archived_jobs(&mut conn, &archived_ids)?);
+                all
+            }
         };
 
         let mut jobs = Vec::new();
-        for id in &job_ids {
-            if let Some(job) = self.load_job(&mut conn, id)? {
+        for job in candidates {
+            {
                 if let Some(s) = status {
                     if job.status as i32 != s {
                         continue;

--- a/crates/taskito-core/src/storage/redis_backend/jobs/state.rs
+++ b/crates/taskito-core/src/storage/redis_backend/jobs/state.rs
@@ -88,12 +88,8 @@ impl RedisStorage {
         job.status = JobStatus::Cancelled;
         job.completed_at = Some(now_millis());
 
-        // Remove from pending queue before archiving moves the job out of the
-        // live indices.
-        let queue_key = self.key(&["queue", &job.queue, "pending"]);
-        conn.zrem::<_, _, ()>(&queue_key, &job.id)
-            .map_err(map_err)?;
-
+        // `archive_job_immediately` removes the job from the per-queue pending
+        // zset as part of its atomic live→archive move (old_status == Pending).
         self.archive_job_immediately(&mut conn, &job, old_status)?;
 
         // Cascade cancel dependents
@@ -184,10 +180,8 @@ impl RedisStorage {
                     job.completed_at = Some(now);
                     job.error = Some(error_msg.clone());
 
-                    let queue_key = self.key(&["queue", &job.queue, "pending"]);
-                    conn.zrem::<_, _, ()>(&queue_key, &job.id)
-                        .map_err(map_err)?;
-
+                    // `archive_job_immediately` removes the job from the
+                    // per-queue pending zset as part of its atomic move.
                     self.archive_job_immediately(&mut conn, &job, old_status)?;
                 }
             }

--- a/crates/taskito-core/src/storage/redis_backend/jobs/state.rs
+++ b/crates/taskito-core/src/storage/redis_backend/jobs/state.rs
@@ -21,7 +21,7 @@ impl RedisStorage {
         job.status = JobStatus::Complete;
         job.completed_at = Some(now_millis());
         job.result = result_bytes;
-        self.save_job_and_move_status(&mut conn, &job, old_status)?;
+        self.archive_job_immediately(&mut conn, &job, old_status)?;
 
         // Clean up unique key if present
         if let Some(ref uk) = job.unique_key {
@@ -44,7 +44,7 @@ impl RedisStorage {
         job.status = JobStatus::Failed;
         job.completed_at = Some(now_millis());
         job.error = Some(error.to_string());
-        self.save_job_and_move_status(&mut conn, &job, old_status)?;
+        self.archive_job_immediately(&mut conn, &job, old_status)?;
 
         Ok(())
     }
@@ -87,12 +87,14 @@ impl RedisStorage {
         let old_status = job.status;
         job.status = JobStatus::Cancelled;
         job.completed_at = Some(now_millis());
-        self.save_job_and_move_status(&mut conn, &job, old_status)?;
 
-        // Remove from pending queue
+        // Remove from pending queue before archiving moves the job out of the
+        // live indices.
         let queue_key = self.key(&["queue", &job.queue, "pending"]);
         conn.zrem::<_, _, ()>(&queue_key, &job.id)
             .map_err(map_err)?;
+
+        self.archive_job_immediately(&mut conn, &job, old_status)?;
 
         // Cascade cancel dependents
         drop(conn);
@@ -138,7 +140,7 @@ impl RedisStorage {
         job.status = JobStatus::Cancelled;
         job.completed_at = Some(now_millis());
         job.error = Some("cancelled by request".to_string());
-        self.save_job_and_move_status(&mut conn, &job, old_status)?;
+        self.archive_job_immediately(&mut conn, &job, old_status)?;
 
         // Clean up cancel request
         let cancel_set = self.key(&["jobs", "cancel_requested"]);
@@ -181,11 +183,12 @@ impl RedisStorage {
                     job.status = JobStatus::Cancelled;
                     job.completed_at = Some(now);
                     job.error = Some(error_msg.clone());
-                    self.save_job_and_move_status(&mut conn, &job, old_status)?;
 
                     let queue_key = self.key(&["queue", &job.queue, "pending"]);
                     conn.zrem::<_, _, ()>(&queue_key, &job.id)
                         .map_err(map_err)?;
+
+                    self.archive_job_immediately(&mut conn, &job, old_status)?;
                 }
             }
         }

--- a/crates/taskito-core/src/storage/sqlite/archival.rs
+++ b/crates/taskito-core/src/storage/sqlite/archival.rs
@@ -22,9 +22,18 @@ impl SqliteStorage {
         );
 
         conn.transaction(|conn| {
-            // Use raw SQL for INSERT INTO ... SELECT across tables
+            // Explicit column lists: `jobs` has a `has_deps` column that
+            // `archived_jobs` lacks, so `SELECT *` would misalign columns.
             let affected = diesel::sql_query(format!(
-                "INSERT OR IGNORE INTO archived_jobs SELECT * FROM jobs \
+                "INSERT OR IGNORE INTO archived_jobs \
+                 (id, queue, task_name, payload, status, priority, created_at, scheduled_at, \
+                  started_at, completed_at, retry_count, max_retries, result, error, timeout_ms, \
+                  unique_key, progress, metadata, notes, cancel_requested, expires_at, \
+                  result_ttl_ms, namespace) \
+                 SELECT id, queue, task_name, payload, status, priority, created_at, scheduled_at, \
+                  started_at, completed_at, retry_count, max_retries, result, error, timeout_ms, \
+                  unique_key, progress, metadata, notes, cancel_requested, expires_at, \
+                  result_ttl_ms, namespace FROM jobs \
                  WHERE status IN ({archivable_statuses}) AND completed_at IS NOT NULL AND completed_at < ?1",
             ))
             .bind::<diesel::sql_types::BigInt, _>(cutoff_ms)

--- a/crates/taskito-core/src/storage/sqlite/jobs.rs
+++ b/crates/taskito-core/src/storage/sqlite/jobs.rs
@@ -3,7 +3,7 @@ use diesel::sqlite::SqliteConnection;
 
 use super::super::models::*;
 use super::super::schema::{
-    job_dependencies, job_errors, jobs, replay_history, task_logs, task_metrics,
+    archived_jobs, job_dependencies, job_errors, jobs, replay_history, task_logs, task_metrics,
 };
 use super::SqliteStorage;
 use crate::error::{QueueError, Result};
@@ -11,3 +11,21 @@ use crate::job::{now_millis, Job, JobStatus, NewJob};
 use crate::storage::QueueStats;
 
 crate::storage::diesel_common::impl_diesel_job_ops!(SqliteStorage, SqliteConnection);
+
+impl SqliteStorage {
+    /// Run a read-then-write unit of work under a write-priority transaction.
+    ///
+    /// Archival reads a job row and then INSERTs/DELETEs it. Under SQLite a
+    /// plain deferred transaction starts as a reader and must later upgrade to
+    /// a writer; two such transactions racing each other deadlock and surface
+    /// as `SQLITE_BUSY` ("database is locked") without honoring `busy_timeout`.
+    /// `BEGIN IMMEDIATE` takes the write lock up front so the busy-timeout
+    /// backoff applies and the operations serialize cleanly.
+    pub(crate) fn archive_transaction<T, F>(&self, f: F) -> Result<T>
+    where
+        F: FnOnce(&mut SqliteConnection) -> std::result::Result<T, QueueError>,
+    {
+        let mut conn = self.conn()?;
+        conn.immediate_transaction(f)
+    }
+}

--- a/crates/taskito-core/src/storage/sqlite/mod.rs
+++ b/crates/taskito-core/src/storage/sqlite/mod.rs
@@ -147,6 +147,12 @@ impl SqliteStorage {
         for sql in common_migrations::backfill_statements() {
             diesel::sql_query(*sql).execute(&mut conn)?;
         }
+        drop(conn);
+
+        // Drain any pre-existing terminal jobs left in `jobs` by older
+        // versions into `archived_jobs`. Terminal jobs now live there from the
+        // moment they transition; this one-time sweep migrates the backlog.
+        self.archive_old_jobs(i64::MAX)?;
 
         Ok(())
     }

--- a/crates/taskito-core/src/storage/sqlite/tests.rs
+++ b/crates/taskito-core/src/storage/sqlite/tests.rs
@@ -772,3 +772,138 @@ fn test_purge_completed_respects_per_job_ttl() {
     assert!(storage.get_job(&expired.id).unwrap().is_none());
     assert!(storage.get_job(&kept.id).unwrap().is_some());
 }
+
+// ── Immediate terminal-job archival ──────────────────────────────────
+
+/// Count rows in the live `jobs` table for a given id.
+fn jobs_row_count(storage: &SqliteStorage, id: &str) -> i64 {
+    use crate::storage::schema::jobs;
+    use diesel::prelude::*;
+    let mut conn = storage.conn().unwrap();
+    jobs::table
+        .filter(jobs::id.eq(id))
+        .count()
+        .get_result(&mut conn)
+        .unwrap()
+}
+
+/// Count rows in the `archived_jobs` table for a given id.
+fn archived_row_count(storage: &SqliteStorage, id: &str) -> i64 {
+    use crate::storage::schema::archived_jobs;
+    use diesel::prelude::*;
+    let mut conn = storage.conn().unwrap();
+    archived_jobs::table
+        .filter(archived_jobs::id.eq(id))
+        .count()
+        .get_result(&mut conn)
+        .unwrap()
+}
+
+#[test]
+fn test_complete_moves_to_archived_immediately() {
+    let storage = test_storage();
+    let job = storage.enqueue(make_job("archive_complete")).unwrap();
+    storage
+        .dequeue("default", now_millis() + 1000, None)
+        .unwrap();
+
+    storage.complete(&job.id, Some(vec![7])).unwrap();
+
+    // Gone from the live table, present in the archive.
+    assert_eq!(jobs_row_count(&storage, &job.id), 0);
+    assert_eq!(archived_row_count(&storage, &job.id), 1);
+}
+
+#[test]
+fn test_get_job_finds_archived() {
+    let storage = test_storage();
+    let job = storage.enqueue(make_job("archive_get")).unwrap();
+    storage
+        .dequeue("default", now_millis() + 1000, None)
+        .unwrap();
+    storage.complete(&job.id, Some(vec![1])).unwrap();
+
+    let fetched = storage.get_job(&job.id).unwrap().unwrap();
+    assert_eq!(fetched.id, job.id);
+    assert_eq!(fetched.status, JobStatus::Complete);
+    assert_eq!(fetched.result, Some(vec![1]));
+}
+
+#[test]
+fn test_stats_counts_archived_terminals() {
+    let storage = test_storage();
+
+    // Three jobs completed (archived), one left pending, one running.
+    for i in 0..3 {
+        let job = storage.enqueue(make_job(&format!("done_{i}"))).unwrap();
+        storage
+            .dequeue("default", now_millis() + 1000, None)
+            .unwrap();
+        storage.complete(&job.id, None).unwrap();
+    }
+    storage.enqueue(make_job("still_pending")).unwrap();
+    let running = storage.enqueue(make_job("running")).unwrap();
+    storage
+        .dequeue("default", now_millis() + 1000, None)
+        .unwrap();
+
+    let stats = storage.stats().unwrap();
+    assert_eq!(stats.completed, 3);
+    assert_eq!(stats.pending, 1);
+    assert_eq!(stats.running, 1);
+    let _ = running;
+}
+
+#[test]
+fn test_list_jobs_terminal_status_reads_archive() {
+    let storage = test_storage();
+    let job = storage.enqueue(make_job("listed")).unwrap();
+    storage
+        .dequeue("default", now_millis() + 1000, None)
+        .unwrap();
+    storage.complete(&job.id, None).unwrap();
+
+    // Filtering by a terminal status returns the archived row.
+    let complete = storage
+        .list_jobs(Some(JobStatus::Complete as i32), None, None, 50, 0, None)
+        .unwrap();
+    assert!(complete.iter().any(|j| j.id == job.id));
+
+    // No status filter merges live + archived.
+    let all = storage.list_jobs(None, None, None, 50, 0, None).unwrap();
+    assert!(all.iter().any(|j| j.id == job.id));
+
+    // Pending filter must not surface the archived job.
+    let pending = storage
+        .list_jobs(Some(JobStatus::Pending as i32), None, None, 50, 0, None)
+        .unwrap();
+    assert!(!pending.iter().any(|j| j.id == job.id));
+}
+
+#[test]
+fn test_fail_and_cancel_archive_immediately() {
+    let storage = test_storage();
+
+    // Failed running job is archived.
+    let failed = storage.enqueue(make_job("to_fail")).unwrap();
+    storage
+        .dequeue("default", now_millis() + 1000, None)
+        .unwrap();
+    storage.fail(&failed.id, "boom").unwrap();
+    assert_eq!(jobs_row_count(&storage, &failed.id), 0);
+    assert_eq!(archived_row_count(&storage, &failed.id), 1);
+    assert_eq!(
+        storage.get_job(&failed.id).unwrap().unwrap().status,
+        JobStatus::Failed
+    );
+
+    // Cancelled pending job is archived.
+    let cancelled = storage.enqueue(make_job("to_cancel")).unwrap();
+    assert!(storage.cancel_job(&cancelled.id).unwrap());
+    assert_eq!(jobs_row_count(&storage, &cancelled.id), 0);
+    assert_eq!(archived_row_count(&storage, &cancelled.id), 1);
+    assert_eq!(
+        storage.get_job(&cancelled.id).unwrap().unwrap().status,
+        JobStatus::Cancelled
+    );
+}

--- a/crates/taskito-core/tests/rust/storage_tests.rs
+++ b/crates/taskito-core/tests/rust/storage_tests.rs
@@ -433,6 +433,49 @@ fn test_immediate_archival(s: &impl Storage) {
     assert!(pending.iter().any(|j| j.id == pending_job.id));
 }
 
+fn test_enqueue_dep_on_completed_archived_job(s: &impl Storage) {
+    let q = "q-dep-archived-complete";
+
+    // Run A to completion — it now lives in `archived_jobs`, not `jobs`.
+    let a = s.enqueue(make_job(q, "dep_parent_done")).unwrap();
+    s.dequeue(q, now_millis() + 1000, None).unwrap();
+    s.complete(&a.id, None).unwrap();
+
+    // Enqueuing B with a completed (archived) dependency must succeed: the
+    // existence check has to fall back to the archive.
+    let mut b_job = make_job(q, "dep_child");
+    b_job.depends_on = vec![a.id.clone()];
+    let b = s.enqueue(b_job).unwrap();
+
+    // And B must be dequeuable: a completed archived parent counts as satisfied.
+    let dequeued = s.dequeue(q, now_millis() + 1000, None).unwrap();
+    assert_eq!(
+        dequeued.map(|j| j.id),
+        Some(b.id),
+        "B should dequeue once its archived-complete dependency is satisfied"
+    );
+}
+
+fn test_dependent_blocked_by_cancelled_parent(s: &impl Storage) {
+    let q = "q-dep-cancelled-parent";
+
+    let a = s.enqueue(make_job(q, "dep_parent_cancel")).unwrap();
+    let mut b_job = make_job(q, "dep_child_blocked");
+    b_job.depends_on = vec![a.id.clone()];
+    let b = s.enqueue(b_job).unwrap();
+
+    // Cancelling A archives it as Cancelled. B's dependency is now unsatisfiable.
+    assert!(s.cancel_job(&a.id).unwrap());
+
+    // A dequeue attempt must not return B (its archived parent is non-Complete).
+    // Cascade-cancel may also have archived B; either way it must not dequeue.
+    let dequeued = s.dequeue(q, now_millis() + 1000, None).unwrap();
+    assert!(
+        dequeued.as_ref().map(|j| &j.id) != Some(&b.id),
+        "B must not dequeue while its parent is archived-cancelled"
+    );
+}
+
 fn run_storage_tests(s: &impl Storage) {
     test_enqueue_and_get(s);
     test_dequeue(s);
@@ -454,6 +497,8 @@ fn run_storage_tests(s: &impl Storage) {
     test_execution_claims_purge(s);
     test_dashboard_settings(s);
     test_immediate_archival(s);
+    test_enqueue_dep_on_completed_archived_job(s);
+    test_dependent_blocked_by_cancelled_parent(s);
 }
 
 // ── Backend-specific wiring ──────────────────────────────────────────
@@ -482,6 +527,74 @@ fn redis_storage_tests() {
     };
 
     run_storage_tests(&storage);
+    redis_mutators_reject_archived_jobs(&storage);
+    redis_purge_preserves_reused_unique_key(&storage);
+}
+
+/// A terminal job has left the live indices, so a mutator that resolves the
+/// live row (`get_job_required`) must return `JobNotFound` rather than partially
+/// reindexing an archived row.
+#[cfg(feature = "redis")]
+fn redis_mutators_reject_archived_jobs(s: &taskito_core::RedisStorage) {
+    let q = "q-redis-mutate-archived";
+
+    // Cancel a pending job → archived as Cancelled.
+    let cancelled = s.enqueue(make_job(q, "redis_archived_cancel")).unwrap();
+    assert!(s.cancel_job(&cancelled.id).unwrap());
+    assert!(matches!(
+        s.retry(&cancelled.id, now_millis()),
+        Err(taskito_core::error::QueueError::JobNotFound(_))
+    ));
+    assert!(matches!(
+        s.mark_cancelled(&cancelled.id),
+        Err(taskito_core::error::QueueError::JobNotFound(_))
+    ));
+
+    // Complete a job → archived as Complete; the same guard applies.
+    let done = s.enqueue(make_job(q, "redis_archived_done")).unwrap();
+    s.dequeue(q, now_millis() + 1000, None).unwrap();
+    s.complete(&done.id, None).unwrap();
+    assert!(matches!(
+        s.retry(&done.id, now_millis()),
+        Err(taskito_core::error::QueueError::JobNotFound(_))
+    ));
+}
+
+/// Purging an archived job must not delete a `jobs:unique` pointer now owned by
+/// a different live job that reused the same `unique_key`.
+#[cfg(feature = "redis")]
+fn redis_purge_preserves_reused_unique_key(s: &taskito_core::RedisStorage) {
+    let q = "q-redis-unique-reuse";
+    let shared_key = "redis-reused-unique";
+
+    // Run A to completion under the shared unique key.
+    let mut a_job = make_job(q, "unique_reuse_a");
+    a_job.unique_key = Some(shared_key.to_string());
+    let a = s.enqueue_unique(a_job).unwrap();
+    s.dequeue(q, now_millis() + 1000, None).unwrap();
+    s.complete(&a.id, None).unwrap();
+
+    // A new live job B reuses the freed unique key and owns the lock.
+    let mut b_job = make_job(q, "unique_reuse_b");
+    b_job.unique_key = Some(shared_key.to_string());
+    let b = s.enqueue_unique(b_job).unwrap();
+    assert_ne!(
+        a.id, b.id,
+        "B should be a distinct live job, not deduped to A"
+    );
+
+    // Purge A's archived row — must leave B's unique lock intact.
+    s.purge_completed(now_millis() + 1000).unwrap();
+
+    // Re-enqueuing under the same key must still dedup to B, proving the lock
+    // survived the purge.
+    let mut c_job = make_job(q, "unique_reuse_c");
+    c_job.unique_key = Some(shared_key.to_string());
+    let c = s.enqueue_unique(c_job).unwrap();
+    assert_eq!(
+        c.id, b.id,
+        "unique lock for B must survive purging archived A"
+    );
 }
 
 #[cfg(feature = "postgres")]

--- a/crates/taskito-core/tests/rust/storage_tests.rs
+++ b/crates/taskito-core/tests/rust/storage_tests.rs
@@ -375,6 +375,64 @@ fn test_circuit_breakers(s: &impl Storage) {
 
 // ── Run all generic tests against a storage impl ─────────────────────
 
+fn test_immediate_archival(s: &impl Storage) {
+    let q = "q-archival";
+
+    // Complete, fail, and cancel are all terminal: they archive immediately but
+    // remain readable via get_job and surface in the per-queue terminal stats.
+    let done = s.enqueue(make_job(q, "arch_done")).unwrap();
+    s.dequeue(q, now_millis() + 1000, None).unwrap();
+    s.complete(&done.id, Some(vec![9])).unwrap();
+
+    let failed = s.enqueue(make_job(q, "arch_fail")).unwrap();
+    s.dequeue(q, now_millis() + 1000, None).unwrap();
+    s.fail(&failed.id, "boom").unwrap();
+
+    let cancelled = s.enqueue(make_job(q, "arch_cancel")).unwrap();
+    assert!(s.cancel_job(&cancelled.id).unwrap());
+
+    // One running and one pending left live. Enqueue the to-be-running job
+    // first so the FIFO dequeue claims it, leaving the later one pending.
+    s.enqueue(make_job(q, "arch_running")).unwrap();
+    s.dequeue(q, now_millis() + 1000, None).unwrap();
+    let pending_job = s.enqueue(make_job(q, "arch_pending")).unwrap();
+
+    // get_job resolves archived terminals.
+    assert_eq!(
+        s.get_job(&done.id).unwrap().unwrap().status,
+        JobStatus::Complete
+    );
+    assert_eq!(
+        s.get_job(&failed.id).unwrap().unwrap().status,
+        JobStatus::Failed
+    );
+    assert_eq!(
+        s.get_job(&cancelled.id).unwrap().unwrap().status,
+        JobStatus::Cancelled
+    );
+
+    // Per-queue stats: terminals from the archive, pending/running live.
+    let stats = s.stats_by_queue(q).unwrap();
+    assert_eq!(stats.completed, 1, "completed");
+    assert_eq!(stats.failed, 1, "failed");
+    assert_eq!(stats.cancelled, 1, "cancelled");
+    assert_eq!(stats.pending, 1, "pending");
+    assert_eq!(stats.running, 1, "running");
+
+    // Listing by a terminal status reads the archive; pending must not surface
+    // the archived row.
+    let complete = s
+        .list_jobs(Some(JobStatus::Complete as i32), Some(q), None, 50, 0, None)
+        .unwrap();
+    assert!(complete.iter().any(|j| j.id == done.id));
+
+    let pending = s
+        .list_jobs(Some(JobStatus::Pending as i32), Some(q), None, 50, 0, None)
+        .unwrap();
+    assert!(!pending.iter().any(|j| j.id == done.id));
+    assert!(pending.iter().any(|j| j.id == pending_job.id));
+}
+
 fn run_storage_tests(s: &impl Storage) {
     test_enqueue_and_get(s);
     test_dequeue(s);
@@ -395,6 +453,7 @@ fn run_storage_tests(s: &impl Storage) {
     test_circuit_breakers(s);
     test_execution_claims_purge(s);
     test_dashboard_settings(s);
+    test_immediate_archival(s);
 }
 
 // ── Backend-specific wiring ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

**P2** of the Taskito 2.0 optimization program. Terminal jobs
(Complete/Failed/Dead/Cancelled) now move to the existing `archived_jobs` table
**the moment they reach a terminal state**, instead of lingering in `jobs` until a
TTL sweep. The hot `jobs` table — scanned by the dequeue index on every poll and
by `stats` — stays bounded to pending/running rows regardless of history depth.

## Design

- **Diesel (SQLite + Postgres):** `complete`/`fail`/`mark_cancelled`/`move_to_dlq`/
  `cascade_cancel` and the pending-cancel paths now read → INSERT into
  `archived_jobs` → DELETE from `jobs`, in one write-priority transaction
  (SQLite `BEGIN IMMEDIATE` to avoid lock-upgrade deadlocks under fan-out).
- **Stats stay correct:** pending/running counts come from `jobs`; terminal
  counts from `archived_jobs`. The two are merged, so dashboard
  completed/failed/dead/cancelled numbers are unchanged. `get_job` and
  `list_jobs`/`list_jobs_filtered` transparently fall back to the archive;
  `purge_*` now target it.
- **Redis:** terminal transitions call `archive_job_immediately` — the job moves
  out of the live indices into `archived:<id>` / `archived:status:<n>` /
  `archived:all`; `stats`/`get_job`/`list` updated to match.
- **Upgrade:** pre-existing terminal rows are drained into `archived_jobs` once
  during `run_migrations()`. New `idx_archived_jobs_status` /
  `idx_archived_jobs_queue_status` indexes back the count/list queries.

No `Storage` trait signature changes — internal behavior only.

## Verification (all three backends + Python)

- SQLite `cargo test --workspace`: **67 storage tests** (+5 new) green.
- Postgres contract suite (fresh schema): green.
- Redis contract suite (fresh DB): green.
- `cargo clippy` clean across default/postgres/redis.
- Full Python suite: **1010 passed, 4 skipped**.

New tests cover immediate archival on complete/fail/cancel, `get_job` archive
fallback, terminal-status `list_jobs`, and stat counts.

## Compatibility / review note

Downgrade caveat: a pre-2.0 binary's `get_job` only checks `jobs`, so it won't
see rows this version archived. Document a minimum-version floor before enabling
in production.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal jobs are archived immediately and archived records are visible to get/list/stats and dependency checks.

* **Refactor**
  * Unified archiving flow across backends; listing/stats merge live+archived with consistent ordering/pagination; archived-aware dependency resolution.

* **Bug Fixes**
  * Reduced deadlock/contention risk during archival and dead-letter moves.

* **Tests**
  * Added integration and SQLite/Redis tests for immediate archival, stats, listing, and archived-dependency behavior.

* **Chores**
  * One-time migration sweep and new archive indexes added.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ByteVeda/taskito/pull/216?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->