### PR TITLE
perf(storage): move payloads to a side table for narrow dequeue

### DIFF
--- a/crates/taskito-core/src/job.rs
+++ b/crates/taskito-core/src/job.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use uuid::Uuid;
 
-use crate::storage::models::{ArchivedJobRow, JobRow};
+use crate::storage::models::{ArchivedJobRow, JobRow, NarrowJobRow};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[repr(i32)]
@@ -154,6 +154,41 @@ impl From<ArchivedJobRow> for Job {
             namespace: row.namespace,
             // Archived jobs are terminal and never re-dequeued.
             has_deps: false,
+        }
+    }
+}
+
+impl Job {
+    /// Assemble a [`Job`] from a blob-free [`NarrowJobRow`] plus the
+    /// `payload`/`result` fetched separately from the `job_payloads` side
+    /// table. The narrow row carries every non-blob column; the caller
+    /// supplies the blobs after claiming the single job it wants.
+    pub fn from_narrow(narrow: NarrowJobRow, payload: Vec<u8>, result: Option<Vec<u8>>) -> Self {
+        Self {
+            id: narrow.id,
+            queue: narrow.queue,
+            task_name: narrow.task_name,
+            payload,
+            status: JobStatus::from_i32(narrow.status).unwrap_or(JobStatus::Pending),
+            priority: narrow.priority,
+            created_at: narrow.created_at,
+            scheduled_at: narrow.scheduled_at,
+            started_at: narrow.started_at,
+            completed_at: narrow.completed_at,
+            retry_count: narrow.retry_count,
+            max_retries: narrow.max_retries,
+            result,
+            error: narrow.error,
+            timeout_ms: narrow.timeout_ms,
+            unique_key: narrow.unique_key,
+            progress: narrow.progress,
+            metadata: narrow.metadata,
+            notes: narrow.notes,
+            cancel_requested: narrow.cancel_requested != 0,
+            expires_at: narrow.expires_at,
+            result_ttl_ms: narrow.result_ttl_ms,
+            namespace: narrow.namespace,
+            has_deps: narrow.has_deps,
         }
     }
 }

--- a/crates/taskito-core/src/storage/diesel_common/dead_letter.rs
+++ b/crates/taskito-core/src/storage/diesel_common/dead_letter.rs
@@ -152,6 +152,17 @@ macro_rules! impl_diesel_dead_letter_ops {
                         .values(&row)
                         .execute(conn)?;
 
+                    // Dual-write the payload to the 1:1 side table so the
+                    // re-enqueued job is readable through the narrow dequeue /
+                    // get_job join path.
+                    diesel::insert_into(super::super::schema::job_payloads::table)
+                        .values(&super::super::models::NewJobPayloadRow {
+                            job_id: &job.id,
+                            payload: &job.payload,
+                            result: None,
+                        })
+                        .execute(conn)?;
+
                     let deleted = diesel::delete(dead_letter::table.find(dead_id)).execute(conn)?;
                     if deleted == 0 {
                         // A concurrent retry won the race. Roll back the

--- a/crates/taskito-core/src/storage/diesel_common/jobs.rs
+++ b/crates/taskito-core/src/storage/diesel_common/jobs.rs
@@ -456,7 +456,11 @@ macro_rules! impl_diesel_job_ops {
                             continue;
                         }
 
-                        diesel::update(jobs::table)
+                        // Claim guarded by the affected-row count: if another
+                        // worker already moved this row out of `Pending`, the
+                        // update touches zero rows — skip it rather than
+                        // handing out a job we don't own.
+                        let claimed = diesel::update(jobs::table)
                             .filter(jobs::id.eq(&row.id))
                             .filter(jobs::status.eq(JobStatus::Pending as i32))
                             .set((
@@ -464,6 +468,10 @@ macro_rules! impl_diesel_job_ops {
                                 jobs::started_at.eq(now),
                             ))
                             .execute(conn)?;
+
+                        if claimed == 0 {
+                            continue;
+                        }
 
                         let updated: NarrowJobRow = jobs::table
                             .find(&row.id)

--- a/crates/taskito-core/src/storage/diesel_common/jobs.rs
+++ b/crates/taskito-core/src/storage/diesel_common/jobs.rs
@@ -31,6 +31,12 @@ macro_rules! impl_diesel_job_ops {
                     replay_history::table.filter(replay_history::original_job_id.eq_any(job_ids)),
                 )
                 .execute(conn)?;
+                // Explicit delete of the side-table rows. The FK declares
+                // ON DELETE CASCADE, but SQLite only enforces foreign keys when
+                // `PRAGMA foreign_keys = ON` is set, so we delete here to be
+                // correct regardless of the connection's FK-enforcement state.
+                diesel::delete(job_payloads::table.filter(job_payloads::job_id.eq_any(job_ids)))
+                    .execute(conn)?;
 
                 Ok(())
             }
@@ -71,6 +77,13 @@ macro_rules! impl_diesel_job_ops {
 
                 diesel::insert_into(archived_jobs::table)
                     .values(&archived)
+                    .execute(conn)?;
+                // Archived jobs keep their blobs in `archived_jobs`'s own
+                // payload/result columns and have no `job_payloads` row. Drop
+                // the side-table row explicitly: SQLite doesn't enforce the
+                // ON DELETE CASCADE FK unless `PRAGMA foreign_keys = ON`, so
+                // relying on the cascade would leak `job_payloads` rows.
+                diesel::delete(job_payloads::table.filter(job_payloads::job_id.eq(&row.id)))
                     .execute(conn)?;
                 diesel::delete(jobs::table.filter(jobs::id.eq(&row.id))).execute(conn)?;
                 Ok(())
@@ -187,6 +200,17 @@ macro_rules! impl_diesel_job_ops {
                         .values(&row)
                         .execute(conn)?;
 
+                    // Dual-write the payload to the 1:1 side table. The kept
+                    // `jobs.payload` column above stays populated for one-release
+                    // rollback safety; reads come from `job_payloads`.
+                    diesel::insert_into(job_payloads::table)
+                        .values(&NewJobPayloadRow {
+                            job_id: &job.id,
+                            payload: &job.payload,
+                            result: None,
+                        })
+                        .execute(conn)?;
+
                     // Insert dependency rows
                     for dep_id in &depends_on {
                         let dep_row = NewJobDependencyRow {
@@ -255,6 +279,21 @@ macro_rules! impl_diesel_job_ops {
                             .values(chunk)
                             .execute(conn)?;
                     }
+
+                    // Dual-write payload side-table rows in matching chunks.
+                    let payload_rows: Vec<NewJobPayloadRow> = jobs
+                        .iter()
+                        .map(|job| NewJobPayloadRow {
+                            job_id: &job.id,
+                            payload: &job.payload,
+                            result: None,
+                        })
+                        .collect();
+                    for chunk in payload_rows.chunks(BATCH_INSERT_CHUNK) {
+                        diesel::insert_into(job_payloads::table)
+                            .values(chunk)
+                            .execute(conn)?;
+                    }
                     Ok(jobs)
                 })
             }
@@ -307,6 +346,14 @@ macro_rules! impl_diesel_job_ops {
 
                     diesel::insert_into(jobs::table)
                         .values(&row)
+                        .execute(conn)?;
+
+                    diesel::insert_into(job_payloads::table)
+                        .values(&NewJobPayloadRow {
+                            job_id: &job.id,
+                            payload: &job.payload,
+                            result: None,
+                        })
                         .execute(conn)?;
 
                     // Insert dependency rows
@@ -379,16 +426,26 @@ macro_rules! impl_diesel_job_ops {
                         query = query.filter(jobs::namespace.is_null());
                     }
 
-                    let candidates: Vec<JobRow> = query.select(JobRow::as_select()).load(conn)?;
+                    // Narrow scan: select every column EXCEPT the payload/result
+                    // blobs. Claiming one job out of up to 100 candidates no
+                    // longer reads 99 discarded blobs into heap.
+                    let candidates: Vec<NarrowJobRow> =
+                        query.select(NarrowJobRow::as_select()).load(conn)?;
 
-                    for mut row in candidates {
-                        // Skip expired jobs — archive them as cancelled.
+                    for row in candidates {
+                        // Skip expired jobs — archive them as cancelled. The
+                        // archived row keeps the payload, so load the full row
+                        // (only for this one expired candidate) before archiving.
                         if let Some(expires_at) = row.expires_at {
                             if now > expires_at {
-                                row.status = JobStatus::Cancelled as i32;
-                                row.completed_at = Some(now);
-                                row.error = Some("expired before execution".to_string());
-                                Self::archive_job_row(conn, &row)?;
+                                let mut full: JobRow = jobs::table
+                                    .find(&row.id)
+                                    .select(JobRow::as_select())
+                                    .first(conn)?;
+                                full.status = JobStatus::Cancelled as i32;
+                                full.completed_at = Some(now);
+                                full.error = Some("expired before execution".to_string());
+                                Self::archive_job_row(conn, &full)?;
                                 continue;
                             }
                         }
@@ -408,12 +465,23 @@ macro_rules! impl_diesel_job_ops {
                             ))
                             .execute(conn)?;
 
-                        let updated: JobRow = jobs::table
+                        let updated: NarrowJobRow = jobs::table
                             .find(&row.id)
-                            .select(JobRow::as_select())
+                            .select(NarrowJobRow::as_select())
                             .first(conn)?;
 
-                        return Ok(Some(Job::from(updated)));
+                        // Now fetch only the winning job's blobs from the side
+                        // table and assemble the full Job.
+                        let payload_row: JobPayloadRow = job_payloads::table
+                            .find(&updated.id)
+                            .select(JobPayloadRow::as_select())
+                            .first(conn)?;
+
+                        return Ok(Some(Job::from_narrow(
+                            updated,
+                            payload_row.payload,
+                            payload_row.result,
+                        )));
                     }
 
                     Ok(None)
@@ -840,14 +908,19 @@ macro_rules! impl_diesel_job_ops {
             pub fn get_job(&self, id: &str) -> Result<Option<Job>> {
                 let mut conn = self.conn()?;
 
-                let row: Option<JobRow> = jobs::table
-                    .find(id)
-                    .select(JobRow::as_select())
+                let row: Option<(NarrowJobRow, JobPayloadRow)> = jobs::table
+                    .inner_join(job_payloads::table.on(job_payloads::job_id.eq(jobs::id)))
+                    .filter(jobs::id.eq(id))
+                    .select((NarrowJobRow::as_select(), JobPayloadRow::as_select()))
                     .first(&mut conn)
                     .optional()?;
 
-                if let Some(row) = row {
-                    return Ok(Some(Job::from(row)));
+                if let Some((narrow, payload)) = row {
+                    return Ok(Some(Job::from_narrow(
+                        narrow,
+                        payload.payload,
+                        payload.result,
+                    )));
                 }
 
                 let archived: Option<ArchivedJobRow> = archived_jobs::table
@@ -1052,7 +1125,10 @@ macro_rules! impl_diesel_job_ops {
             ) -> Result<Vec<Job>> {
                 let mut conn = self.conn()?;
 
-                let mut query = jobs::table.into_boxed().order(jobs::created_at.desc());
+                let mut query = jobs::table
+                    .inner_join(job_payloads::table.on(job_payloads::job_id.eq(jobs::id)))
+                    .into_boxed()
+                    .order(jobs::created_at.desc());
 
                 if let Some(s) = status {
                     query = query.filter(jobs::status.eq(s));
@@ -1079,13 +1155,18 @@ macro_rules! impl_diesel_job_ops {
                     query = query.filter(jobs::namespace.eq(ns));
                 }
 
-                let rows: Vec<JobRow> = query
+                let rows: Vec<(NarrowJobRow, JobPayloadRow)> = query
                     .limit(limit)
                     .offset(offset)
-                    .select(JobRow::as_select())
+                    .select((NarrowJobRow::as_select(), JobPayloadRow::as_select()))
                     .load(&mut conn)?;
 
-                Ok(rows.into_iter().map(Job::from).collect())
+                Ok(rows
+                    .into_iter()
+                    .map(|(narrow, payload)| {
+                        Job::from_narrow(narrow, payload.payload, payload.result)
+                    })
+                    .collect())
             }
 
             /// Query the `archived_jobs` table with the shared filter set.
@@ -1210,16 +1291,21 @@ macro_rules! impl_diesel_job_ops {
                 let mut conn = self.conn()?;
 
                 // Push the `started_at + timeout_ms < now` deadline into SQL so
-                // only genuinely-stale rows (and their payload blobs) are read,
-                // instead of every running job.
-                let rows: Vec<JobRow> = jobs::table
+                // only genuinely-stale rows are read, instead of every running
+                // job. The narrow row skips the payload/result blobs entirely —
+                // reaping only needs the timeout arithmetic plus id/task/queue,
+                // so the assembled Job carries an empty payload.
+                let rows: Vec<NarrowJobRow> = jobs::table
                     .filter(jobs::status.eq(JobStatus::Running as i32))
                     .filter(jobs::started_at.is_not_null())
                     .filter((jobs::started_at.assume_not_null() + jobs::timeout_ms).lt(now))
-                    .select(JobRow::as_select())
+                    .select(NarrowJobRow::as_select())
                     .load(&mut conn)?;
 
-                Ok(rows.into_iter().map(Job::from).collect())
+                Ok(rows
+                    .into_iter()
+                    .map(|narrow| Job::from_narrow(narrow, Vec::new(), None))
+                    .collect())
             }
 
             /// Record an error for a job attempt.

--- a/crates/taskito-core/src/storage/diesel_common/migrations.rs
+++ b/crates/taskito-core/src/storage/diesel_common/migrations.rs
@@ -96,6 +96,13 @@ pub fn create_tables(d: &Dialect) -> Vec<String> {
             )"
         ),
         format!(
+            "CREATE TABLE IF NOT EXISTS job_payloads (
+                job_id  TEXT PRIMARY KEY REFERENCES jobs(id) ON DELETE CASCADE,
+                payload {bin} NOT NULL,
+                result  {bin}
+            )"
+        ),
+        format!(
             "CREATE TABLE IF NOT EXISTS dead_letter (
                 id              TEXT PRIMARY KEY,
                 original_job_id TEXT NOT NULL,
@@ -370,4 +377,21 @@ pub fn backfill_statements() -> &'static [&'static str] {
         "UPDATE jobs SET has_deps = (id IN (SELECT job_id FROM job_dependencies)) \
          WHERE status = 0 AND has_deps <> (id IN (SELECT job_id FROM job_dependencies))",
     ]
+}
+
+/// Backfill the `job_payloads` side table from the kept `jobs.payload` /
+/// `jobs.result` columns. Idempotent: SQLite uses `INSERT OR IGNORE`, Postgres
+/// `ON CONFLICT (job_id) DO NOTHING`, so it only copies rows that aren't there
+/// yet. After a database that pre-dates the side table is migrated, every live
+/// job gets a matching payload row; subsequent runs match nothing.
+pub fn backfill_payload_side_table(d: &Dialect) -> Vec<String> {
+    let stmt = if d.alter_if_not_exists.is_empty() {
+        // SQLite: empty `alter_if_not_exists` marks this dialect.
+        "INSERT OR IGNORE INTO job_payloads (job_id, payload, result) \
+         SELECT id, payload, result FROM jobs"
+    } else {
+        "INSERT INTO job_payloads (job_id, payload, result) \
+         SELECT id, payload, result FROM jobs ON CONFLICT (job_id) DO NOTHING"
+    };
+    vec![stmt.to_string()]
 }

--- a/crates/taskito-core/src/storage/models.rs
+++ b/crates/taskito-core/src/storage/models.rs
@@ -3,8 +3,8 @@ use serde::{Deserialize, Serialize};
 
 use super::schema::{
     archived_jobs, circuit_breakers, dashboard_settings, dead_letter, distributed_locks,
-    execution_claims, job_dependencies, job_errors, jobs, periodic_tasks, queue_state, rate_limits,
-    replay_history, task_logs, task_metrics, workers,
+    execution_claims, job_dependencies, job_errors, job_payloads, jobs, periodic_tasks,
+    queue_state, rate_limits, replay_history, task_logs, task_metrics, workers,
 };
 
 /// A row in the `jobs` table (for SELECT queries).
@@ -35,6 +35,55 @@ pub struct JobRow {
     pub result_ttl_ms: Option<i64>,
     pub namespace: Option<String>,
     pub has_deps: bool,
+}
+
+/// A row in the `jobs` table with every column EXCEPT the `payload`/`result`
+/// blobs. The hot dequeue candidate scan, reap, and listing paths select this
+/// so claiming one job never reads up to 100 discarded payload blobs into heap.
+/// The blobs live in the 1:1 `job_payloads` side table.
+#[derive(Queryable, Selectable, Debug, Clone)]
+#[diesel(table_name = jobs)]
+pub struct NarrowJobRow {
+    pub id: String,
+    pub queue: String,
+    pub task_name: String,
+    pub status: i32,
+    pub priority: i32,
+    pub created_at: i64,
+    pub scheduled_at: i64,
+    pub started_at: Option<i64>,
+    pub completed_at: Option<i64>,
+    pub retry_count: i32,
+    pub max_retries: i32,
+    pub error: Option<String>,
+    pub timeout_ms: i64,
+    pub unique_key: Option<String>,
+    pub progress: Option<i32>,
+    pub metadata: Option<String>,
+    pub notes: Option<String>,
+    pub cancel_requested: i32,
+    pub expires_at: Option<i64>,
+    pub result_ttl_ms: Option<i64>,
+    pub namespace: Option<String>,
+    pub has_deps: bool,
+}
+
+/// A row in the 1:1 `job_payloads` side table (for SELECT queries).
+#[derive(Queryable, Selectable, Debug, Clone)]
+#[diesel(table_name = job_payloads)]
+pub struct JobPayloadRow {
+    pub job_id: String,
+    pub payload: Vec<u8>,
+    pub result: Option<Vec<u8>>,
+}
+
+/// Insertable struct for `job_payloads` side-table rows.
+#[derive(Insertable, Debug)]
+#[diesel(table_name = job_payloads)]
+pub struct NewJobPayloadRow<'a> {
+    pub job_id: &'a str,
+    pub payload: &'a [u8],
+    pub result: Option<&'a [u8]>,
 }
 
 /// Insertable struct for creating new jobs.

--- a/crates/taskito-core/src/storage/postgres/archival.rs
+++ b/crates/taskito-core/src/storage/postgres/archival.rs
@@ -38,6 +38,17 @@ impl PostgresStorage {
             .bind::<diesel::sql_types::BigInt, _>(cutoff_ms)
             .execute(conn)?;
 
+            // The ON DELETE CASCADE FK would clear these on the jobs delete, but
+            // delete explicitly first to keep the ordering unambiguous and match
+            // the SQLite path.
+            diesel::sql_query(format!(
+                "DELETE FROM job_payloads WHERE job_id IN \
+                 (SELECT id FROM jobs WHERE status IN ({archivable_statuses}) \
+                  AND completed_at IS NOT NULL AND completed_at < $1)",
+            ))
+            .bind::<diesel::sql_types::BigInt, _>(cutoff_ms)
+            .execute(conn)?;
+
             diesel::sql_query(format!(
                 "DELETE FROM jobs WHERE status IN ({archivable_statuses}) AND completed_at IS NOT NULL AND completed_at < $1",
             ))

--- a/crates/taskito-core/src/storage/postgres/jobs.rs
+++ b/crates/taskito-core/src/storage/postgres/jobs.rs
@@ -3,7 +3,8 @@ use diesel::prelude::*;
 
 use super::super::models::*;
 use super::super::schema::{
-    archived_jobs, job_dependencies, job_errors, jobs, replay_history, task_logs, task_metrics,
+    archived_jobs, job_dependencies, job_errors, job_payloads, jobs, replay_history, task_logs,
+    task_metrics,
 };
 use super::PostgresStorage;
 use crate::error::{QueueError, Result};

--- a/crates/taskito-core/src/storage/postgres/mod.rs
+++ b/crates/taskito-core/src/storage/postgres/mod.rs
@@ -144,6 +144,9 @@ impl PostgresStorage {
         for sql in common_migrations::backfill_statements() {
             diesel::sql_query(*sql).execute(&mut conn)?;
         }
+        for sql in common_migrations::backfill_payload_side_table(&common_migrations::POSTGRES) {
+            diesel::sql_query(&sql).execute(&mut conn)?;
+        }
         drop(conn);
 
         // Drain any pre-existing terminal jobs left in `jobs` by older

--- a/crates/taskito-core/src/storage/schema.rs
+++ b/crates/taskito-core/src/storage/schema.rs
@@ -224,4 +224,13 @@ diesel::table! {
     }
 }
 
+diesel::table! {
+    job_payloads (job_id) {
+        job_id -> Text,
+        payload -> Binary,
+        result -> Nullable<Binary>,
+    }
+}
+
 diesel::allow_tables_to_appear_in_same_query!(jobs, job_dependencies);
+diesel::allow_tables_to_appear_in_same_query!(jobs, job_payloads);

--- a/crates/taskito-core/src/storage/sqlite/archival.rs
+++ b/crates/taskito-core/src/storage/sqlite/archival.rs
@@ -39,6 +39,17 @@ impl SqliteStorage {
             .bind::<diesel::sql_types::BigInt, _>(cutoff_ms)
             .execute(conn)?;
 
+            // Drop the side-table rows for the jobs about to be deleted.
+            // SQLite doesn't enforce the ON DELETE CASCADE FK unless
+            // `PRAGMA foreign_keys = ON`, so delete explicitly to avoid orphans.
+            diesel::sql_query(format!(
+                "DELETE FROM job_payloads WHERE job_id IN \
+                 (SELECT id FROM jobs WHERE status IN ({archivable_statuses}) \
+                  AND completed_at IS NOT NULL AND completed_at < ?1)",
+            ))
+            .bind::<diesel::sql_types::BigInt, _>(cutoff_ms)
+            .execute(conn)?;
+
             diesel::sql_query(format!(
                 "DELETE FROM jobs WHERE status IN ({archivable_statuses}) AND completed_at IS NOT NULL AND completed_at < ?1",
             ))

--- a/crates/taskito-core/src/storage/sqlite/jobs.rs
+++ b/crates/taskito-core/src/storage/sqlite/jobs.rs
@@ -3,7 +3,8 @@ use diesel::sqlite::SqliteConnection;
 
 use super::super::models::*;
 use super::super::schema::{
-    archived_jobs, job_dependencies, job_errors, jobs, replay_history, task_logs, task_metrics,
+    archived_jobs, job_dependencies, job_errors, job_payloads, jobs, replay_history, task_logs,
+    task_metrics,
 };
 use super::SqliteStorage;
 use crate::error::{QueueError, Result};

--- a/crates/taskito-core/src/storage/sqlite/mod.rs
+++ b/crates/taskito-core/src/storage/sqlite/mod.rs
@@ -147,6 +147,9 @@ impl SqliteStorage {
         for sql in common_migrations::backfill_statements() {
             diesel::sql_query(*sql).execute(&mut conn)?;
         }
+        for sql in common_migrations::backfill_payload_side_table(&common_migrations::SQLITE) {
+            diesel::sql_query(&sql).execute(&mut conn)?;
+        }
         drop(conn);
 
         // Drain any pre-existing terminal jobs left in `jobs` by older

--- a/crates/taskito-core/src/storage/sqlite/tests.rs
+++ b/crates/taskito-core/src/storage/sqlite/tests.rs
@@ -907,3 +907,98 @@ fn test_fail_and_cancel_archive_immediately() {
         JobStatus::Cancelled
     );
 }
+
+// ── Payload side-table (job_payloads) ────────────────────────────────
+
+/// Count rows in `job_payloads` for a given job id.
+fn payload_row_count(storage: &SqliteStorage, job_id: &str) -> i64 {
+    use crate::storage::schema::job_payloads;
+    use diesel::prelude::*;
+    let mut conn = storage.conn().unwrap();
+    job_payloads::table
+        .filter(job_payloads::job_id.eq(job_id))
+        .count()
+        .get_result(&mut conn)
+        .unwrap()
+}
+
+#[test]
+fn test_enqueue_populates_payload_side_table() {
+    use crate::storage::schema::job_payloads;
+    use diesel::prelude::*;
+    let storage = test_storage();
+    let mut nj = make_job("side_table");
+    nj.payload = vec![9, 8, 7, 6];
+    let job = storage.enqueue(nj).unwrap();
+
+    let mut conn = storage.conn().unwrap();
+    let (payload, result): (Vec<u8>, Option<Vec<u8>>) = job_payloads::table
+        .filter(job_payloads::job_id.eq(&job.id))
+        .select((job_payloads::payload, job_payloads::result))
+        .first(&mut conn)
+        .unwrap();
+    assert_eq!(payload, vec![9, 8, 7, 6]);
+    assert!(result.is_none());
+}
+
+#[test]
+fn test_dequeue_returns_full_payload() {
+    let storage = test_storage();
+    let mut nj = make_job("dq_payload");
+    nj.payload = vec![42, 43, 44];
+    storage.enqueue(nj).unwrap();
+
+    let dequeued = storage
+        .dequeue("default", now_millis(), None)
+        .unwrap()
+        .unwrap();
+    assert_eq!(dequeued.payload, vec![42, 43, 44]);
+    assert_eq!(dequeued.status, JobStatus::Running);
+}
+
+#[test]
+fn test_complete_archives_and_removes_side_table_row() {
+    let storage = test_storage();
+    let job = storage.enqueue(make_job("complete_side")).unwrap();
+    storage.dequeue("default", now_millis(), None).unwrap();
+    // The side-table row exists while the job is live.
+    assert_eq!(payload_row_count(&storage, &job.id), 1);
+
+    storage.complete(&job.id, Some(vec![5, 5, 5])).unwrap();
+
+    // Completing archives the job: the live row and its side-table row are
+    // both gone; the result is preserved in `archived_jobs`.
+    assert_eq!(jobs_row_count(&storage, &job.id), 0);
+    assert_eq!(payload_row_count(&storage, &job.id), 0);
+    let fetched = storage.get_job(&job.id).unwrap().unwrap();
+    assert_eq!(fetched.result, Some(vec![5, 5, 5]));
+}
+
+#[test]
+fn test_get_job_returns_payload_and_result() {
+    let storage = test_storage();
+    let mut nj = make_job("get_side");
+    nj.payload = vec![1, 1, 2, 3, 5];
+    let job = storage.enqueue(nj).unwrap();
+    storage.dequeue("default", now_millis(), None).unwrap();
+    storage.complete(&job.id, Some(vec![8, 13])).unwrap();
+
+    // After archival, get_job assembles payload + result from `archived_jobs`.
+    let fetched = storage.get_job(&job.id).unwrap().unwrap();
+    assert_eq!(fetched.payload, vec![1, 1, 2, 3, 5]);
+    assert_eq!(fetched.result, Some(vec![8, 13]));
+}
+
+#[test]
+fn test_side_table_stays_one_to_one_with_live_jobs() {
+    let storage = test_storage();
+    let job = storage.enqueue(make_job("cascade_side")).unwrap();
+    // A live (pending) job has exactly one side-table row.
+    assert_eq!(payload_row_count(&storage, &job.id), 1);
+
+    // Cancelling the pending job archives it and drops the side-table row,
+    // keeping `job_payloads` 1:1 with the live `jobs` table (no leak).
+    assert!(storage.cancel_job(&job.id).unwrap());
+    assert_eq!(jobs_row_count(&storage, &job.id), 0);
+    assert_eq!(payload_row_count(&storage, &job.id), 0);
+}

--- a/crates/taskito-core/tests/rust/storage_tests.rs
+++ b/crates/taskito-core/tests/rust/storage_tests.rs
@@ -476,6 +476,61 @@ fn test_dependent_blocked_by_cancelled_parent(s: &impl Storage) {
     );
 }
 
+/// Exercise the payload/result round-trip through the full job lifecycle.
+/// On the Diesel backends this verifies the `job_payloads` side table is
+/// populated on enqueue, returned by dequeue, and read back by get_job after
+/// the job is archived. Redis passes trivially: its Job JSON already carries
+/// the blobs.
+fn test_payload_side_table(s: &impl Storage) {
+    let q = "q-payload-side-table";
+    let mut nj = make_job(q, "payload_side_task");
+    nj.payload = vec![0xDE, 0xAD, 0xBE, 0xEF];
+    let job = s.enqueue(nj).unwrap();
+
+    let dequeued = s.dequeue(q, now_millis() + 1000, None).unwrap().unwrap();
+    assert_eq!(dequeued.id, job.id);
+    assert_eq!(dequeued.payload, vec![0xDE, 0xAD, 0xBE, 0xEF]);
+
+    s.complete(&job.id, Some(vec![0x01, 0x02, 0x03])).unwrap();
+
+    let fetched = s.get_job(&job.id).unwrap().unwrap();
+    assert_eq!(fetched.status, JobStatus::Complete);
+    assert_eq!(fetched.payload, vec![0xDE, 0xAD, 0xBE, 0xEF]);
+    assert_eq!(fetched.result, Some(vec![0x01, 0x02, 0x03]));
+}
+
+/// A job run to completion is archived: its blobs move into `archived_jobs`
+/// and its `job_payloads` side-table row is dropped (no leak). `get_job` must
+/// still resolve the full payload + result from the archive. On the Diesel
+/// backends the archived job has no side-table row, so a stray join would lose
+/// it — this guards that the archived fallback reads `archived_jobs` directly.
+/// Redis passes trivially. The SQLite-only test
+/// `test_side_table_stays_one_to_one_with_live_jobs` asserts the row removal
+/// directly against `job_payloads`.
+fn test_archived_job_payload_resolves(s: &impl Storage) {
+    let q = "q-archived-payload-resolves";
+    let mut nj = make_job(q, "archived_payload_task");
+    nj.payload = vec![0xCA, 0xFE, 0xBA, 0xBE];
+    let job = s.enqueue(nj).unwrap();
+
+    s.dequeue(q, now_millis() + 1000, None).unwrap();
+    s.complete(&job.id, Some(vec![0x11, 0x22])).unwrap();
+
+    // The job now lives only in `archived_jobs`; the side-table row is gone.
+    let fetched = s.get_job(&job.id).unwrap().unwrap();
+    assert_eq!(fetched.status, JobStatus::Complete);
+    assert_eq!(fetched.payload, vec![0xCA, 0xFE, 0xBA, 0xBE]);
+    assert_eq!(fetched.result, Some(vec![0x11, 0x22]));
+
+    // Listing by the terminal status reads the archive and still carries blobs.
+    let listed = s
+        .list_jobs(Some(JobStatus::Complete as i32), Some(q), None, 50, 0, None)
+        .unwrap();
+    let row = listed.iter().find(|j| j.id == job.id).unwrap();
+    assert_eq!(row.payload, vec![0xCA, 0xFE, 0xBA, 0xBE]);
+    assert_eq!(row.result, Some(vec![0x11, 0x22]));
+}
+
 fn run_storage_tests(s: &impl Storage) {
     test_enqueue_and_get(s);
     test_dequeue(s);
@@ -499,6 +554,8 @@ fn run_storage_tests(s: &impl Storage) {
     test_immediate_archival(s);
     test_enqueue_dep_on_completed_archived_job(s);
     test_dependent_blocked_by_cancelled_parent(s);
+    test_payload_side_table(s);
+    test_archived_job_payload_resolves(s);
 }
 
 // ── Backend-specific wiring ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

**P3** of the Taskito 2.0 program. The Diesel dequeue loads up to 100 candidate
rows — each carrying the `payload` BLOB — to claim **one** job. At 1–50KB
payloads that's 1–50MB read into heap per dispatch, 99% discarded. This moves
`payload`/`result` into a 1:1 `job_payloads` side table so the hot candidate
scan, `stats`, and `reap` read only the narrow row; the payload is fetched only
for the job actually claimed.

## Design

- New `job_payloads (job_id PK, payload, result)`, FK → `jobs(id)`.
- `NarrowJobRow` (jobs minus the blobs) backs the dequeue candidate scan and
  `reap_stale_jobs`; the winning job's blobs are fetched from `job_payloads`.
  `get_job`/`list_jobs` inner-join the side table; `complete` writes the result there.
- **`jobs.payload`/`jobs.result` columns are kept and dual-written** for one
  release — a downgrade stays safe and the migration is an idempotent backfill.
  A future 2.1 migration drops them.
- **Redis is unchanged** — its Job JSON is already a single blob.

## Verification (all three backends + Python)

- SQLite `cargo test --workspace`: 67 storage tests (+5 new) green.
- Postgres + Redis contract suites (fresh DBs): green, incl. `test_payload_side_table`.
- `cargo clippy` clean across default/postgres/redis/workflows.
- **Full Python suite: 1010 passed, 4 skipped** — payload round-trips through
  dequeue are exercised by nearly every worker test.
- ruff + mypy clean.

## Review note

Branched from `master` independently of #216 (P2 archival). Both touch `complete`
and `get_job`, so whichever merges second needs a small mechanical rebase. The
archival × side-table interaction is intentionally left for review during
integration rather than blindly composed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Jobs now use a separate payload side table and a narrow-row read path to avoid loading large blobs during scans, improving dequeue/list/reap performance.
* **New Features**
  * Added constructor to assemble full jobs from narrow rows plus payload/result; migration/backfill steps populate the new payload store.
* **Bug Fixes**
  * Archival/delete flows updated to avoid orphaned payloads and preserve payload/result for archived jobs.
* **Tests**
  * New integration and SQLite tests covering payload/result lifecycle and archival behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ByteVeda/taskito/pull/219?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->