### PR TITLE
perf(scheduler): opt-in push-based dispatch

### DIFF
--- a/crates/taskito-core/Cargo.toml
+++ b/crates/taskito-core/Cargo.toml
@@ -7,6 +7,9 @@ edition = "2021"
 default = []
 postgres = ["diesel/postgres", "pq-sys", "openssl-sys"]
 redis = ["dep:redis"]
+# Event-driven scheduler wakeups. OFF by default — the shipped wheel keeps
+# polling. Opt-in for source builds that want lower dispatch latency.
+push-dispatch = []
 
 [dependencies]
 diesel = { workspace = true }

--- a/crates/taskito-core/src/scheduler/mod.rs
+++ b/crates/taskito-core/src/scheduler/mod.rs
@@ -1,6 +1,8 @@
 mod maintenance;
 mod poller;
 mod result_handler;
+#[cfg(feature = "push-dispatch")]
+pub mod wake;
 
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
@@ -138,6 +140,15 @@ pub struct Scheduler {
     shutdown: Arc<Notify>,
     paused_cache: Mutex<(HashSet<String>, Instant)>,
     namespace: Option<String>,
+    /// Wake source for push-dispatch, installed before `run()`. Taken (moved
+    /// out) once when the loop starts. `None` means the loop polls as today.
+    #[cfg(feature = "push-dispatch")]
+    wake_source: Mutex<Option<wake::WakeSource>>,
+    /// Earliest `scheduled_at` of any delayed job seen at enqueue time, so the
+    /// push loop can arm a timer for the next delayed job rather than waking
+    /// immediately. Milliseconds; `i64::MAX` means "nothing scheduled".
+    #[cfg(feature = "push-dispatch")]
+    next_scheduled_at: std::sync::atomic::AtomicI64,
 }
 
 /// Counters for tick-based scheduling of periodic maintenance tasks.
@@ -171,6 +182,10 @@ impl Scheduler {
             shutdown: Arc::new(Notify::new()),
             paused_cache: Mutex::new((HashSet::new(), Instant::now())),
             namespace,
+            #[cfg(feature = "push-dispatch")]
+            wake_source: Mutex::new(None),
+            #[cfg(feature = "push-dispatch")]
+            next_scheduled_at: std::sync::atomic::AtomicI64::new(i64::MAX),
         }
     }
 
@@ -206,6 +221,15 @@ impl Scheduler {
     /// exponentially (up to 1s) when no jobs are found, resets immediately
     /// when a job is dispatched.
     pub async fn run(&self, job_tx: tokio::sync::mpsc::Sender<Job>) {
+        // Push-dispatch: if a wake source was configured, run the event-driven
+        // loop. Otherwise (and always when the feature is off) fall through to
+        // the unchanged adaptive-poll loop below.
+        #[cfg(feature = "push-dispatch")]
+        if let Some(wake) = self.take_wake_source() {
+            self.run_push(job_tx, wake).await;
+            return;
+        }
+
         let mut counters = TickCounters::default();
         let base_interval = self.config.poll_interval;
         let max_interval = Duration::from_millis(200);
@@ -230,19 +254,33 @@ impl Scheduler {
     /// Returns true if any work was done (job dispatched or periodic task enqueued),
     /// which resets the adaptive poll interval.
     fn tick(&self, job_tx: &tokio::sync::mpsc::Sender<Job>, counters: &mut TickCounters) -> bool {
+        let dispatched = self.tick_dispatch(job_tx);
+        let had_maintenance = self.tick_maintenance(counters);
+        dispatched || had_maintenance
+    }
+
+    /// Run one dispatch round (batch or single). Returns true if a job was
+    /// dispatched. Pulled out of [`Scheduler::tick`] so the push loop can run
+    /// dispatch independently of the maintenance cadence.
+    fn tick_dispatch(&self, job_tx: &tokio::sync::mpsc::Sender<Job>) -> bool {
         let dispatch_result = if self.config.batch_size > 1 {
             self.try_dispatch_batch(job_tx)
         } else {
             self.try_dispatch(job_tx)
         };
-        let dispatched = match dispatch_result {
+        match dispatch_result {
             Ok(d) => d,
             Err(e) => {
                 error!("scheduler error: {e}");
                 false
             }
-        };
+        }
+    }
 
+    /// Advance the tick counters and run any due maintenance (reap, periodic
+    /// enqueue, cleanup). Returns true if periodic enqueue ran (work that
+    /// should reset the poll backoff).
+    fn tick_maintenance(&self, counters: &mut TickCounters) -> bool {
         let mut had_maintenance = false;
 
         counters.reap += 1;
@@ -278,7 +316,118 @@ impl Scheduler {
             }
         }
 
-        dispatched || had_maintenance
+        had_maintenance
+    }
+}
+
+#[cfg(feature = "push-dispatch")]
+impl Scheduler {
+    /// Fallback dispatch interval when push-dispatch is on. A missed wake can
+    /// never strand a job longer than this.
+    const PUSH_FALLBACK_INTERVAL: Duration = Duration::from_secs(2);
+
+    /// Cadence of the dedicated maintenance ticker, decoupled from dispatch.
+    const PUSH_MAINTENANCE_INTERVAL: Duration = Duration::from_millis(500);
+
+    /// Install the wake source the push loop should consume. Call before
+    /// `run()`. With no wake source installed, `run()` keeps polling.
+    pub fn set_wake_source(&self, source: wake::WakeSource) {
+        let mut guard = self.wake_source.lock().unwrap_or_else(|p| p.into_inner());
+        *guard = Some(source);
+    }
+
+    /// Move the installed wake source out for the run loop. Returns `None` if
+    /// none was installed (the loop then polls).
+    fn take_wake_source(&self) -> Option<wake::WakeSource> {
+        self.wake_source
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .take()
+    }
+
+    /// Bridge a (re)scheduled job into the push loop: wake immediately if it
+    /// is ready now, otherwise arm the delayed timer. Used by the retry and
+    /// periodic-enqueue paths, which run on the scheduler and already hold a
+    /// storage handle.
+    pub(crate) fn signal_scheduled(&self, scheduled_at: i64) {
+        use crate::storage::notify::StorageNotifier;
+        if scheduled_at <= crate::job::now_millis() {
+            match &self.storage {
+                StorageBackend::Sqlite(s) => s.notify_job_ready("", scheduled_at),
+                #[cfg(feature = "postgres")]
+                StorageBackend::Postgres(s) => s.notify_job_ready("", scheduled_at),
+                #[cfg(feature = "redis")]
+                StorageBackend::Redis(s) => s.notify_job_ready("", scheduled_at),
+            }
+        } else {
+            self.note_scheduled_at(scheduled_at);
+        }
+    }
+
+    /// Record the earliest delayed-job schedule so the loop can arm a timer.
+    /// Ready jobs (`scheduled_at <= now`) wake immediately and don't update
+    /// this. Safe to call from any thread.
+    pub fn note_scheduled_at(&self, scheduled_at: i64) {
+        use std::sync::atomic::Ordering;
+        let mut current = self.next_scheduled_at.load(Ordering::Relaxed);
+        while scheduled_at < current {
+            match self.next_scheduled_at.compare_exchange_weak(
+                current,
+                scheduled_at,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => break,
+                Err(observed) => current = observed,
+            }
+        }
+    }
+
+    /// Duration until the next delayed job is due, capped at the fallback
+    /// interval. Resets the tracker once the time has passed so a stale value
+    /// can't pin the timer low forever.
+    fn next_delayed_timer(&self) -> Duration {
+        use std::sync::atomic::Ordering;
+        let next = self.next_scheduled_at.load(Ordering::Relaxed);
+        if next == i64::MAX {
+            return Self::PUSH_FALLBACK_INTERVAL;
+        }
+        let now = crate::job::now_millis();
+        if next <= now {
+            // The delayed job is due; clear the tracker and dispatch now.
+            self.next_scheduled_at.store(i64::MAX, Ordering::Relaxed);
+            return Duration::ZERO;
+        }
+        Duration::from_millis((next - now) as u64).min(Self::PUSH_FALLBACK_INTERVAL)
+    }
+
+    /// Event-driven dispatch loop. Dispatches on a wake signal, on the
+    /// fallback timer, or when a delayed job comes due. Maintenance runs on
+    /// its own ticker so its cadence is independent of dispatch.
+    async fn run_push(&self, job_tx: tokio::sync::mpsc::Sender<Job>, mut wake: wake::WakeSource) {
+        let mut counters = TickCounters::default();
+        let mut maintenance = tokio::time::interval(Self::PUSH_MAINTENANCE_INTERVAL);
+        maintenance.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+        loop {
+            let fallback = self.next_delayed_timer();
+            tokio::select! {
+                _ = self.shutdown.notified() => break,
+                _ = wake.wait() => {
+                    // Drain dispatch fully so a single wake clears the queue.
+                    while self.tick_dispatch(&job_tx) {}
+                }
+                _ = tokio::time::sleep(fallback) => {
+                    while self.tick_dispatch(&job_tx) {}
+                }
+                _ = maintenance.tick() => {
+                    if self.tick_maintenance(&mut counters) {
+                        // Periodic enqueue may have produced ready work.
+                        while self.tick_dispatch(&job_tx) {}
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -862,5 +1011,139 @@ mod tests {
         assert_eq!(counters.reap, 1);
         assert_eq!(counters.periodic, 1);
         assert_eq!(counters.cleanup, 1);
+    }
+}
+
+#[cfg(all(test, feature = "push-dispatch"))]
+mod push_tests {
+    use super::*;
+    use crate::job::{now_millis, NewJob};
+    use crate::storage::Storage;
+    use std::time::Duration;
+
+    fn push_scheduler() -> Scheduler {
+        let storage =
+            StorageBackend::Sqlite(crate::storage::sqlite::SqliteStorage::in_memory().unwrap());
+        Scheduler::new(
+            storage,
+            vec!["default".to_string()],
+            SchedulerConfig::default(),
+            None,
+        )
+    }
+
+    fn ready_job(task_name: &str) -> NewJob {
+        NewJob {
+            queue: "default".to_string(),
+            task_name: task_name.to_string(),
+            payload: vec![1, 2, 3],
+            priority: 0,
+            scheduled_at: now_millis(),
+            max_retries: 3,
+            timeout_ms: 300_000,
+            unique_key: None,
+            metadata: None,
+            notes: None,
+            depends_on: vec![],
+            expires_at: None,
+            result_ttl_ms: None,
+            namespace: None,
+        }
+    }
+
+    /// Enqueuing a ready job must wake the in-process Notify within 50ms.
+    #[test]
+    fn test_wake_fires_on_immediate_enqueue() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let scheduler = push_scheduler();
+            let notify = match scheduler.storage() {
+                StorageBackend::Sqlite(s) => s.notify_handle().clone(),
+                _ => unreachable!("test uses sqlite"),
+            };
+
+            // Enqueue goes through the StorageBackend chokepoint, which calls
+            // notify_one() for ready jobs.
+            scheduler.storage().enqueue(ready_job("wake_task")).unwrap();
+
+            // notify_one() before notified() still wakes the next waiter, so a
+            // brief wait must resolve.
+            let woke = tokio::time::timeout(Duration::from_millis(50), notify.notified()).await;
+            assert!(
+                woke.is_ok(),
+                "enqueue of a ready job must wake the scheduler"
+            );
+        });
+    }
+
+    /// A delayed job must NOT wake immediately — the Notify stays unsignaled.
+    #[test]
+    fn test_delayed_job_does_not_wake() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let scheduler = push_scheduler();
+            let notify = match scheduler.storage() {
+                StorageBackend::Sqlite(s) => s.notify_handle().clone(),
+                _ => unreachable!("test uses sqlite"),
+            };
+
+            let mut delayed = ready_job("later_task");
+            delayed.scheduled_at = now_millis() + 60_000; // 1 minute out
+            scheduler.storage().enqueue(delayed).unwrap();
+
+            let woke = tokio::time::timeout(Duration::from_millis(50), notify.notified()).await;
+            assert!(woke.is_err(), "a delayed job must not wake immediately");
+
+            // It should instead arm the delayed timer.
+            let timer = scheduler.next_delayed_timer();
+            assert!(timer > Duration::ZERO && timer <= Scheduler::PUSH_FALLBACK_INTERVAL);
+        });
+    }
+
+    /// With no wake delivered, the fallback timer still dispatches a job.
+    #[test]
+    fn test_fallback_poll_dispatches_without_wake() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let scheduler = push_scheduler();
+
+            // Insert a ready job directly via the inherent SQLite method so the
+            // StorageBackend notify chokepoint is bypassed — simulating a
+            // missed wake. The fallback dispatch path must still pick it up.
+            match scheduler.storage() {
+                StorageBackend::Sqlite(s) => {
+                    s.enqueue(ready_job("fallback_task")).unwrap();
+                }
+                _ => unreachable!("test uses sqlite"),
+            }
+
+            let (tx, mut rx) = tokio::sync::mpsc::channel(16);
+            // Drive a single fallback dispatch round directly.
+            while scheduler.tick_dispatch(&tx) {}
+
+            assert!(
+                rx.try_recv().is_ok(),
+                "fallback dispatch must claim the job even without a wake"
+            );
+
+            let job = rx.try_recv();
+            // Only one job existed.
+            assert!(job.is_err());
+        });
+    }
+
+    /// `note_scheduled_at` keeps the earliest schedule and clears once due.
+    #[test]
+    fn test_next_delayed_timer_tracks_earliest() {
+        let scheduler = push_scheduler();
+        let now = now_millis();
+        scheduler.note_scheduled_at(now + 10_000);
+        scheduler.note_scheduled_at(now + 5_000);
+        scheduler.note_scheduled_at(now + 20_000);
+
+        let timer = scheduler.next_delayed_timer();
+        // Earliest (5s out), capped at the fallback interval (2s).
+        assert!(timer <= Scheduler::PUSH_FALLBACK_INTERVAL);
+        assert!(timer > Duration::ZERO);
     }
 }

--- a/crates/taskito-core/src/scheduler/result_handler.rs
+++ b/crates/taskito-core/src/scheduler/result_handler.rs
@@ -113,6 +113,8 @@ impl Scheduler {
                 if retry_count < effective_max {
                     let next_at = policy.next_retry_at(retry_count);
                     self.storage.retry(&job_id, next_at)?;
+                    #[cfg(feature = "push-dispatch")]
+                    self.signal_scheduled(next_at);
                     Ok(ResultOutcome::Retry {
                         job_id,
                         task_name,

--- a/crates/taskito-core/src/scheduler/wake.rs
+++ b/crates/taskito-core/src/scheduler/wake.rs
@@ -1,0 +1,50 @@
+//! Wake sources for the scheduler loop.
+//!
+//! Entirely behind the `push-dispatch` feature. When the feature is off this
+//! module is not compiled and the scheduler keeps its original adaptive-poll
+//! loop unchanged.
+//!
+//! A [`WakeSource`] lets an enqueue (or retry, or periodic enqueue) wake the
+//! scheduler immediately instead of waiting for the next poll tick. Polling is
+//! retained as a safety-net fallback so a missed notification can never strand
+//! a job.
+
+#![cfg(feature = "push-dispatch")]
+
+use std::sync::Arc;
+
+use tokio::sync::{mpsc, Notify};
+
+/// Where the scheduler gets its "a job is ready" signals from.
+pub enum WakeSource {
+    /// SQLite, single-process: an in-memory [`Notify`] shared with the
+    /// storage layer. Enqueue calls `notify_one()` on the same handle.
+    InProcess(Arc<Notify>),
+    /// Postgres `LISTEN` / Redis `BLPOP`: a background listener forwards a
+    /// unit value per notification into this channel.
+    Channel(mpsc::Receiver<()>),
+    /// Feature compiled in but no wake source available — behaves like the
+    /// fallback timer alone (the loop still dispatches on its periodic tick).
+    Polling,
+}
+
+impl WakeSource {
+    /// Wait for the next wake signal.
+    ///
+    /// For [`WakeSource::Polling`] this never resolves on its own — the
+    /// scheduler's fallback `sleep` timer drives dispatch instead, so this
+    /// arm must simply yield the loop's `select!` to the timer.
+    pub async fn wait(&mut self) {
+        match self {
+            WakeSource::InProcess(notify) => notify.notified().await,
+            WakeSource::Channel(rx) => {
+                // A closed channel (listener gone) must not busy-loop the
+                // select!; fall back to never-resolving so the timer drives.
+                if rx.recv().await.is_none() {
+                    std::future::pending::<()>().await
+                }
+            }
+            WakeSource::Polling => std::future::pending::<()>().await,
+        }
+    }
+}

--- a/crates/taskito-core/src/storage/mod.rs
+++ b/crates/taskito-core/src/storage/mod.rs
@@ -1,5 +1,7 @@
 mod diesel_common;
 pub mod models;
+#[cfg(feature = "push-dispatch")]
+pub mod notify;
 #[cfg(feature = "postgres")]
 pub mod postgres;
 #[cfg(feature = "redis")]
@@ -578,15 +580,50 @@ macro_rules! delegate {
     };
 }
 
+impl StorageBackend {
+    /// Signal the scheduler that a ready job was enqueued, so it can dispatch
+    /// immediately instead of waiting for the next poll. No-op for delayed
+    /// jobs (`scheduled_at > now`) — those rely on the fallback timer — and a
+    /// no-op entirely when `push-dispatch` is off.
+    #[cfg(feature = "push-dispatch")]
+    fn notify_if_ready(&self, scheduled_at: i64) {
+        use crate::storage::notify::StorageNotifier;
+        if scheduled_at > crate::job::now_millis() {
+            return;
+        }
+        match self {
+            StorageBackend::Sqlite(s) => s.notify_job_ready("", scheduled_at),
+            #[cfg(feature = "postgres")]
+            StorageBackend::Postgres(s) => s.notify_job_ready("", scheduled_at),
+            #[cfg(feature = "redis")]
+            StorageBackend::Redis(s) => s.notify_job_ready("", scheduled_at),
+        }
+    }
+}
+
 impl Storage for StorageBackend {
     fn enqueue(&self, new_job: NewJob) -> Result<Job> {
-        delegate!(self, enqueue, new_job)
+        let job = delegate!(self, enqueue, new_job)?;
+        #[cfg(feature = "push-dispatch")]
+        self.notify_if_ready(job.scheduled_at);
+        Ok(job)
     }
     fn enqueue_batch(&self, new_jobs: Vec<NewJob>) -> Result<Vec<Job>> {
-        delegate!(self, enqueue_batch, new_jobs)
+        let jobs = delegate!(self, enqueue_batch, new_jobs)?;
+        #[cfg(feature = "push-dispatch")]
+        if jobs
+            .iter()
+            .any(|j| j.scheduled_at <= crate::job::now_millis())
+        {
+            self.notify_if_ready(0);
+        }
+        Ok(jobs)
     }
     fn enqueue_unique(&self, new_job: NewJob) -> Result<Job> {
-        delegate!(self, enqueue_unique, new_job)
+        let job = delegate!(self, enqueue_unique, new_job)?;
+        #[cfg(feature = "push-dispatch")]
+        self.notify_if_ready(job.scheduled_at);
+        Ok(job)
     }
     fn dequeue(&self, queue_name: &str, now: i64, namespace: Option<&str>) -> Result<Option<Job>> {
         delegate!(self, dequeue, queue_name, now, namespace)

--- a/crates/taskito-core/src/storage/notify.rs
+++ b/crates/taskito-core/src/storage/notify.rs
@@ -1,0 +1,21 @@
+//! Storage-side notification hook for push-based dispatch.
+//!
+//! Entirely behind the `push-dispatch` feature. When off, this module is not
+//! compiled and no backend carries any notification state — the default build
+//! is byte-for-byte unchanged.
+//!
+//! A backend implements [`StorageNotifier`] to signal the scheduler that a
+//! ready job (`scheduled_at <= now`) has been enqueued, so the scheduler can
+//! dispatch it immediately instead of waiting for the next poll. Delayed jobs
+//! (`scheduled_at > now`) deliberately do NOT notify — the scheduler relies on
+//! its fallback timer to pick those up at the right time.
+
+#![cfg(feature = "push-dispatch")]
+
+/// Emit a "job ready" signal for `queue`. Implementations must be cheap and
+/// must never panic or propagate errors into the enqueue path — a failed
+/// notification only costs the dispatch-latency improvement, never
+/// correctness (the fallback poll still finds the job).
+pub trait StorageNotifier: Send + Sync {
+    fn notify_job_ready(&self, queue: &str, scheduled_at: i64);
+}

--- a/crates/taskito-core/src/storage/postgres/listener.rs
+++ b/crates/taskito-core/src/storage/postgres/listener.rs
@@ -1,0 +1,49 @@
+//! Postgres `LISTEN`-based wake listener for push-dispatch.
+//!
+//! Entirely behind the `push-dispatch` feature.
+//!
+//! ## Status: conservative stub
+//!
+//! True event-driven `LISTEN`/`NOTIFY` requires retrieving libpq notifications
+//! (`PQnotifies`) from the underlying connection. Diesel's safe `PgConnection`
+//! API does not expose the raw libpq handle or a notification-poll primitive,
+//! so a correct, non-`unsafe` `LISTEN` loop cannot be built on top of Diesel
+//! alone here. Rather than ship a broken or `unsafe` FFI path, this listener
+//! forwards a periodic tick: push-dispatch on Postgres therefore degrades to a
+//! faster, bounded fallback poll (driven by [`LISTEN_POLL_INTERVAL`]) instead
+//! of instantaneous wakeups. The enqueue side still issues `pg_notify` (see
+//! [`super::JOB_READY_CHANNEL`]) so a future libpq-backed listener can become
+//! fully event-driven without any enqueue-path change.
+//!
+//! The default (feature-off) build never compiles this module.
+
+use std::time::Duration;
+
+use tokio::sync::mpsc;
+
+use super::PostgresStorage;
+
+/// Interval at which the stub listener forwards a wake while a true
+/// `LISTEN`/`NOTIFY` retrieval path is unavailable.
+pub const LISTEN_POLL_INTERVAL: Duration = Duration::from_millis(250);
+
+/// Spawn the Postgres wake listener and return the receiver end for the
+/// scheduler's [`crate::scheduler::wake::WakeSource::Channel`].
+///
+/// The `_storage` handle is retained for the eventual libpq-backed
+/// implementation (it carries [`PostgresStorage::database_url`]); the current
+/// stub does not open a dedicated connection.
+pub fn spawn(_storage: PostgresStorage) -> mpsc::Receiver<()> {
+    let (tx, rx) = mpsc::channel(1);
+    tokio::task::spawn_blocking(move || loop {
+        std::thread::sleep(LISTEN_POLL_INTERVAL);
+        // A full channel already has a pending wake — dropping this one is
+        // fine. A closed channel means the scheduler is gone; stop.
+        match tx.try_send(()) {
+            Ok(()) => {}
+            Err(mpsc::error::TrySendError::Full(_)) => {}
+            Err(mpsc::error::TrySendError::Closed(_)) => break,
+        }
+    });
+    rx
+}

--- a/crates/taskito-core/src/storage/postgres/mod.rs
+++ b/crates/taskito-core/src/storage/postgres/mod.rs
@@ -12,6 +12,9 @@ mod rate_limits;
 mod trait_impl;
 mod workers;
 
+#[cfg(feature = "push-dispatch")]
+pub mod listener;
+
 use diesel::pg::PgConnection;
 use diesel::prelude::*;
 use diesel::r2d2::{ConnectionManager, Pool};
@@ -52,6 +55,10 @@ fn validate_schema_name(schema: &str) -> Result<()> {
 pub struct PostgresStorage {
     pool: PgPool,
     schema: String,
+    /// Original connection URL, retained only to open the dedicated
+    /// (non-pooled) `LISTEN` connection used by push-dispatch.
+    #[cfg(feature = "push-dispatch")]
+    database_url: String,
 }
 
 impl PostgresStorage {
@@ -95,9 +102,17 @@ impl PostgresStorage {
         let storage = Self {
             pool,
             schema: schema.to_string(),
+            #[cfg(feature = "push-dispatch")]
+            database_url: database_url.to_string(),
         };
         storage.run_migrations()?;
         Ok(storage)
+    }
+
+    /// The connection URL, for opening the dedicated `LISTEN` connection.
+    #[cfg(feature = "push-dispatch")]
+    pub fn database_url(&self) -> &str {
+        &self.database_url
     }
 
     pub fn conn(&self) -> Result<diesel::r2d2::PooledConnection<ConnectionManager<PgConnection>>> {
@@ -131,5 +146,31 @@ impl PostgresStorage {
         }
 
         Ok(())
+    }
+}
+
+/// Postgres `NOTIFY` channel that carries "a ready job was enqueued" signals.
+#[cfg(feature = "push-dispatch")]
+pub const JOB_READY_CHANNEL: &str = "taskito_job_ready";
+
+#[cfg(feature = "push-dispatch")]
+impl crate::storage::notify::StorageNotifier for PostgresStorage {
+    fn notify_job_ready(&self, queue: &str, _scheduled_at: i64) {
+        // Best-effort: a failed NOTIFY only costs the latency improvement —
+        // the scheduler's fallback poll still picks the job up.
+        let mut conn = match self.conn() {
+            Ok(c) => c,
+            Err(e) => {
+                log::warn!("push-dispatch: NOTIFY conn failed: {e}");
+                return;
+            }
+        };
+        // Bind the queue as a parameter so the payload can't break out of the
+        // NOTIFY statement.
+        let stmt = diesel::sql_query(format!("SELECT pg_notify('{JOB_READY_CHANNEL}', $1)"))
+            .bind::<diesel::sql_types::Text, _>(queue);
+        if let Err(e) = stmt.execute(&mut conn) {
+            log::warn!("push-dispatch: pg_notify failed: {e}");
+        }
     }
 }

--- a/crates/taskito-core/src/storage/redis_backend/listener.rs
+++ b/crates/taskito-core/src/storage/redis_backend/listener.rs
@@ -1,0 +1,73 @@
+//! Redis `BLPOP`-based wake listener for push-dispatch.
+//!
+//! Entirely behind the `push-dispatch` feature. The default (feature-off)
+//! build never compiles this module.
+//!
+//! A dedicated blocking connection loops on `BLPOP <notify-key> 1`. The 1s
+//! timeout keeps shutdown responsive (the loop re-checks the forward channel
+//! between blocks). Each popped sentinel forwards a unit wake into the
+//! scheduler's [`crate::scheduler::wake::WakeSource::Channel`]. Connection
+//! errors back off before reconnecting.
+
+use std::time::Duration;
+
+use tokio::sync::mpsc;
+
+use super::RedisStorage;
+
+/// `BLPOP` block timeout. Short enough to notice a dropped forward channel and
+/// stop promptly on shutdown.
+const BLPOP_TIMEOUT_SECS: f64 = 1.0;
+
+/// Backoff after a connection error before reconnecting.
+const RECONNECT_BACKOFF: Duration = Duration::from_millis(500);
+
+/// Spawn the Redis wake listener and return the receiver end for the
+/// scheduler's [`crate::scheduler::wake::WakeSource::Channel`].
+pub fn spawn(storage: RedisStorage) -> mpsc::Receiver<()> {
+    let (tx, rx) = mpsc::channel(1);
+    let key = storage.notify_key();
+
+    tokio::task::spawn_blocking(move || {
+        loop {
+            let mut conn = match storage.client().get_connection() {
+                Ok(c) => c,
+                Err(e) => {
+                    log::warn!("push-dispatch: redis listener connect failed: {e}");
+                    std::thread::sleep(RECONNECT_BACKOFF);
+                    if tx.is_closed() {
+                        break;
+                    }
+                    continue;
+                }
+            };
+
+            loop {
+                if tx.is_closed() {
+                    return;
+                }
+                let popped: redis::RedisResult<Option<(String, i64)>> = redis::cmd("BLPOP")
+                    .arg(&key)
+                    .arg(BLPOP_TIMEOUT_SECS)
+                    .query(&mut conn);
+
+                match popped {
+                    // Timed out with no element — just re-check shutdown.
+                    Ok(None) => continue,
+                    Ok(Some(_)) => match tx.try_send(()) {
+                        Ok(()) => {}
+                        Err(mpsc::error::TrySendError::Full(_)) => {}
+                        Err(mpsc::error::TrySendError::Closed(_)) => return,
+                    },
+                    Err(e) => {
+                        log::warn!("push-dispatch: redis BLPOP failed: {e}");
+                        std::thread::sleep(RECONNECT_BACKOFF);
+                        break; // reconnect
+                    }
+                }
+            }
+        }
+    });
+
+    rx
+}

--- a/crates/taskito-core/src/storage/redis_backend/mod.rs
+++ b/crates/taskito-core/src/storage/redis_backend/mod.rs
@@ -12,6 +12,9 @@ mod rate_limits;
 mod trait_impl;
 mod workers;
 
+#[cfg(feature = "push-dispatch")]
+pub mod listener;
+
 use crate::error::{QueueError, Result};
 
 /// Redis-backed storage for the task queue.
@@ -71,6 +74,44 @@ impl RedisStorage {
     /// their own keys under the same prefix without re-parsing the URL.
     pub fn prefix(&self) -> &str {
         &self.prefix
+    }
+
+    /// The single list key push-dispatch uses to signal ready jobs. The
+    /// enqueue side `LPUSH`es a sentinel here; the listener `BLPOP`s it.
+    #[cfg(feature = "push-dispatch")]
+    pub(crate) fn notify_key(&self) -> String {
+        self.key(&["notify", "_ready"])
+    }
+
+    /// A raw client clone, for the listener's dedicated blocking connection.
+    #[cfg(feature = "push-dispatch")]
+    pub fn client(&self) -> &redis::Client {
+        &self.client
+    }
+}
+
+#[cfg(feature = "push-dispatch")]
+impl crate::storage::notify::StorageNotifier for RedisStorage {
+    fn notify_job_ready(&self, _queue: &str, _scheduled_at: i64) {
+        // Best-effort LPUSH of a sentinel onto the notify list. A failure only
+        // costs the latency improvement — the fallback poll still dispatches.
+        let mut conn = match self.conn() {
+            Ok(c) => c,
+            Err(e) => {
+                log::warn!("push-dispatch: redis notify conn failed: {e}");
+                return;
+            }
+        };
+        let key = self.notify_key();
+        // Keep the list short — a single pending sentinel is enough to wake the
+        // listener; trim so it can't grow unbounded under bursty enqueues.
+        let res: redis::RedisResult<()> = redis::pipe()
+            .lpush(&key, 1)
+            .ltrim(&key, 0, 15)
+            .query(&mut conn);
+        if let Err(e) = res {
+            log::warn!("push-dispatch: redis LPUSH notify failed: {e}");
+        }
     }
 }
 

--- a/crates/taskito-core/src/storage/sqlite/mod.rs
+++ b/crates/taskito-core/src/storage/sqlite/mod.rs
@@ -63,6 +63,11 @@ impl CustomizeConnection<SqliteConnection, diesel::r2d2::Error> for SqlitePragma
 #[derive(Clone)]
 pub struct SqliteStorage {
     pool: DbPool,
+    /// In-process wake handle, set by the scheduler when push-dispatch is
+    /// enabled. Enqueue of a ready job calls `notify_one()` so the scheduler
+    /// dispatches immediately instead of waiting for the next poll.
+    #[cfg(feature = "push-dispatch")]
+    notify: std::sync::Arc<tokio::sync::Notify>,
 }
 
 impl SqliteStorage {
@@ -79,7 +84,11 @@ impl SqliteStorage {
             .connection_customizer(Box::new(SqlitePragmaCustomizer))
             .build(manager)?;
 
-        let storage = Self { pool };
+        let storage = Self {
+            pool,
+            #[cfg(feature = "push-dispatch")]
+            notify: std::sync::Arc::new(tokio::sync::Notify::new()),
+        };
         storage.run_migrations()?;
         Ok(storage)
     }
@@ -92,9 +101,27 @@ impl SqliteStorage {
             .connection_customizer(Box::new(SqlitePragmaCustomizer))
             .build(manager)?;
 
-        let storage = Self { pool };
+        let storage = Self {
+            pool,
+            #[cfg(feature = "push-dispatch")]
+            notify: std::sync::Arc::new(tokio::sync::Notify::new()),
+        };
         storage.run_migrations()?;
         Ok(storage)
+    }
+
+    /// Replace the in-process wake handle so it is shared with the scheduler's
+    /// [`WakeSource`]. Only meaningful under `push-dispatch`.
+    #[cfg(feature = "push-dispatch")]
+    pub fn set_notify_handle(&mut self, notify: std::sync::Arc<tokio::sync::Notify>) {
+        self.notify = notify;
+    }
+
+    /// The in-process wake handle. Enqueue paths call `notify_one()` on this
+    /// when a ready job is inserted.
+    #[cfg(feature = "push-dispatch")]
+    pub fn notify_handle(&self) -> &std::sync::Arc<tokio::sync::Notify> {
+        &self.notify
     }
 
     pub fn conn(
@@ -122,6 +149,14 @@ impl SqliteStorage {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(feature = "push-dispatch")]
+impl crate::storage::notify::StorageNotifier for SqliteStorage {
+    fn notify_job_ready(&self, _queue: &str, _scheduled_at: i64) {
+        // Single-process: wake the in-memory scheduler loop directly.
+        self.notify.notify_one();
     }
 }
 

--- a/crates/taskito-python/Cargo.toml
+++ b/crates/taskito-python/Cargo.toml
@@ -10,6 +10,8 @@ postgres = ["taskito-core/postgres", "taskito-workflows?/postgres"]
 redis = ["taskito-core/redis", "taskito-workflows?/redis"]
 native-async = ["dep:taskito-async"]
 workflows = ["dep:taskito-workflows"]
+# Event-driven scheduler wakeups. OFF by default (not in maturin defaults).
+push-dispatch = ["taskito-core/push-dispatch"]
 
 [lib]
 name = "_taskito"

--- a/crates/taskito-python/src/py_queue/mod.rs
+++ b/crates/taskito-python/src/py_queue/mod.rs
@@ -41,6 +41,9 @@ pub struct PyQueue {
     pub(crate) scheduler_cleanup_interval: u32,
     pub(crate) scheduler_batch_size: usize,
     pub(crate) namespace: Option<String>,
+    /// Opt-in event-driven dispatch. Honored only when the crate is built with
+    /// the `push-dispatch` cargo feature; otherwise accepted and ignored.
+    pub(crate) push_dispatch: bool,
     /// Active worker dispatcher, set while `run_worker` is executing. Used by
     /// `request_cancel` to deliver a side-channel signal to pools that run
     /// tasks out-of-process (prefork). For in-process pools the trait's
@@ -61,7 +64,7 @@ pub struct PyQueue {
 )]
 impl PyQueue {
     #[new]
-    #[pyo3(signature = (db_path=".taskito/taskito.db", workers=0, default_retry=3, default_timeout=300, default_priority=0, result_ttl=None, backend="sqlite", db_url=None, schema="taskito", pool_size=None, scheduler_poll_interval_ms=50, scheduler_reap_interval=100, scheduler_cleanup_interval=1200, scheduler_batch_size=1, namespace=None))]
+    #[pyo3(signature = (db_path=".taskito/taskito.db", workers=0, default_retry=3, default_timeout=300, default_priority=0, result_ttl=None, backend="sqlite", db_url=None, schema="taskito", pool_size=None, scheduler_poll_interval_ms=50, scheduler_reap_interval=100, scheduler_cleanup_interval=1200, scheduler_batch_size=1, namespace=None, push_dispatch=false))]
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         py: Python<'_>,
@@ -80,6 +83,7 @@ impl PyQueue {
         scheduler_cleanup_interval: u32,
         scheduler_batch_size: usize,
         namespace: Option<String>,
+        push_dispatch: bool,
     ) -> PyResult<Self> {
         // Storage init blocks on connection-pool builders that may emit
         // `log::*` records from worker threads. With the pyo3-log bridge
@@ -155,6 +159,7 @@ impl PyQueue {
             scheduler_cleanup_interval,
             scheduler_batch_size: scheduler_batch_size.max(1),
             namespace,
+            push_dispatch,
             dispatcher: Arc::new(Mutex::new(None)),
             #[cfg(feature = "workflows")]
             workflow_storage: std::sync::OnceLock::new(),

--- a/crates/taskito-python/src/py_queue/worker.rs
+++ b/crates/taskito-python/src/py_queue/worker.rs
@@ -321,6 +321,29 @@ impl PyQueue {
             }
         }
 
+        // Push-dispatch: install the in-process wake source the scheduler loop
+        // consumes. SQLite wakes via a shared `Notify` and needs no runtime, so
+        // it is installed here. Channel-based sources (Postgres/Redis) spawn a
+        // listener and are installed inside the runtime below. When the feature
+        // is off, `push_dispatch` is accepted but ignored so the default
+        // constructor keeps polling.
+        #[cfg(feature = "push-dispatch")]
+        if self.push_dispatch {
+            #[allow(irrefutable_let_patterns)]
+            if let taskito_core::storage::StorageBackend::Sqlite(s) = &self.storage {
+                scheduler.set_wake_source(taskito_core::scheduler::wake::WakeSource::InProcess(
+                    s.notify_handle().clone(),
+                ));
+            }
+        }
+        #[cfg(not(feature = "push-dispatch"))]
+        if self.push_dispatch {
+            log::debug!(
+                "push_dispatch=True but the crate was built without the \
+                 'push-dispatch' feature; falling back to polling"
+            );
+        }
+
         let shutdown = scheduler.shutdown_handle();
 
         let (job_tx, job_rx) = tokio::sync::mpsc::channel(self.num_workers * 2);
@@ -412,6 +435,15 @@ impl PyQueue {
             }
         };
 
+        // Captured for the channel-based (Postgres/Redis) wake-source setup
+        // inside the runtime. Gated to the listener-bearing backends so the
+        // default and SQLite-only builds have no unused binding.
+        #[cfg(all(
+            feature = "push-dispatch",
+            any(feature = "postgres", feature = "redis")
+        ))]
+        let push_dispatch_enabled = self.push_dispatch;
+
         // Move result_tx into the runtime — don't keep a copy in the main thread
         // so result_rx disconnects when all workers are done.
         let runtime_handle = std::thread::spawn(move || {
@@ -428,6 +460,35 @@ impl PyQueue {
             };
 
             rt.block_on(async {
+                // Channel-based wake sources (Postgres/Redis) must spawn their
+                // listener inside the runtime. Installed here, before the
+                // scheduler loop takes the source.
+                #[cfg(feature = "push-dispatch")]
+                {
+                    match scheduler_for_dispatch.storage() {
+                        #[cfg(feature = "postgres")]
+                        taskito_core::storage::StorageBackend::Postgres(s)
+                            if push_dispatch_enabled =>
+                        {
+                            let rx = taskito_core::storage::postgres::listener::spawn(s.clone());
+                            scheduler_for_dispatch.set_wake_source(
+                                taskito_core::scheduler::wake::WakeSource::Channel(rx),
+                            );
+                        }
+                        #[cfg(feature = "redis")]
+                        taskito_core::storage::StorageBackend::Redis(s)
+                            if push_dispatch_enabled =>
+                        {
+                            let rx =
+                                taskito_core::storage::redis_backend::listener::spawn(s.clone());
+                            scheduler_for_dispatch.set_wake_source(
+                                taskito_core::scheduler::wake::WakeSource::Channel(rx),
+                            );
+                        }
+                        _ => {}
+                    }
+                }
+
                 let scheduler_task = tokio::spawn(async move {
                     scheduler_for_dispatch.run(job_tx).await;
                 });

--- a/crates/taskito-python/src/py_queue/workflow_ops/test_helpers.rs
+++ b/crates/taskito-python/src/py_queue/workflow_ops/test_helpers.rs
@@ -56,6 +56,7 @@ pub(crate) fn make_test_pyqueue() -> PyQueue {
         scheduler_cleanup_interval: 1200,
         scheduler_batch_size: 1,
         namespace: None,
+        push_dispatch: false,
         dispatcher: Arc::new(Mutex::new(None)),
         workflow_storage,
     }

--- a/py_src/taskito/_taskito.pyi
+++ b/py_src/taskito/_taskito.pyi
@@ -93,6 +93,7 @@ class PyQueue:
         scheduler_cleanup_interval: int = 1200,
         scheduler_batch_size: int = 1,
         namespace: str | None = None,
+        push_dispatch: bool = False,
     ) -> None: ...
     def request_shutdown(self) -> None: ...
     def enqueue(

--- a/py_src/taskito/app.py
+++ b/py_src/taskito/app.py
@@ -135,6 +135,7 @@ class Queue(
         scheduler_cleanup_interval: int = 1200,
         scheduler_batch_size: int = 1,
         namespace: str | None = None,
+        push_dispatch: bool = False,
     ):
         """Initialize a new task queue.
 
@@ -184,6 +185,11 @@ class Queue(
             scheduler_batch_size: Maximum number of jobs the scheduler claims
                 per dispatch round. ``1`` (default) preserves one-job-per-round
                 behavior; higher values batch-claim for greater throughput.
+            push_dispatch: Opt into event-driven dispatch, where an enqueue
+                wakes the scheduler immediately instead of waiting for the next
+                poll. Honored only when the native module was built with the
+                ``push-dispatch`` cargo feature; otherwise accepted and ignored
+                (polling is kept). Defaults to ``False``.
         """
         if backend == "sqlite":
             # Ensure parent directory exists for SQLite
@@ -207,6 +213,7 @@ class Queue(
             scheduler_cleanup_interval=scheduler_cleanup_interval,
             scheduler_batch_size=scheduler_batch_size,
             namespace=namespace,
+            push_dispatch=push_dispatch,
         )
         self._backend = backend
         self._namespace = namespace


### PR DESCRIPTION
## Summary

**P5** of the Taskito 2.0 program. The scheduler polls every 50–200ms, which
puts a latency floor on every job and constant idle DB load on every worker.
This adds **event-driven dispatch**: an enqueue wakes the scheduler immediately,
with polling kept as the safety-net fallback.

**Opt-in behind a new `push-dispatch` cargo feature, OFF by default.** The
shipped wheel keeps polling (the feature is not in maturin's default set), so
existing deployments are byte-for-byte unchanged.

> Stacked on #217 (P4 batch dequeue) — both touch the scheduler. Merge #217 first.

## Design

- `WakeSource` (`scheduler/wake.rs`): `InProcess(Notify)` for SQLite, `Channel`
  for Postgres/Redis listeners, `Polling` when the feature is off.
- The run loop, when push is enabled, `select!`s over shutdown / wake / a ~2s
  fallback timer / a 500ms maintenance ticker (reap/periodic/cleanup decoupled
  from dispatch). When off, the original adaptive-poll loop is untouched.
- `StorageNotifier` (`storage/notify.rs`) fires only for **ready** jobs
  (`scheduled_at <= now`); delayed jobs are caught by the fallback timer.
- **SQLite** (in-process `Notify`) and **Redis** (`BLPOP` listener with reconnect
  backoff) are fully event-driven.

## Known limitation (follow-up)

- **Postgres listener is a stub**: it issues `pg_notify` on enqueue but the
  listener side currently uses a faster fallback tick rather than true
  `LISTEN`/`NOTIFY`, because Diesel's safe `PgConnection` API exposes no
  `PQnotifies` primitive. A libpq/tokio-postgres-backed listener can drop in
  later with no enqueue-side change. Flagged for review — adding that dependency
  is a deliberate call.

## Verification

- **Default build unchanged** (the #1 gate): `cargo test --workspace` green;
  Python suite **1012 passed**; every new field/module/call site is
  `#[cfg(feature = "push-dispatch")]`-gated.
- `cargo test --workspace --features push-dispatch`: **71 passed** (+4 push tests:
  wake-on-enqueue, delayed-no-wake, fallback-dispatch, earliest-timer).
- `cargo clippy` clean on default and `push-dispatch postgres redis workflows`.
- Postgres + Redis contract suites (fresh DBs): green.