### PR TITLE
chore(release): 0.15.2

### DIFF
--- a/crates/taskito-async/Cargo.toml
+++ b/crates/taskito-async/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-async"
-version = "0.15.1"
+version = "0.15.2"
 edition = "2021"
 
 [dependencies]

--- a/crates/taskito-core/Cargo.toml
+++ b/crates/taskito-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-core"
-version = "0.15.1"
+version = "0.15.2"
 edition = "2021"
 
 [features]

--- a/crates/taskito-python/Cargo.toml
+++ b/crates/taskito-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-python"
-version = "0.15.1"
+version = "0.15.2"
 edition = "2021"
 
 [features]

--- a/crates/taskito-workflows/Cargo.toml
+++ b/crates/taskito-workflows/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-workflows"
-version = "0.15.1"
+version = "0.15.2"
 edition = "2021"
 
 [features]

--- a/docs/content/docs/more/changelog.mdx
+++ b/docs/content/docs/more/changelog.mdx
@@ -5,6 +5,47 @@ description: "Release history for taskito — every notable change, fix, and fea
 
 All notable changes to taskito are documented here.
 
+## 0.15.2
+
+Security-hardening release. No breaking changes.
+
+### Added
+
+- **`SignedSerializer`.** Opt-in HMAC-SHA256 integrity wrapper for task payloads
+  and results — a worker refuses to deserialize bytes not produced with the
+  shared key, closing the untrusted-storage code-execution path. Compose with
+  `EncryptedSerializer` for confidentiality + integrity.
+- **`Queue.max_payload_bytes`.** Per-queue cap (default 1 MiB) that rejects
+  oversized serialized payloads at enqueue time.
+- **Security guide.** New *Operations → Security* page documenting the trust
+  model and a production hardening checklist.
+
+### Changed
+
+- **Dashboard authorization is enforced server-side.** Mutating API routes now
+  require the `admin` role; `viewer` sessions are read-only. Session and CSRF
+  cookies carry `Secure`, and `/metrics` / `/readiness` can be gated behind
+  `TASKITO_DASHBOARD_METRICS_TOKEN`.
+- **Scaler binds to `127.0.0.1` by default.** Use `--host 0.0.0.0` only behind a
+  trusted network boundary.
+
+### Fixed
+
+- **Settings API no longer leaks auth data.** `/api/settings` hides and rejects
+  internal `auth:` keys (password hashes, sessions, CSRF secret).
+- **Webhook SSRF closed.** Target URLs are re-validated against
+  private/loopback/metadata addresses at delivery time (defeating DNS
+  rebinding) and redirects are no longer followed.
+- **Proxy hardening.** File-proxy allowlist prefix/symlink bypass closed;
+  argument reconstruction restricted to safe type kinds; a warning is emitted
+  when proxy recipes are reconstructed without a signing key.
+- **Lock owner token no longer disclosed.** `DistributedLock.info()` masks
+  another holder's `owner_id`; Redis locks set a native TTL with an atomic reap.
+- **No duplicate execution on claim errors.** The scheduler skips dispatch when
+  a claim attempt errors instead of running the job unguarded.
+- **Job-list API summarizes tracebacks.** Only the final exception line is shown
+  in the jobs list; the full traceback stays on the per-job errors endpoint.
+
 ## 0.15.1
 
 ### Fixed

--- a/py_src/taskito/__init__.py
+++ b/py_src/taskito/__init__.py
@@ -120,4 +120,4 @@ try:
 
     __version__ = _get_version("taskito")
 except PackageNotFoundError:
-    __version__ = "0.15.1"
+    __version__ = "0.15.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "taskito"
-version = "0.15.1"
+version = "0.15.2"
 description = "Rust-powered task queue for Python. No broker required."
 requires-python = ">=3.10"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary

Release 0.15.2. Version bump only — no functional changes beyond what already
merged to `master` (the security audit remediation in #226).

## Changes

Bumps `0.15.1` → `0.15.2` across the published artifacts:

- `crates/taskito-core/Cargo.toml`
- `crates/taskito-async/Cargo.toml`
- `crates/taskito-python/Cargo.toml` (package version + path-dep version pins)
- `crates/taskito-workflows/Cargo.toml`
- `pyproject.toml`
- `py_src/taskito/__init__.py` (fallback `__version__`)
- `Cargo.lock` (regenerated)

## Test plan

- [x] `cargo check --workspace` — clean
- [x] `uv run maturin develop` + `import taskito; taskito.__version__ == "0.15.2"`
- [x] ruff + ruff-format + mypy pre-commit hooks pass
- [ ] Tag `v0.15.2` from `master` after merge to trigger publish


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Released version 0.15.2: bumped package and Python runtime/project versions across the repo.

* **Documentation**
  * Added 0.15.2 changelog documenting security hardening, new safety features, dashboard authorization and cookie behavior updates, reliability/scheduler fixes, and various vulnerability mitigations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ByteVeda/taskito/pull/227?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->