### PR TITLE
feat(dashboard): "Friendly ops" redesign

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -18,6 +18,9 @@
     "ci": "biome ci src/ && pnpm run typecheck && vitest run && vite build"
   },
   "dependencies": {
+    "@fontsource/ibm-plex-mono": "^5.2.7",
+    "@fontsource/ibm-plex-sans": "^5.2.8",
+    "@fontsource/ibm-plex-serif": "^5.2.7",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-scroll-area": "^1.2.10",

--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -8,6 +8,15 @@ importers:
 
   .:
     dependencies:
+      '@fontsource/ibm-plex-mono':
+        specifier: ^5.2.7
+        version: 5.2.7
+      '@fontsource/ibm-plex-sans':
+        specifier: ^5.2.8
+        version: 5.2.8
+      '@fontsource/ibm-plex-serif':
+        specifier: ^5.2.7
+        version: 5.2.7
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -443,6 +452,15 @@ packages:
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@fontsource/ibm-plex-mono@5.2.7':
+    resolution: {integrity: sha512-MKAb8qV+CaiMQn2B0dIi1OV3565NYzp3WN5b4oT6LTkk+F0jR6j0ZN+5BKJiIhffDC3rtBULsYZE65+0018z9w==}
+
+  '@fontsource/ibm-plex-sans@5.2.8':
+    resolution: {integrity: sha512-eztSXjDhPhcpxNIiGTgMebdLP9qS4rWkysuE1V7c+DjOR0qiezaiDaTwQE7bTnG5HxAY/8M43XKDvs3cYq6ZYQ==}
+
+  '@fontsource/ibm-plex-serif@5.2.7':
+    resolution: {integrity: sha512-04owmc2OQQ/DAMjXjEMJc+7V4dBVmR01aIFOg4cuqS8pQ4HbvtlYs/u6+O0vCt21EMx5M/azIbgx43iKyisEOA==}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -2268,6 +2286,12 @@ snapshots:
       react-dom: 19.2.6(react@19.2.6)
 
   '@floating-ui/utils@0.2.11': {}
+
+  '@fontsource/ibm-plex-mono@5.2.7': {}
+
+  '@fontsource/ibm-plex-sans@5.2.8': {}
+
+  '@fontsource/ibm-plex-serif@5.2.7': {}
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:

--- a/dashboard/src/components/layout/app-shell.tsx
+++ b/dashboard/src/components/layout/app-shell.tsx
@@ -19,7 +19,7 @@ export function AppShell({ children }: { children: ReactNode }) {
           <Header />
           <TopProgressBar />
           <main className="flex-1 px-4 py-5 md:px-6 md:py-6">
-            <div key={pathname} className="mx-auto max-w-[1400px] animate-fade-in">
+            <div key={pathname} className="mx-auto max-w-[1240px] animate-page-rise">
               <RouteErrorBoundary>{children}</RouteErrorBoundary>
             </div>
           </main>

--- a/dashboard/src/components/layout/brand-mark.tsx
+++ b/dashboard/src/components/layout/brand-mark.tsx
@@ -1,0 +1,37 @@
+/**
+ * The taskito mark — a rounded "task token" with two dot eyes and a
+ * check-smile, filled with the live accent. Colors come from CSS vars so it
+ * tracks the active theme/accent automatically.
+ */
+export function BrandMark({ size = 38, className }: { size?: number; className?: string }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 40 40"
+      fill="none"
+      className={className}
+      aria-hidden="true"
+    >
+      <title>taskito</title>
+      <rect x="3" y="3" width="34" height="34" rx="11" fill="var(--accent)" />
+      <rect x="3" y="3" width="34" height="34" rx="11" fill="url(#tk-g)" fillOpacity="0.18" />
+      <defs>
+        <linearGradient id="tk-g" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stopColor="#fff" />
+          <stop offset="1" stopColor="#fff" stopOpacity="0" />
+        </linearGradient>
+      </defs>
+      <circle cx="15" cy="16" r="2.1" fill="var(--accent-fg)" />
+      <circle cx="25" cy="16" r="2.1" fill="var(--accent-fg)" />
+      <path
+        d="M14 24.5l3.4 3.4L27 19"
+        stroke="var(--accent-fg)"
+        strokeWidth="2.6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        fill="none"
+      />
+    </svg>
+  );
+}

--- a/dashboard/src/components/layout/header.tsx
+++ b/dashboard/src/components/layout/header.tsx
@@ -13,9 +13,8 @@ export function Header() {
       <MobileMenu />
       <Button
         variant="outline"
-        size="sm"
         onClick={() => setOpen(true)}
-        className="hidden md:inline-flex w-[260px] justify-between text-[var(--fg-subtle)] font-normal"
+        className="hidden w-[300px] max-w-[38vw] justify-between font-normal text-[var(--fg-subtle)] md:inline-flex"
       >
         <span className="inline-flex items-center gap-2">
           <Search className="size-3.5" aria-hidden />

--- a/dashboard/src/components/layout/index.ts
+++ b/dashboard/src/components/layout/index.ts
@@ -8,6 +8,7 @@ export { LastRefreshed } from "./last-refreshed";
 export { MobileMenu } from "./mobile-menu";
 export { PageHeader } from "./page-header";
 export { RouteErrorBoundary } from "./route-error-boundary";
+export { SectionHeading } from "./section-heading";
 export { Sidebar } from "./sidebar";
 export { ThemeToggle } from "./theme-toggle";
 export { TopProgressBar } from "./top-progress-bar";

--- a/dashboard/src/components/layout/last-refreshed.tsx
+++ b/dashboard/src/components/layout/last-refreshed.tsx
@@ -1,5 +1,6 @@
 import { Loader2 } from "lucide-react";
 import { useEffect, useState } from "react";
+import { LiveDot } from "@/components/ui";
 import { useLastRefreshed } from "@/hooks";
 import { cn } from "@/lib/cn";
 
@@ -55,7 +56,7 @@ export function LastRefreshed({ className }: { className?: string }) {
       {isFetching ? (
         <Loader2 className="size-3 animate-spin text-accent" aria-hidden />
       ) : (
-        <span aria-hidden className="size-1.5 rounded-full bg-success" />
+        <LiveDot tone="success" size={6} />
       )}
       {label}
     </span>

--- a/dashboard/src/components/layout/page-header.tsx
+++ b/dashboard/src/components/layout/page-header.tsx
@@ -22,24 +22,26 @@ export function PageHeader({
   return (
     <div
       className={cn(
-        "mb-6 flex flex-col gap-3 md:flex-row md:items-start md:justify-between",
+        "mb-[22px] flex flex-col gap-3 md:flex-row md:items-end md:justify-between",
         className,
       )}
     >
-      <div>
+      <div className="min-w-0">
         {breadcrumbs && breadcrumbs.length > 0 ? (
           <Breadcrumbs items={breadcrumbs} className="mb-2" />
         ) : eyebrow ? (
-          <div className="mb-1 text-[11px] font-semibold uppercase tracking-wider text-[var(--fg-subtle)]">
+          <div className="mb-1.5 font-mono text-[0.68rem] font-semibold uppercase tracking-[0.13em] text-[var(--accent-ink)]">
             {eyebrow}
           </div>
         ) : null}
-        <h1 className="text-2xl font-semibold tracking-tight text-[var(--fg)]">{title}</h1>
+        <h1 className="font-serif text-[2rem] font-semibold leading-[1.05] tracking-[-0.02em] text-[var(--fg)]">
+          {title}
+        </h1>
         {description ? (
-          <p className="mt-1.5 text-sm text-[var(--fg-muted)]">{description}</p>
+          <p className="mt-2 max-w-[60ch] text-[0.92rem] text-[var(--fg-muted)]">{description}</p>
         ) : null}
       </div>
-      {actions ? <div className="flex flex-wrap items-center gap-2">{actions}</div> : null}
+      {actions ? <div className="flex flex-wrap items-center gap-2.5">{actions}</div> : null}
     </div>
   );
 }

--- a/dashboard/src/components/layout/section-heading.tsx
+++ b/dashboard/src/components/layout/section-heading.tsx
@@ -1,0 +1,20 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/cn";
+
+interface SectionHeadingProps {
+  title: ReactNode;
+  action?: ReactNode;
+  className?: string;
+}
+
+/** A serif section title with an optional right-aligned action. */
+export function SectionHeading({ title, action, className }: SectionHeadingProps) {
+  return (
+    <div className={cn("mb-3 flex min-h-[30px] items-center justify-between gap-3", className)}>
+      <h2 className="font-serif text-[1.18rem] font-semibold tracking-[-0.01em] whitespace-nowrap text-[var(--fg)]">
+        {title}
+      </h2>
+      {action ?? null}
+    </div>
+  );
+}

--- a/dashboard/src/components/layout/sidebar.tsx
+++ b/dashboard/src/components/layout/sidebar.tsx
@@ -1,55 +1,82 @@
+import { useQuery } from "@tanstack/react-query";
 import { Link, useLocation } from "@tanstack/react-router";
-import { AlertOctagon, ExternalLink as ExternalLinkIcon } from "lucide-react";
+import { ExternalLink as ExternalLinkIcon } from "lucide-react";
+import { LiveDot } from "@/components/ui";
+import { statsQuery } from "@/features/overview/hooks";
 import { useBranding, useExternalLinks } from "@/features/settings";
 import { cn } from "@/lib/cn";
+import { formatCount } from "@/lib/number";
+import { site } from "@/lib/site";
+import { BrandMark } from "./brand-mark";
 import { NAV } from "./nav-config";
 
 export function Sidebar() {
   const { pathname } = useLocation();
   const { title } = useBranding();
   const externalLinks = useExternalLinks();
+  // Shares the ["stats"] cache with the Overview — no extra polling here, just
+  // a one-time fetch that stays in sync as other views refetch.
+  const { data: stats } = useQuery(statsQuery());
+  const deadCount = stats?.dead ?? 0;
+  const isDefaultBrand = title === site.name;
+
   return (
-    <aside className="hidden lg:flex w-60 shrink-0 flex-col border-r border-[var(--border)] bg-[var(--bg-subtle)]">
-      <div className="flex items-center gap-2 px-5 py-4">
-        <div className="grid place-items-center size-7 rounded-md bg-accent text-accent-fg">
-          <AlertOctagon className="size-4" aria-hidden />
-        </div>
-        <div className="flex flex-col leading-tight">
-          <span className="text-sm font-semibold tracking-tight">{title}</span>
-          <span className="text-[10px] uppercase tracking-wider text-[var(--fg-subtle)]">
-            Dashboard
-          </span>
+    <aside className="hidden w-[248px] shrink-0 flex-col border-r border-[var(--border)] bg-[var(--bg-subtle)] lg:flex">
+      <div className="flex items-center gap-2.5 px-[18px] pt-[18px] pb-4">
+        <BrandMark size={38} />
+        <div className="leading-none">
+          <div className="text-[1.18rem] font-semibold tracking-[-0.02em]">
+            {isDefaultBrand ? (
+              <>
+                task<span className="text-[var(--accent-ink)]">ito</span>
+              </>
+            ) : (
+              title
+            )}
+          </div>
+          <div className="mt-[3px] font-mono text-[0.66rem] uppercase tracking-[0.16em] text-[var(--fg-subtle)]">
+            Queue console
+          </div>
         </div>
       </div>
       <nav className="flex-1 overflow-y-auto px-3 pb-4">
         {NAV.map((group) => (
-          <div key={group.title} className="mt-5 first:mt-2">
-            <div className="px-2 pb-1.5 text-[10px] font-semibold uppercase tracking-wider text-[var(--fg-subtle)]">
+          <div key={group.title} className="mt-[18px] first:mt-1.5">
+            <div className="px-2.5 pb-[7px] font-mono text-[0.62rem] font-semibold uppercase tracking-[0.13em] text-[var(--fg-subtle)]">
               {group.title}
             </div>
             <ul className="flex flex-col gap-0.5">
               {group.items.map(({ to, label, icon: Icon }) => {
                 const active = pathname === to || (to !== "/" && pathname.startsWith(`${to}/`));
+                const count = to === "/dead-letters" && deadCount > 0 ? deadCount : null;
                 return (
                   <li key={to}>
                     <Link
                       to={to}
                       aria-current={active ? "page" : undefined}
                       className={cn(
-                        "relative flex items-center gap-2.5 rounded-md px-2 py-1.5 text-sm transition-colors",
+                        "relative flex items-center gap-2.5 rounded-[9px] px-2.5 py-2 text-sm transition-colors",
                         active
-                          ? "bg-[var(--surface-2)] text-[var(--fg)] shadow-xs"
-                          : "text-[var(--fg-muted)] hover:bg-[var(--surface-2)]/60 hover:text-[var(--fg)]",
+                          ? "bg-[var(--surface)] font-semibold text-[var(--fg)] shadow-[var(--card-shadow)]"
+                          : "font-normal text-[var(--fg-muted)] hover:bg-[var(--surface-2)]/70 hover:text-[var(--fg)]",
                       )}
                     >
                       {active ? (
                         <span
                           aria-hidden
-                          className="absolute -left-3 inset-y-1.5 w-0.5 rounded-r-full bg-accent"
+                          className="absolute -left-3 inset-y-2 w-[3px] rounded-r-full bg-accent"
                         />
                       ) : null}
-                      <Icon className={cn("size-4", active && "text-accent")} aria-hidden />
-                      <span>{label}</span>
+                      <Icon
+                        className={cn("size-[17px] shrink-0", active && "text-accent")}
+                        aria-hidden
+                      />
+                      <span className="truncate">{label}</span>
+                      {count != null ? (
+                        <span className="ml-auto font-mono text-[0.7rem] font-semibold tabular-nums text-danger">
+                          {formatCount(count)}
+                        </span>
+                      ) : null}
                     </Link>
                   </li>
                 );
@@ -58,8 +85,8 @@ export function Sidebar() {
           </div>
         ))}
         {externalLinks.length > 0 ? (
-          <div className="mt-5">
-            <div className="px-2 pb-1.5 text-[10px] font-semibold uppercase tracking-wider text-[var(--fg-subtle)]">
+          <div className="mt-[18px]">
+            <div className="px-2.5 pb-[7px] font-mono text-[0.62rem] font-semibold uppercase tracking-[0.13em] text-[var(--fg-subtle)]">
               Links
             </div>
             <ul className="flex flex-col gap-0.5">
@@ -69,9 +96,9 @@ export function Sidebar() {
                     href={link.url}
                     target="_blank"
                     rel="noreferrer noopener"
-                    className="flex items-center gap-2.5 rounded-md px-2 py-1.5 text-sm text-[var(--fg-muted)] transition-colors hover:bg-[var(--surface-2)] hover:text-[var(--fg)]"
+                    className="flex items-center gap-2.5 rounded-[9px] px-2.5 py-2 text-sm text-[var(--fg-muted)] transition-colors hover:bg-[var(--surface-2)] hover:text-[var(--fg)]"
                   >
-                    <ExternalLinkIcon className="size-4" aria-hidden />
+                    <ExternalLinkIcon className="size-[17px] shrink-0" aria-hidden />
                     <span className="truncate">{link.label}</span>
                   </a>
                 </li>
@@ -80,8 +107,9 @@ export function Sidebar() {
           </div>
         ) : null}
       </nav>
-      <div className="border-t border-[var(--border)] px-5 py-3 text-[11px] text-[var(--fg-subtle)]">
-        {import.meta.env.DEV ? "dev build" : "production"}
+      <div className="flex items-center gap-2 border-t border-[var(--border)] px-[18px] py-3 text-[0.72rem] text-[var(--fg-subtle)]">
+        <LiveDot tone="success" />
+        Core healthy · {import.meta.env.DEV ? "dev build" : "production"}
       </div>
     </aside>
   );

--- a/dashboard/src/components/ui/badge.tsx
+++ b/dashboard/src/components/ui/badge.tsx
@@ -3,17 +3,16 @@ import type { HTMLAttributes } from "react";
 import { cn } from "@/lib/cn";
 
 const badgeVariants = cva(
-  "inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium tracking-tight",
+  "inline-flex items-center gap-1.5 rounded-[var(--chip-radius)] border px-2.5 py-0.5 text-[0.74rem] font-medium whitespace-nowrap",
   {
     variants: {
       tone: {
-        neutral:
-          "bg-[var(--surface-3)] text-[var(--fg-muted)] ring-1 ring-inset ring-[var(--border-strong)]",
-        accent: "bg-accent-dim text-accent ring-1 ring-inset ring-accent/30",
-        info: "bg-info-dim text-info ring-1 ring-inset ring-info/30",
-        success: "bg-success-dim text-success ring-1 ring-inset ring-success/30",
-        warning: "bg-warning-dim text-warning ring-1 ring-inset ring-warning/30",
-        danger: "bg-danger-dim text-danger ring-1 ring-inset ring-danger/30",
+        neutral: "bg-[var(--surface-3)] text-[var(--fg-muted)] border-[var(--border-strong)]",
+        accent: "bg-accent-dim text-accent-ink border-accent/30",
+        info: "bg-info-dim text-info border-info/30",
+        success: "bg-success-dim text-success border-success/30",
+        warning: "bg-warning-dim text-warning border-warning/30",
+        danger: "bg-danger-dim text-danger border-danger/30",
       },
     },
     defaultVariants: {
@@ -24,10 +23,18 @@ const badgeVariants = cva(
 
 export interface BadgeProps
   extends HTMLAttributes<HTMLSpanElement>,
-    VariantProps<typeof badgeVariants> {}
+    VariantProps<typeof badgeVariants> {
+  /** Render a small leading dot in the badge's own color (status pills). */
+  dot?: boolean;
+}
 
-export function Badge({ className, tone, ...props }: BadgeProps) {
-  return <span className={cn(badgeVariants({ tone, className }))} {...props} />;
+export function Badge({ className, tone, dot, children, ...props }: BadgeProps) {
+  return (
+    <span className={cn(badgeVariants({ tone }), className)} {...props}>
+      {dot ? <span className="size-1.5 shrink-0 rounded-full bg-current" aria-hidden /> : null}
+      {children}
+    </span>
+  );
 }
 
 export { badgeVariants };

--- a/dashboard/src/components/ui/button.tsx
+++ b/dashboard/src/components/ui/button.tsx
@@ -40,17 +40,29 @@ export interface ButtonProps
 }
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild, type, ...props }, ref) => {
+  ({ className, variant, size, asChild, type, disabled, ...props }, ref) => {
+    const classes = cn(buttonVariants({ variant, size, className }));
     if (asChild) {
+      // A Slot may wrap a non-button (e.g. a router Link) that ignores the
+      // native `disabled` attribute and its `:disabled` styles, so emulate the
+      // disabled state: dim it, block pointer events, drop it from the tab
+      // order, and expose `aria-disabled` to assistive tech.
       return (
-        <Slot ref={ref} className={cn(buttonVariants({ variant, size, className }))} {...props} />
+        <Slot
+          ref={ref}
+          className={cn(classes, disabled && "pointer-events-none opacity-50")}
+          aria-disabled={disabled || undefined}
+          tabIndex={disabled ? -1 : undefined}
+          {...props}
+        />
       );
     }
     return (
       <button
         ref={ref}
         type={type ?? "button"}
-        className={cn(buttonVariants({ variant, size, className }))}
+        disabled={disabled}
+        className={classes}
         {...props}
       />
     );

--- a/dashboard/src/components/ui/button.tsx
+++ b/dashboard/src/components/ui/button.tsx
@@ -1,25 +1,27 @@
+import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
 import { type ButtonHTMLAttributes, forwardRef } from "react";
 import { cn } from "@/lib/cn";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring)] disabled:pointer-events-none disabled:opacity-50 [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-1.5 whitespace-nowrap rounded-[var(--btn-radius)] text-sm font-medium transition-[background-color,border-color,transform] active:translate-y-px focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring)] disabled:pointer-events-none disabled:opacity-50 [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
-        default: "bg-accent text-accent-fg hover:bg-accent/90 shadow-sm",
+        default:
+          "bg-[var(--accent-strong)] text-accent-fg hover:bg-[color-mix(in_oklch,var(--accent-strong)_88%,black)]",
         secondary:
-          "bg-[var(--surface-2)] text-[var(--fg)] hover:bg-[var(--surface-3)] ring-1 ring-inset ring-[var(--border-strong)]",
+          "bg-[var(--surface-2)] text-[var(--fg)] hover:bg-[var(--surface-3)] border border-[var(--border-strong)]",
         ghost: "text-[var(--fg-muted)] hover:bg-[var(--surface-2)] hover:text-[var(--fg)]",
         outline:
-          "ring-1 ring-inset ring-[var(--border-strong)] bg-transparent text-[var(--fg)] hover:bg-[var(--surface-2)]",
-        danger: "bg-danger text-white hover:bg-danger/90 shadow-sm",
-        link: "text-accent underline-offset-4 hover:underline",
+          "border border-[var(--border-strong)] bg-[var(--surface)] text-[var(--fg)] hover:bg-[var(--surface-2)]",
+        danger: "bg-danger text-white hover:bg-danger/90",
+        link: "text-accent-ink underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-9 px-3.5 py-2",
-        sm: "h-8 rounded-md px-3 text-xs",
-        lg: "h-10 rounded-md px-5",
+        default: "h-9 px-[15px]",
+        sm: "h-[30px] px-[11px] text-[0.78rem]",
+        lg: "h-10 px-5",
         icon: "size-9",
       },
     },
@@ -32,17 +34,27 @@ const buttonVariants = cva(
 
 export interface ButtonProps
   extends ButtonHTMLAttributes<HTMLButtonElement>,
-    VariantProps<typeof buttonVariants> {}
+    VariantProps<typeof buttonVariants> {
+  /** Render as the single child element (e.g. a router `Link`) via Radix Slot. */
+  asChild?: boolean;
+}
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, type = "button", ...props }, ref) => (
-    <button
-      ref={ref}
-      type={type}
-      className={cn(buttonVariants({ variant, size, className }))}
-      {...props}
-    />
-  ),
+  ({ className, variant, size, asChild, type, ...props }, ref) => {
+    if (asChild) {
+      return (
+        <Slot ref={ref} className={cn(buttonVariants({ variant, size, className }))} {...props} />
+      );
+    }
+    return (
+      <button
+        ref={ref}
+        type={type ?? "button"}
+        className={cn(buttonVariants({ variant, size, className }))}
+        {...props}
+      />
+    );
+  },
 );
 Button.displayName = "Button";
 

--- a/dashboard/src/components/ui/callout.tsx
+++ b/dashboard/src/components/ui/callout.tsx
@@ -1,0 +1,33 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/cn";
+
+type CalloutTone = "warning" | "info" | "danger";
+
+const TONE: Record<CalloutTone, string> = {
+  warning: "bg-warning-dim border-warning/30 [&_svg]:text-warning",
+  info: "bg-info-dim border-info/30 [&_svg]:text-info",
+  danger: "bg-danger-dim border-danger/30 [&_svg]:text-danger",
+};
+
+interface CalloutProps {
+  tone?: CalloutTone;
+  icon?: ReactNode;
+  children: ReactNode;
+  className?: string;
+}
+
+/** An inline tinted note with a leading icon — security warnings, hints. */
+export function Callout({ tone = "warning", icon, children, className }: CalloutProps) {
+  return (
+    <div
+      className={cn(
+        "flex items-start gap-2.5 rounded-[var(--btn-radius)] border px-3.5 py-3 text-[0.82rem] leading-relaxed text-[var(--fg)] [&_svg]:mt-px [&_svg]:size-4 [&_svg]:shrink-0",
+        TONE[tone],
+        className,
+      )}
+    >
+      {icon}
+      <span>{children}</span>
+    </div>
+  );
+}

--- a/dashboard/src/components/ui/card.tsx
+++ b/dashboard/src/components/ui/card.tsx
@@ -6,7 +6,7 @@ export const Card = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
     <div
       ref={ref}
       className={cn(
-        "rounded-lg bg-[var(--surface)] ring-1 ring-inset ring-[var(--border)] shadow-xs",
+        "rounded-[var(--card-radius)] border border-[var(--border)] bg-[var(--surface)] shadow-[var(--card-shadow)]",
         className,
       )}
       {...props}
@@ -17,7 +17,11 @@ Card.displayName = "Card";
 
 export const CardHeader = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("flex flex-col gap-1 px-5 pt-5 pb-2", className)} {...props} />
+    <div
+      ref={ref}
+      className={cn("flex flex-col gap-1 px-[var(--pad)] pt-[var(--pad)]", className)}
+      {...props}
+    />
   ),
 );
 CardHeader.displayName = "CardHeader";
@@ -26,7 +30,10 @@ export const CardTitle = forwardRef<HTMLHeadingElement, HTMLAttributes<HTMLHeadi
   ({ className, ...props }, ref) => (
     <h3
       ref={ref}
-      className={cn("text-sm font-medium text-[var(--fg-muted)] tracking-tight", className)}
+      className={cn(
+        "text-[0.95rem] font-semibold tracking-tight text-[var(--fg)] whitespace-nowrap",
+        className,
+      )}
       {...props}
     />
   ),
@@ -43,7 +50,7 @@ CardDescription.displayName = "CardDescription";
 
 export const CardContent = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("px-5 pb-5", className)} {...props} />
+    <div ref={ref} className={cn("p-[var(--pad)]", className)} {...props} />
   ),
 );
 CardContent.displayName = "CardContent";
@@ -52,7 +59,10 @@ export const CardFooter = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivEleme
   ({ className, ...props }, ref) => (
     <div
       ref={ref}
-      className={cn("flex items-center px-5 py-3 border-t border-[var(--border)]", className)}
+      className={cn(
+        "flex items-center px-[var(--pad)] py-3 border-t border-[var(--border)]",
+        className,
+      )}
       {...props}
     />
   ),

--- a/dashboard/src/components/ui/data-table.tsx
+++ b/dashboard/src/components/ui/data-table.tsx
@@ -45,7 +45,7 @@ function DataTableImpl<TData>({
   return (
     <div
       className={cn(
-        "rounded-lg bg-[var(--surface)] ring-1 ring-inset ring-[var(--border)] shadow-xs",
+        "overflow-hidden rounded-[var(--card-radius)] border border-[var(--border)] bg-[var(--surface)] shadow-[var(--card-shadow)]",
         className,
       )}
     >
@@ -62,7 +62,7 @@ function DataTableImpl<TData>({
                       <button
                         type="button"
                         onClick={header.column.getToggleSortingHandler()}
-                        className="inline-flex items-center gap-1 uppercase tracking-wider transition-colors hover:text-[var(--fg)]"
+                        className="inline-flex items-center gap-1 transition-colors hover:text-[var(--fg)]"
                       >
                         {flexRender(header.column.columnDef.header, header.getContext())}
                         {sorted === "asc" ? (

--- a/dashboard/src/components/ui/index.ts
+++ b/dashboard/src/components/ui/index.ts
@@ -1,5 +1,6 @@
 export { Badge, badgeVariants } from "./badge";
 export { Button, buttonVariants } from "./button";
+export { Callout } from "./callout";
 export {
   Card,
   CardContent,
@@ -55,8 +56,13 @@ export { EmptyState } from "./empty-state";
 export { ErrorState } from "./error-state";
 export { Input } from "./input";
 export { Kbd } from "./kbd";
+export { type KvItem, KvList } from "./kv-list";
+export { LiveDot } from "./live-dot";
+export { MeterBar } from "./meter-bar";
 export { Pagination } from "./pagination";
+export { QueueBar } from "./queue-bar";
 export { ScrollArea, ScrollBar } from "./scroll-area";
+export { Segmented, type SegmentedOption } from "./segmented";
 export {
   Select,
   SelectContent,
@@ -83,6 +89,9 @@ export {
 } from "./sheet";
 export { Skeleton, TableSkeleton } from "./skeleton";
 export { StatCard } from "./stat-card";
+export { StatusBadge } from "./status-badge";
+export { Stepper } from "./stepper";
+export { Switch } from "./switch";
 export {
   Table,
   TableBody,

--- a/dashboard/src/components/ui/kv-list.tsx
+++ b/dashboard/src/components/ui/kv-list.tsx
@@ -1,0 +1,45 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/cn";
+
+export interface KvItem {
+  label: string;
+  value: ReactNode;
+  mono?: boolean;
+}
+
+interface KvListProps {
+  items: KvItem[];
+  /** Lay rows out in two columns on wider screens (default) or a single one. */
+  columns?: 1 | 2;
+  className?: string;
+}
+
+/** A label/value list — runtime info, config snapshots. */
+export function KvList({ items, columns = 2, className }: KvListProps) {
+  return (
+    <dl
+      className={cn(
+        "grid gap-x-[22px] [&>div:nth-last-of-type(-n+2)]:border-b-0",
+        columns === 2 ? "grid-cols-1 sm:grid-cols-2" : "grid-cols-1",
+        className,
+      )}
+    >
+      {items.map((item) => (
+        <div
+          key={item.label}
+          className="flex items-center justify-between gap-2.5 border-b border-[var(--border)]/60 py-2.5"
+        >
+          <dt className="text-[0.8rem] text-[var(--fg-subtle)]">{item.label}</dt>
+          <dd
+            className={cn(
+              "text-[0.85rem] font-semibold text-[var(--fg)]",
+              item.mono && "font-mono tabular-nums",
+            )}
+          >
+            {item.value}
+          </dd>
+        </div>
+      ))}
+    </dl>
+  );
+}

--- a/dashboard/src/components/ui/kv-list.tsx
+++ b/dashboard/src/components/ui/kv-list.tsx
@@ -19,8 +19,10 @@ export function KvList({ items, columns = 2, className }: KvListProps) {
   return (
     <dl
       className={cn(
-        "grid gap-x-[22px] [&>div:nth-last-of-type(-n+2)]:border-b-0",
-        columns === 2 ? "grid-cols-1 sm:grid-cols-2" : "grid-cols-1",
+        "grid gap-x-[22px]",
+        columns === 2
+          ? "grid-cols-1 sm:grid-cols-2 [&>div:nth-last-of-type(-n+2)]:border-b-0"
+          : "grid-cols-1 [&>div:last-of-type]:border-b-0",
         className,
       )}
     >

--- a/dashboard/src/components/ui/live-dot.tsx
+++ b/dashboard/src/components/ui/live-dot.tsx
@@ -1,0 +1,39 @@
+import { cn } from "@/lib/cn";
+
+type DotTone = "success" | "info" | "accent" | "warning" | "danger";
+
+const TONE_TEXT: Record<DotTone, string> = {
+  success: "text-success",
+  info: "text-info",
+  accent: "text-accent",
+  warning: "text-warning",
+  danger: "text-danger",
+};
+
+interface LiveDotProps {
+  tone?: DotTone;
+  /** Animate the pulsing ring. Off for static status dots. */
+  pulse?: boolean;
+  size?: number;
+  className?: string;
+}
+
+/**
+ * A small filled dot. With `pulse`, it emits an expanding ring (the "live"
+ * signal). The ring is driven off `currentColor`, so the tone class sets both
+ * the fill and the ring color.
+ */
+export function LiveDot({ tone = "success", pulse = true, size = 7, className }: LiveDotProps) {
+  return (
+    <span
+      aria-hidden
+      style={{ width: size, height: size }}
+      className={cn(
+        "inline-block shrink-0 rounded-full bg-current",
+        TONE_TEXT[tone],
+        pulse && "pulse-ring",
+        className,
+      )}
+    />
+  );
+}

--- a/dashboard/src/components/ui/meter-bar.tsx
+++ b/dashboard/src/components/ui/meter-bar.tsx
@@ -1,0 +1,26 @@
+import { cn } from "@/lib/cn";
+import { TONE_VAR, type Tone } from "@/lib/status";
+
+interface MeterBarProps {
+  /** 0–100. Clamped. */
+  value: number;
+  tone?: Tone;
+  height?: number;
+  className?: string;
+}
+
+/** A single-value progress bar tinted by tone (gauges, success rates, pools). */
+export function MeterBar({ value, tone = "info", height = 6, className }: MeterBarProps) {
+  const pct = Math.max(0, Math.min(100, value));
+  return (
+    <div
+      className={cn("overflow-hidden rounded-full bg-[var(--surface-3)]", className)}
+      style={{ height }}
+    >
+      <span
+        className="block h-full rounded-full"
+        style={{ width: `${pct}%`, background: TONE_VAR[tone] }}
+      />
+    </div>
+  );
+}

--- a/dashboard/src/components/ui/queue-bar.tsx
+++ b/dashboard/src/components/ui/queue-bar.tsx
@@ -1,0 +1,58 @@
+import { cn } from "@/lib/cn";
+
+interface QueueBarProps {
+  pending: number;
+  running: number;
+  /** failed + dead combined. */
+  failedTotal: number;
+  className?: string;
+}
+
+interface Segment {
+  value: number;
+  color: string;
+  label: string;
+}
+
+/**
+ * The live workload *mix* as proportional segments: running (info) ·
+ * pending (subtle) · failed/dead (danger). Lifetime "completed" is
+ * deliberately excluded — it swamps everything. When all three are zero we
+ * render a faint full success sliver ("all clear").
+ */
+export function QueueBar({ pending, running, failedTotal, className }: QueueBarProps) {
+  const total = pending + running + failedTotal;
+  const segments: Segment[] = [
+    { value: running, color: "var(--info)", label: "running" },
+    { value: pending, color: "var(--fg-subtle)", label: "pending" },
+    { value: failedTotal, color: "var(--danger)", label: "failed/dead" },
+  ];
+  return (
+    <div
+      className={cn(
+        "flex h-1.5 min-w-[90px] overflow-hidden rounded-full bg-[var(--surface-3)]",
+        className,
+      )}
+      title="running · pending · failed"
+    >
+      {total === 0 ? (
+        <span
+          className="h-full w-full"
+          style={{ background: "var(--success-dim)" }}
+          title="all clear"
+        />
+      ) : (
+        segments.map((seg) =>
+          seg.value > 0 ? (
+            <span
+              key={seg.label}
+              className="h-full"
+              style={{ width: `${(seg.value / total) * 100}%`, background: seg.color }}
+              title={`${seg.label}: ${seg.value}`}
+            />
+          ) : null,
+        )
+      )}
+    </div>
+  );
+}

--- a/dashboard/src/components/ui/segmented.tsx
+++ b/dashboard/src/components/ui/segmented.tsx
@@ -1,0 +1,55 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/cn";
+
+export interface SegmentedOption<T extends string> {
+  value: T;
+  label: ReactNode;
+}
+
+interface SegmentedProps<T extends string> {
+  options: SegmentedOption<T>[];
+  value: T;
+  onChange: (value: T) => void;
+  "aria-label"?: string;
+  className?: string;
+}
+
+/** A segmented single-select control (status / level / window filters). */
+export function Segmented<T extends string>({
+  options,
+  value,
+  onChange,
+  className,
+  "aria-label": ariaLabel,
+}: SegmentedProps<T>) {
+  return (
+    <fieldset
+      className={cn(
+        "m-0 inline-flex min-w-0 overflow-hidden rounded-[var(--btn-radius)] border border-[var(--border-strong)] p-0",
+        className,
+      )}
+    >
+      {ariaLabel ? <legend className="sr-only">{ariaLabel}</legend> : null}
+      {options.map((option, i) => {
+        const active = option.value === value;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            aria-pressed={active}
+            onClick={() => onChange(option.value)}
+            className={cn(
+              "h-[34px] px-[13px] text-[0.8rem] font-medium transition-colors",
+              i > 0 && "border-l border-[var(--border)]",
+              active
+                ? "bg-accent-dim font-semibold text-[var(--accent-ink)]"
+                : "bg-[var(--surface)] text-[var(--fg-muted)] hover:text-[var(--fg)]",
+            )}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </fieldset>
+  );
+}

--- a/dashboard/src/components/ui/stat-card.tsx
+++ b/dashboard/src/components/ui/stat-card.tsx
@@ -18,13 +18,14 @@ interface StatCardProps extends HTMLAttributes<HTMLDivElement> {
   tone?: StatTone;
 }
 
-const TONE_RING: Record<StatTone, string> = {
-  neutral: "text-[var(--fg-muted)]",
-  accent: "text-accent",
-  info: "text-info",
-  success: "text-success",
-  warning: "text-warning",
-  danger: "text-danger",
+/** Tinted icon chip — the icon's color plus its faint background tint. */
+const TONE_CHIP: Record<StatTone, string> = {
+  neutral: "bg-[var(--surface-2)] text-[var(--fg-muted)]",
+  accent: "bg-accent-dim text-accent",
+  info: "bg-info-dim text-info",
+  success: "bg-success-dim text-success",
+  warning: "bg-warning-dim text-warning",
+  danger: "bg-danger-dim text-danger",
 };
 
 const TREND_ICON: Record<StatTrend["direction"], typeof ArrowUp> = {
@@ -38,18 +39,36 @@ export const StatCard = forwardRef<HTMLDivElement, StatCardProps>(
     const TrendIcon = trend ? TREND_ICON[trend.direction] : null;
     const trendClass = trend ? trendToneClass(trend.direction, trend.upIsGood ?? true) : "";
     return (
-      <Card ref={ref} className={cn("flex flex-col px-5 py-4", className)} {...props}>
-        <div className="flex items-start justify-between">
-          <div className="text-xs font-medium uppercase tracking-wide text-[var(--fg-subtle)]">
+      <Card
+        ref={ref}
+        className={cn(
+          "flex flex-col overflow-hidden p-[var(--pad)] transition-shadow hover:shadow-[var(--card-hover-shadow)]",
+          className,
+        )}
+        {...props}
+      >
+        <div className="flex items-center justify-between">
+          <div className="text-[length:var(--label-size)] font-medium tracking-[0.005em] text-[var(--fg-muted)]">
             {label}
           </div>
-          {icon ? <div className={cn("shrink-0", TONE_RING[tone])}>{icon}</div> : null}
+          {icon ? (
+            <span
+              className={cn(
+                "grid size-[30px] shrink-0 place-items-center rounded-[9px] [&_svg]:size-4",
+                TONE_CHIP[tone],
+              )}
+            >
+              {icon}
+            </span>
+          ) : null}
         </div>
-        <div className="mt-2 flex items-baseline gap-2">
-          <div className="text-2xl font-semibold tracking-tight tabular-nums">{value}</div>
+        <div className="mt-3.5 flex items-baseline gap-2">
+          <div className="font-mono text-[length:var(--stat-size)] font-semibold leading-[1.05] tracking-[-0.03em] tabular-nums whitespace-nowrap">
+            {value}
+          </div>
           {trend && TrendIcon ? (
             <span
-              className={cn("inline-flex items-center gap-0.5 text-xs font-medium", trendClass)}
+              className={cn("inline-flex items-center gap-0.5 text-xs font-semibold", trendClass)}
             >
               <TrendIcon className="size-3" aria-hidden />
               <span className="sr-only">Trend {trend.direction}:</span>

--- a/dashboard/src/components/ui/status-badge.tsx
+++ b/dashboard/src/components/ui/status-badge.tsx
@@ -1,0 +1,11 @@
+import { JOB_STATUS_LABEL, JOB_STATUS_TONE, type JobStatus } from "@/lib/status";
+import { Badge } from "./badge";
+
+/** A job-status pill with a leading status dot. */
+export function StatusBadge({ status }: { status: JobStatus }) {
+  return (
+    <Badge tone={JOB_STATUS_TONE[status]} dot>
+      {JOB_STATUS_LABEL[status]}
+    </Badge>
+  );
+}

--- a/dashboard/src/components/ui/stepper.tsx
+++ b/dashboard/src/components/ui/stepper.tsx
@@ -1,0 +1,60 @@
+import { Minus, Plus } from "lucide-react";
+import { cn } from "@/lib/cn";
+
+interface StepperProps {
+  value: number;
+  onChange: (value: number) => void;
+  min?: number;
+  max?: number;
+  step?: number;
+  /** Render the value (e.g. append a unit). Defaults to the raw number. */
+  format?: (value: number) => string;
+  "aria-label"?: string;
+  className?: string;
+}
+
+/** A −/+ number stepper with a mono value readout. */
+export function Stepper({
+  value,
+  onChange,
+  min = Number.NEGATIVE_INFINITY,
+  max = Number.POSITIVE_INFINITY,
+  step = 1,
+  format,
+  className,
+  "aria-label": ariaLabel,
+}: StepperProps) {
+  const round = (n: number) => Number(n.toFixed(4));
+  const dec = () => onChange(Math.max(min, round(value - step)));
+  const inc = () => onChange(Math.min(max, round(value + step)));
+  return (
+    <div
+      className={cn(
+        "inline-flex items-center overflow-hidden rounded-[var(--btn-radius)] border border-[var(--border-strong)]",
+        className,
+      )}
+    >
+      <button
+        type="button"
+        onClick={dec}
+        disabled={value <= min}
+        aria-label={ariaLabel ? `Decrease ${ariaLabel}` : "Decrease"}
+        className="grid size-[34px] place-items-center text-[var(--fg-muted)] transition-colors hover:bg-[var(--surface-2)] hover:text-[var(--fg)] disabled:opacity-40 disabled:hover:bg-transparent"
+      >
+        <Minus className="size-3.5" aria-hidden />
+      </button>
+      <span className="min-w-[48px] px-1 text-center font-mono text-[0.85rem] tabular-nums">
+        {format ? format(value) : value}
+      </span>
+      <button
+        type="button"
+        onClick={inc}
+        disabled={value >= max}
+        aria-label={ariaLabel ? `Increase ${ariaLabel}` : "Increase"}
+        className="grid size-[34px] place-items-center text-[var(--fg-muted)] transition-colors hover:bg-[var(--surface-2)] hover:text-[var(--fg)] disabled:opacity-40 disabled:hover:bg-transparent"
+      >
+        <Plus className="size-3.5" aria-hidden />
+      </button>
+    </div>
+  );
+}

--- a/dashboard/src/components/ui/stepper.tsx
+++ b/dashboard/src/components/ui/stepper.tsx
@@ -43,7 +43,10 @@ export function Stepper({
       >
         <Minus className="size-3.5" aria-hidden />
       </button>
-      <span className="min-w-[48px] px-1 text-center font-mono text-[0.85rem] tabular-nums">
+      <span
+        aria-live="polite"
+        className="min-w-[48px] px-1 text-center font-mono text-[0.85rem] tabular-nums"
+      >
         {format ? format(value) : value}
       </span>
       <button

--- a/dashboard/src/components/ui/switch.tsx
+++ b/dashboard/src/components/ui/switch.tsx
@@ -1,0 +1,46 @@
+import { cn } from "@/lib/cn";
+
+interface SwitchProps {
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+  disabled?: boolean;
+  id?: string;
+  "aria-label"?: string;
+  "aria-labelledby"?: string;
+  className?: string;
+}
+
+/** 40×23 pill toggle: off = surface-3, on = accent; a 17px knob slides 17px. */
+export function Switch({
+  checked,
+  onCheckedChange,
+  disabled,
+  id,
+  className,
+  ...aria
+}: SwitchProps) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      id={id}
+      aria-checked={checked}
+      disabled={disabled}
+      onClick={() => onCheckedChange(!checked)}
+      className={cn(
+        "relative h-[23px] w-10 shrink-0 rounded-full border transition-colors disabled:cursor-not-allowed disabled:opacity-50",
+        checked ? "border-accent bg-accent" : "border-[var(--border-strong)] bg-[var(--surface-3)]",
+        className,
+      )}
+      {...aria}
+    >
+      <span
+        aria-hidden
+        className={cn(
+          "absolute top-0.5 left-0.5 size-[17px] rounded-full bg-white shadow-[0_1px_2px_rgba(0,0,0,0.25)] transition-transform",
+          checked && "translate-x-[17px]",
+        )}
+      />
+    </button>
+  );
+}

--- a/dashboard/src/components/ui/table.tsx
+++ b/dashboard/src/components/ui/table.tsx
@@ -66,7 +66,7 @@ const TableHead = forwardRef<HTMLTableCellElement, ThHTMLAttributes<HTMLTableCel
     <th
       ref={ref}
       className={cn(
-        "h-10 px-4 text-left align-middle text-[11px] font-semibold uppercase tracking-wider text-[var(--fg-subtle)]",
+        "h-11 bg-[var(--surface-2)]/50 px-[var(--pad)] text-left align-middle text-[length:var(--label-size)] font-medium tracking-[0.005em] text-[var(--fg-subtle)] whitespace-nowrap",
         className,
       )}
       {...props}
@@ -79,7 +79,10 @@ const TableCell = forwardRef<HTMLTableCellElement, TdHTMLAttributes<HTMLTableCel
   ({ className, ...props }, ref) => (
     <td
       ref={ref}
-      className={cn("px-4 py-3 align-middle text-sm text-[var(--fg)]", className)}
+      className={cn(
+        "h-[var(--row-h)] px-[var(--pad)] align-middle text-[0.85rem] text-[var(--fg)]",
+        className,
+      )}
       {...props}
     />
   ),

--- a/dashboard/src/features/circuit-breakers/components/circuit-breakers-table.tsx
+++ b/dashboard/src/features/circuit-breakers/components/circuit-breakers-table.tsx
@@ -1,7 +1,13 @@
-import type { ColumnDef } from "@tanstack/react-table";
 import { CircuitBoard } from "lucide-react";
-import { useMemo } from "react";
-import { Badge, DataTable, EmptyState, ErrorState, TableSkeleton } from "@/components/ui";
+import {
+  Badge,
+  Card,
+  CardContent,
+  EmptyState,
+  ErrorState,
+  MeterBar,
+  Skeleton,
+} from "@/components/ui";
 import type { CircuitBreaker } from "@/lib/api-types";
 import { CIRCUIT_LABEL, CIRCUIT_TONE } from "@/lib/status";
 import { formatDuration, formatRelative } from "@/lib/time";
@@ -19,68 +25,6 @@ export function CircuitBreakersTable({
   error,
   onRetry,
 }: CircuitBreakersTableProps) {
-  const columns = useMemo<ColumnDef<CircuitBreaker>[]>(
-    () => [
-      {
-        accessorKey: "task_name",
-        header: "Task",
-        cell: ({ getValue }) => (
-          <span className="font-medium text-[var(--fg)]">{getValue<string>()}</span>
-        ),
-      },
-      {
-        accessorKey: "state",
-        header: "State",
-        cell: ({ row }) => (
-          <Badge tone={CIRCUIT_TONE[row.original.state]}>{CIRCUIT_LABEL[row.original.state]}</Badge>
-        ),
-      },
-      {
-        accessorKey: "failure_count",
-        header: "Failures / Threshold",
-        cell: ({ row }) => {
-          const { failure_count, threshold } = row.original;
-          const over = failure_count >= threshold;
-          return (
-            <span className={`tabular-nums ${over ? "text-danger" : "text-[var(--fg-muted)]"}`}>
-              {failure_count} / {threshold}
-            </span>
-          );
-        },
-      },
-      {
-        accessorKey: "window_ms",
-        header: "Window",
-        cell: ({ getValue }) => (
-          <span className="text-xs tabular-nums text-[var(--fg-muted)]">
-            {formatDuration(getValue<number>())}
-          </span>
-        ),
-      },
-      {
-        accessorKey: "cooldown_ms",
-        header: "Cooldown",
-        cell: ({ getValue }) => (
-          <span className="text-xs tabular-nums text-[var(--fg-muted)]">
-            {formatDuration(getValue<number>())}
-          </span>
-        ),
-      },
-      {
-        accessorKey: "last_failure_at",
-        header: "Last failure",
-        cell: ({ getValue }) => {
-          const v = getValue<number | null>();
-          if (!v) return <span className="text-[var(--fg-subtle)]">—</span>;
-          return (
-            <span className="text-xs tabular-nums text-[var(--fg-muted)]">{formatRelative(v)}</span>
-          );
-        },
-      },
-    ],
-    [],
-  );
-
   if (error) {
     return (
       <ErrorState
@@ -92,7 +36,14 @@ export function CircuitBreakersTable({
   }
 
   if (loading && !breakers) {
-    return <TableSkeleton rows={4} columns={["w-32", "w-16", "w-24", "w-16", "w-16", "w-20"]} />;
+    return (
+      <div className="grid gap-[var(--gap)] [grid-template-columns:repeat(auto-fill,minmax(290px,1fr))]">
+        {Array.from({ length: 4 }, (_, i) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: fixed-length skeleton placeholders
+          <Skeleton key={i} className="h-44 w-full" />
+        ))}
+      </div>
+    );
   }
 
   if (!breakers || breakers.length === 0) {
@@ -105,5 +56,63 @@ export function CircuitBreakersTable({
     );
   }
 
-  return <DataTable columns={columns} data={breakers} rowKey={(b) => b.task_name} />;
+  return (
+    <div className="grid gap-[var(--gap)] [grid-template-columns:repeat(auto-fill,minmax(290px,1fr))]">
+      {breakers.map((breaker) => (
+        <CircuitBreakerCard key={breaker.task_name} breaker={breaker} />
+      ))}
+    </div>
+  );
+}
+
+function CircuitBreakerCard({ breaker }: { breaker: CircuitBreaker }) {
+  const { task_name, state, failure_count, threshold, window_ms, cooldown_ms, last_failure_at } =
+    breaker;
+  const tone = CIRCUIT_TONE[state];
+  const pct = threshold > 0 ? (failure_count / threshold) * 100 : 0;
+
+  return (
+    <Card className="transition-shadow hover:shadow-[var(--card-hover-shadow)]">
+      <CardContent className="flex flex-col gap-4">
+        <div className="flex items-center justify-between gap-2">
+          <span className="truncate font-mono text-[0.84rem] font-semibold text-[var(--fg)]">
+            {task_name}
+          </span>
+          <Badge tone={tone} dot>
+            {CIRCUIT_LABEL[state]}
+          </Badge>
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <div className="flex items-center justify-between text-xs text-[var(--fg-muted)]">
+            <span>Failures in window</span>
+            <span className="font-mono tabular-nums">
+              {failure_count} / {threshold}
+            </span>
+          </div>
+          <MeterBar value={pct} tone={tone} />
+        </div>
+
+        <div className="grid grid-cols-3 gap-2 border-t border-[var(--border)] pt-3">
+          <CircuitMeta label="Window" value={formatDuration(window_ms)} />
+          <CircuitMeta label="Cooldown" value={formatDuration(cooldown_ms)} />
+          <CircuitMeta
+            label="Last failure"
+            value={last_failure_at ? formatRelative(last_failure_at) : "never"}
+          />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function CircuitMeta({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span className="text-[0.68rem] uppercase tracking-wide text-[var(--fg-subtle)]">
+        {label}
+      </span>
+      <span className="font-mono text-[0.78rem] tabular-nums text-[var(--fg)]">{value}</span>
+    </div>
+  );
 }

--- a/dashboard/src/features/dead-letters/components/dead-letter-list.tsx
+++ b/dashboard/src/features/dead-letters/components/dead-letter-list.tsx
@@ -1,10 +1,10 @@
-import { Skull } from "lucide-react";
+import { CheckCircle2 } from "lucide-react";
 import { useMemo } from "react";
 import { EmptyState, ErrorState, Skeleton } from "@/components/ui";
 import type { DeadLetter } from "@/lib/api-types";
 import { groupByError } from "../utils";
 import { DeadLetterGroupRow } from "./dead-letter-group-row";
-import { DeadLetterRow } from "./dead-letter-row";
+import { DeadLetterTable } from "./dead-letter-table";
 
 export type DeadLetterView = "flat" | "grouped";
 
@@ -39,9 +39,9 @@ export function DeadLetterList({ items, view, loading, error, onRetry }: DeadLet
   if (!items || items.length === 0) {
     return (
       <EmptyState
-        icon={Skull}
-        title="No dead letters"
-        description="Jobs that exhaust their retries land here."
+        icon={CheckCircle2}
+        title="Nothing dead here"
+        description="Every job has been replayed or discarded. Nice and tidy."
       />
     );
   }
@@ -56,11 +56,5 @@ export function DeadLetterList({ items, view, loading, error, onRetry }: DeadLet
     );
   }
 
-  return (
-    <div className="flex flex-col gap-2">
-      {items.map((item) => (
-        <DeadLetterRow key={item.id} item={item} />
-      ))}
-    </div>
-  );
+  return <DeadLetterTable items={items} />;
 }

--- a/dashboard/src/features/dead-letters/components/dead-letter-table.tsx
+++ b/dashboard/src/features/dead-letters/components/dead-letter-table.tsx
@@ -1,0 +1,85 @@
+import { Link } from "@tanstack/react-router";
+import { RotateCcw } from "lucide-react";
+import {
+  Button,
+  Card,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui";
+import type { DeadLetter } from "@/lib/api-types";
+import { formatRelative } from "@/lib/time";
+import { useRetryDeadLetter } from "../hooks";
+
+interface DeadLetterTableProps {
+  items: DeadLetter[];
+}
+
+/** Flat-view table: one row per dead letter, replayable via the retry mutation. */
+export function DeadLetterTable({ items }: DeadLetterTableProps) {
+  return (
+    <Card className="overflow-hidden">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Original job</TableHead>
+            <TableHead>Task</TableHead>
+            <TableHead>Queue</TableHead>
+            <TableHead>Last error</TableHead>
+            <TableHead className="text-right">Failed</TableHead>
+            <TableHead className="text-right">Actions</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {items.map((item) => (
+            <DeadLetterTableRow key={item.id} item={item} />
+          ))}
+        </TableBody>
+      </Table>
+    </Card>
+  );
+}
+
+function DeadLetterTableRow({ item }: { item: DeadLetter }) {
+  const retry = useRetryDeadLetter();
+  return (
+    <TableRow>
+      <TableCell>
+        <Link
+          to="/jobs/$id"
+          params={{ id: item.original_job_id }}
+          className="font-mono text-[0.82rem] tabular-nums text-accent hover:underline"
+        >
+          {item.original_job_id.slice(0, 8)}…
+        </Link>
+      </TableCell>
+      <TableCell className="font-medium text-[var(--fg)]">{item.task_name}</TableCell>
+      <TableCell className="text-[var(--fg-muted)]">{item.queue}</TableCell>
+      <TableCell className="max-w-[300px]">
+        {item.error ? (
+          <span className="block truncate font-mono text-[0.78rem] text-danger" title={item.error}>
+            {item.error}
+          </span>
+        ) : (
+          <span className="text-[var(--fg-subtle)]">—</span>
+        )}
+      </TableCell>
+      <TableCell className="text-right font-mono text-[0.82rem] tabular-nums text-[var(--fg-muted)]">
+        {formatRelative(item.failed_at)}
+      </TableCell>
+      <TableCell className="text-right">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => retry.mutate(item.id)}
+          disabled={retry.isPending}
+        >
+          <RotateCcw aria-hidden /> Replay
+        </Button>
+      </TableCell>
+    </TableRow>
+  );
+}

--- a/dashboard/src/features/dead-letters/components/index.ts
+++ b/dashboard/src/features/dead-letters/components/index.ts
@@ -1,3 +1,4 @@
 export { DeadLetterGroupRow } from "./dead-letter-group-row";
 export { DeadLetterList, type DeadLetterView } from "./dead-letter-list";
 export { DeadLetterRow } from "./dead-letter-row";
+export { DeadLetterTable } from "./dead-letter-table";

--- a/dashboard/src/features/jobs/components/job-filters.tsx
+++ b/dashboard/src/features/jobs/components/job-filters.tsx
@@ -96,7 +96,7 @@ export function JobFiltersBar({ filters, onChange, className }: JobFiltersBarPro
   return (
     <div
       className={cn(
-        "flex flex-col gap-3 rounded-lg bg-[var(--surface)] p-3 ring-1 ring-inset ring-[var(--border)]",
+        "flex flex-col gap-3 rounded-[var(--card-radius)] border border-[var(--border)] bg-[var(--surface)] p-3 shadow-[var(--card-shadow)]",
         className,
       )}
     >

--- a/dashboard/src/features/jobs/components/job-table.tsx
+++ b/dashboard/src/features/jobs/components/job-table.tsx
@@ -2,17 +2,16 @@ import { useNavigate } from "@tanstack/react-router";
 import type { ColumnDef } from "@tanstack/react-table";
 import { useCallback, useMemo } from "react";
 import {
-  Badge,
   DataTable,
   EmptyState,
   ErrorState,
+  StatusBadge,
   TableSkeleton,
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui";
 import type { Job } from "@/lib/api-types";
-import { JOB_STATUS_LABEL, JOB_STATUS_TONE } from "@/lib/status";
 import { formatAbsolute, formatRelative } from "@/lib/time";
 
 interface JobTableProps {
@@ -56,11 +55,7 @@ export function JobTable({ jobs, loading, error, onRetry }: JobTableProps) {
       {
         accessorKey: "status",
         header: "Status",
-        cell: ({ row }) => (
-          <Badge tone={JOB_STATUS_TONE[row.original.status]}>
-            {JOB_STATUS_LABEL[row.original.status]}
-          </Badge>
-        ),
+        cell: ({ row }) => <StatusBadge status={row.original.status} />,
       },
       {
         accessorKey: "retry_count",

--- a/dashboard/src/features/logs/components/log-filters.tsx
+++ b/dashboard/src/features/logs/components/log-filters.tsx
@@ -1,17 +1,21 @@
+import { Search } from "lucide-react";
 import { useEffect, useState } from "react";
-import {
-  Input,
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui";
+import { Input, Segmented, type SegmentedOption } from "@/components/ui";
 import { useDebouncedValue } from "@/hooks";
 import { cn } from "@/lib/cn";
 import { LOG_LEVELS, type LogLevel } from "../api";
 
 const ALL_LEVELS = "__all__";
+
+type LevelValue = LogLevel | typeof ALL_LEVELS;
+
+const LEVEL_OPTIONS: SegmentedOption<LevelValue>[] = [
+  { value: ALL_LEVELS, label: "All" },
+  ...LOG_LEVELS.map((lvl) => ({
+    value: lvl,
+    label: lvl.charAt(0).toUpperCase() + lvl.slice(1),
+  })),
+];
 
 interface LogFiltersProps {
   task: string | undefined;
@@ -37,30 +41,25 @@ export function LogFilters({ task, level, onChange, className }: LogFiltersProps
   }, [debounced, task, onChange, level]);
 
   return (
-    <div className={cn("grid gap-2 md:grid-cols-[1fr_200px]", className)}>
-      <Input
-        value={localTask}
-        onChange={(e) => setLocalTask(e.target.value)}
-        placeholder="Filter by task name…"
-      />
-      <Select
+    <div className={cn("flex flex-wrap items-center gap-2.5", className)}>
+      <Segmented
+        aria-label="Log level"
+        options={LEVEL_OPTIONS}
         value={level ?? ALL_LEVELS}
-        onValueChange={(v) =>
-          onChange({ task, level: v === ALL_LEVELS ? undefined : (v as LogLevel) })
-        }
-      >
-        <SelectTrigger aria-label="Log level">
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value={ALL_LEVELS}>All levels</SelectItem>
-          {LOG_LEVELS.map((lvl) => (
-            <SelectItem key={lvl} value={lvl}>
-              {lvl}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
+        onChange={(v) => onChange({ task, level: v === ALL_LEVELS ? undefined : v })}
+      />
+      <div className="relative max-w-80 flex-1">
+        <Search
+          className="pointer-events-none absolute left-2.5 top-1/2 size-[15px] -translate-y-1/2 text-[var(--fg-subtle)]"
+          aria-hidden
+        />
+        <Input
+          value={localTask}
+          onChange={(e) => setLocalTask(e.target.value)}
+          placeholder="Filter by message or task…"
+          className="pl-8"
+        />
+      </div>
     </div>
   );
 }

--- a/dashboard/src/features/logs/components/log-stream.tsx
+++ b/dashboard/src/features/logs/components/log-stream.tsx
@@ -5,7 +5,11 @@ import { EmptyState, ErrorState, Skeleton } from "@/components/ui";
 import type { TaskLog } from "@/lib/api-types";
 import { cn } from "@/lib/cn";
 import { logLevelClass } from "@/lib/status";
-import { formatAbsolute } from "@/lib/time";
+
+/** Wall-clock time only (24h), to match the live-tail row density. */
+function formatLogTime(ms: number): string {
+  return new Date(ms).toLocaleTimeString("en-US", { hour12: false });
+}
 
 interface LogStreamProps {
   logs: TaskLog[] | undefined;
@@ -53,20 +57,26 @@ export function LogStream({ logs, loading, error, onRetry, className }: LogStrea
   };
 
   if (error) {
-    return <ErrorState title="Couldn't load logs" description={error.message} onRetry={onRetry} />;
+    return (
+      <div className="p-[var(--pad)]">
+        <ErrorState title="Couldn't load logs" description={error.message} onRetry={onRetry} />
+      </div>
+    );
   }
 
   if (loading && !logs) {
-    return <Skeleton className="h-96 w-full" />;
+    return <Skeleton className="m-[var(--pad)] h-96" />;
   }
 
   if (!logs || logs.length === 0) {
     return (
-      <EmptyState
-        icon={ScrollText}
-        title="No logs match this filter"
-        description="Try widening the time range or clearing the task filter."
-      />
+      <div className="p-[var(--pad)]">
+        <EmptyState
+          icon={ScrollText}
+          title="No logs match this filter"
+          description="Try widening the time range or clearing the task filter."
+        />
+      </div>
     );
   }
 
@@ -75,13 +85,12 @@ export function LogStream({ logs, loading, error, onRetry, className }: LogStrea
       <div
         ref={parentRef}
         onScroll={handleScroll}
-        className="h-[560px] overflow-auto rounded-lg bg-[var(--surface)] ring-1 ring-inset ring-[var(--border)]"
+        className="h-[560px] overflow-auto rounded-[var(--card-radius)]"
       >
         <div style={{ height: virtualizer.getTotalSize(), width: "100%", position: "relative" }}>
           {virtualizer.getVirtualItems().map((item) => {
             const log = logs[item.index];
             if (!log) return null;
-            const levelClass = logLevelClass(log.level);
             return (
               <div
                 key={`${log.logged_at}-${log.job_id}-${item.index}`}
@@ -92,16 +101,31 @@ export function LogStream({ logs, loading, error, onRetry, className }: LogStrea
                   right: 0,
                   transform: `translateY(${item.start}px)`,
                 }}
-                className="flex gap-3 px-4 py-1 font-mono text-[11px] hover:bg-[var(--surface-2)]/40"
+                className="flex items-center gap-3 px-4 py-1 text-[0.78rem] hover:bg-[var(--surface-2)]/50"
               >
-                <span className="shrink-0 text-[var(--fg-subtle)]">
-                  {formatAbsolute(log.logged_at)}
+                <span className="shrink-0 font-mono tabular-nums text-[var(--fg-subtle)]">
+                  {formatLogTime(log.logged_at)}
                 </span>
-                <span className={cn("w-14 shrink-0 uppercase", levelClass)}>{log.level}</span>
-                <span className="w-40 shrink-0 truncate text-[var(--fg-muted)]">
+                <span
+                  className={cn(
+                    "inline-flex w-[58px] shrink-0 justify-center rounded-[var(--chip-radius)] bg-current/10 px-1.5 py-0.5 text-[0.62rem] font-semibold uppercase tracking-[0.08em]",
+                    logLevelClass(log.level),
+                  )}
+                >
+                  {log.level}
+                </span>
+                <span className="w-[168px] shrink-0 truncate font-mono text-[var(--accent-ink)]">
                   {log.task_name}
                 </span>
-                <span className="flex-1 truncate text-[var(--fg)]">{log.message}</span>
+                <span className="flex-1 truncate text-[var(--fg)]">
+                  {log.message}
+                  {log.extra ? (
+                    <span className="ml-1.5 font-mono text-[var(--fg-subtle)]">{log.extra}</span>
+                  ) : null}
+                </span>
+                <span className="ml-auto shrink-0 font-mono text-[var(--fg-subtle)]">
+                  {log.job_id.slice(0, 6)}
+                </span>
               </div>
             );
           })}

--- a/dashboard/src/features/logs/hooks.ts
+++ b/dashboard/src/features/logs/hooks.ts
@@ -12,7 +12,7 @@ export function logsListQuery(query: LogsQuery) {
   });
 }
 
-export function useLogs(query: LogsQuery) {
+export function useLogs(query: LogsQuery, live = true) {
   const { intervalMs } = useRefreshInterval();
-  return useQuery({ ...logsListQuery(query), refetchInterval: intervalMs });
+  return useQuery({ ...logsListQuery(query), refetchInterval: live ? intervalMs : false });
 }

--- a/dashboard/src/features/logs/page.tsx
+++ b/dashboard/src/features/logs/page.tsx
@@ -1,5 +1,8 @@
 import { getRouteApi } from "@tanstack/react-router";
+import { useState } from "react";
 import { PageHeader } from "@/components/layout";
+import { Button, Card, CardContent, LiveDot } from "@/components/ui";
+import { formatCount } from "@/lib/number";
 import type { LogLevel } from "./api";
 import { LogFilters, LogStream } from "./components";
 import { useLogs } from "./hooks";
@@ -14,6 +17,7 @@ const routeApi = getRouteApi("/logs");
 export default function LogsPage() {
   const search = routeApi.useSearch();
   const navigate = routeApi.useNavigate();
+  const [live, setLive] = useState(true);
 
   const setFilter = (next: { task?: string; level?: LogLevel }) => {
     navigate({
@@ -25,24 +29,48 @@ export default function LogsPage() {
     });
   };
 
-  const logs = useLogs({
-    task: search.task,
-    level: search.level,
-    sinceSeconds: LOGS_DEFAULT_SINCE_SECONDS,
-    limit: LOGS_PAGE_SIZE,
-  });
+  const logs = useLogs(
+    {
+      task: search.task,
+      level: search.level,
+      sinceSeconds: LOGS_DEFAULT_SINCE_SECONDS,
+      limit: LOGS_PAGE_SIZE,
+    },
+    live,
+  );
+
+  const lineCount = logs.data?.length ?? 0;
 
   return (
     <>
-      <PageHeader title="Logs" description="Live-tailing task log stream across all workers." />
-      <div className="flex flex-col gap-3">
-        <LogFilters task={search.task} level={search.level} onChange={setFilter} />
-        <LogStream
-          logs={logs.data}
-          loading={logs.isLoading || (logs.isFetching && !logs.data)}
-          error={logs.error}
-          onRetry={() => logs.refetch()}
-        />
+      <PageHeader
+        eyebrow="Monitoring"
+        title="Logs"
+        description="A live tail of structured task logs across every worker."
+        actions={
+          <Button variant={live ? "default" : "outline"} onClick={() => setLive((v) => !v)}>
+            {live ? <LiveDot tone="accent" /> : null}
+            {live ? "Live tail on" : "Paused"}
+          </Button>
+        }
+      />
+      <div className="flex flex-col gap-[var(--page-gap)]">
+        <div className="flex flex-wrap items-center gap-2.5">
+          <LogFilters task={search.task} level={search.level} onChange={setFilter} />
+          <span className="ml-auto font-mono text-xs tabular-nums text-[var(--fg-subtle)]">
+            {formatCount(lineCount)} lines
+          </span>
+        </div>
+        <Card>
+          <CardContent className="p-0">
+            <LogStream
+              logs={logs.data}
+              loading={logs.isLoading || (logs.isFetching && !logs.data)}
+              error={logs.error}
+              onRetry={() => logs.refetch()}
+            />
+          </CardContent>
+        </Card>
       </div>
     </>
   );

--- a/dashboard/src/features/logs/page.tsx
+++ b/dashboard/src/features/logs/page.tsx
@@ -48,7 +48,11 @@ export default function LogsPage() {
         title="Logs"
         description="A live tail of structured task logs across every worker."
         actions={
-          <Button variant={live ? "default" : "outline"} onClick={() => setLive((v) => !v)}>
+          <Button
+            variant={live ? "default" : "outline"}
+            aria-pressed={live}
+            onClick={() => setLive((v) => !v)}
+          >
             {live ? <LiveDot tone="accent" /> : null}
             {live ? "Live tail on" : "Paused"}
           </Button>

--- a/dashboard/src/features/metrics/components/metrics-table.tsx
+++ b/dashboard/src/features/metrics/components/metrics-table.tsx
@@ -1,8 +1,10 @@
 import type { ColumnDef } from "@tanstack/react-table";
 import { useMemo } from "react";
-import { DataTable, EmptyState, ErrorState, TableSkeleton } from "@/components/ui";
+import { DataTable, EmptyState, ErrorState, MeterBar, TableSkeleton } from "@/components/ui";
 import type { MetricsResponse, TaskMetrics } from "@/lib/api-types";
 import { formatCount, formatPercent } from "@/lib/number";
+import type { Tone } from "@/lib/status";
+import { formatDuration } from "@/lib/time";
 
 interface Row extends TaskMetrics {
   task: string;
@@ -46,17 +48,23 @@ export function MetricsTable({ metrics, loading, error, onRetry }: MetricsTableP
             accessorKey: "count",
             header: "Runs",
             cell: ({ getValue }) => (
-              <span className="tabular-nums">{formatCount(getValue<number>())}</span>
+              <span className="font-mono tabular-nums">{formatCount(getValue<number>())}</span>
             ),
           },
           {
             accessorKey: "successRate",
-            header: "Success",
+            header: "Success rate",
             cell: ({ row }) => {
-              const rate = row.original.successRate;
-              const tone =
-                rate >= 0.99 ? "text-success" : rate >= 0.9 ? "text-warning" : "text-danger";
-              return <span className={`tabular-nums ${tone}`}>{formatPercent(rate, 1)}</span>;
+              const pct = row.original.successRate * 100;
+              const tone: Tone = pct >= 99 ? "success" : pct >= 96 ? "warning" : "danger";
+              return (
+                <div className="flex items-center gap-2.5">
+                  <MeterBar value={pct} tone={tone} className="min-w-[60px] flex-1" />
+                  <span className="w-11 text-right font-mono text-[0.74rem] tabular-nums text-[var(--fg-muted)]">
+                    {formatPercent(row.original.successRate, 1)}
+                  </span>
+                </div>
+              );
             },
           },
           {
@@ -66,7 +74,9 @@ export function MetricsTable({ metrics, loading, error, onRetry }: MetricsTableP
               const n = getValue<number>();
               return (
                 <span
-                  className={`tabular-nums ${n > 0 ? "text-danger" : "text-[var(--fg-muted)]"}`}
+                  className={`font-mono tabular-nums ${
+                    n > 0 ? "text-danger" : "text-[var(--fg-muted)]"
+                  }`}
                 >
                   {formatCount(n)}
                 </span>
@@ -147,7 +157,9 @@ function GroupHeader({ children }: { children: React.ReactNode }) {
 
 function Ms({ value }: { value: number | null | undefined }) {
   if (value == null || !Number.isFinite(value)) {
-    return <span className="tabular-nums text-[var(--fg-subtle)]">—</span>;
+    return <span className="font-mono tabular-nums text-[var(--fg-subtle)]">—</span>;
   }
-  return <span className="tabular-nums text-[var(--fg-muted)]">{`${value.toFixed(1)}ms`}</span>;
+  return (
+    <span className="font-mono tabular-nums text-[var(--fg-muted)]">{formatDuration(value)}</span>
+  );
 }

--- a/dashboard/src/features/metrics/page.tsx
+++ b/dashboard/src/features/metrics/page.tsx
@@ -1,6 +1,11 @@
 import { getRouteApi } from "@tanstack/react-router";
+import { CheckCircle2, Clock, Zap } from "lucide-react";
 import { useMemo } from "react";
 import { PageHeader } from "@/components/layout";
+import { StatCard } from "@/components/ui";
+import type { MetricsResponse } from "@/lib/api-types";
+import { formatCount, formatPercent } from "@/lib/number";
+import { formatDuration } from "@/lib/time";
 import {
   LatencyChart,
   MetricsTable,
@@ -10,6 +15,38 @@ import {
 } from "./components";
 import { useMetricsSummary, useMetricsTimeseries } from "./hooks";
 import type { TimeRange } from "./types";
+
+interface MetricsSummaryTotals {
+  totalRuns: number;
+  taskCount: number;
+  successRate: number | null;
+  slowestP95: number;
+  slowestTask: string | null;
+}
+
+/** Roll the per-task summary up into the page-level stat tiles. */
+function summarize(metrics: MetricsResponse | undefined): MetricsSummaryTotals {
+  const entries = Object.entries(metrics ?? {});
+  let totalRuns = 0;
+  let totalSuccess = 0;
+  let slowestP95 = 0;
+  let slowestTask: string | null = null;
+  for (const [task, m] of entries) {
+    totalRuns += m.count;
+    totalSuccess += m.success_count;
+    if (m.p95_ms > slowestP95) {
+      slowestP95 = m.p95_ms;
+      slowestTask = task;
+    }
+  }
+  return {
+    totalRuns,
+    taskCount: entries.length,
+    successRate: totalRuns > 0 ? totalSuccess / totalRuns : null,
+    slowestP95,
+    slowestTask,
+  };
+}
 
 const routeApi = getRouteApi("/metrics");
 
@@ -41,6 +78,8 @@ export default function MetricsPage() {
     return summary.data ? Object.keys(summary.data).sort() : [];
   }, [summary.data]);
 
+  const totals = useMemo(() => summarize(summary.data), [summary.data]);
+
   return (
     <>
       <PageHeader
@@ -58,8 +97,30 @@ export default function MetricsPage() {
           </>
         }
       />
-      <div className="flex flex-col gap-4">
-        <div className="grid gap-4 lg:grid-cols-2">
+      <div className="flex flex-col gap-[var(--page-gap)]">
+        <div className="grid gap-[var(--gap)] grid-cols-[repeat(auto-fit,minmax(186px,1fr))]">
+          <StatCard
+            label="Total runs"
+            tone="neutral"
+            icon={<Zap />}
+            value={formatCount(totals.totalRuns)}
+            hint={`across ${formatCount(totals.taskCount)} tasks`}
+          />
+          <StatCard
+            label="Success rate"
+            tone="success"
+            icon={<CheckCircle2 />}
+            value={totals.successRate == null ? "—" : formatPercent(totals.successRate, 2)}
+          />
+          <StatCard
+            label="Slowest p95"
+            tone="warning"
+            icon={<Clock />}
+            value={totals.slowestTask ? formatDuration(totals.slowestP95) : "—"}
+            hint={totals.slowestTask ?? undefined}
+          />
+        </div>
+        <div className="grid gap-[var(--gap)] lg:grid-cols-2">
           <ThroughputChart buckets={series.data} loading={series.isLoading} />
           <LatencyChart buckets={series.data} loading={series.isLoading} />
         </div>

--- a/dashboard/src/features/overview/components/busiest-queues.tsx
+++ b/dashboard/src/features/overview/components/busiest-queues.tsx
@@ -1,0 +1,90 @@
+import { Box } from "lucide-react";
+import { useMemo } from "react";
+import {
+  Badge,
+  EmptyState,
+  QueueBar,
+  Skeleton,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui";
+import type { QueueStatsMap } from "@/lib/api-types";
+import { formatCount } from "@/lib/number";
+
+interface BusiestQueuesProps {
+  queueStats: QueueStatsMap | undefined;
+  paused: string[] | undefined;
+  loading: boolean;
+}
+
+/** The six queues with the most live work (running + pending), with a mix bar. */
+export function BusiestQueues({ queueStats, paused, loading }: BusiestQueuesProps) {
+  const rows = useMemo(() => {
+    if (!queueStats) return [];
+    const pausedSet = new Set(paused ?? []);
+    return Object.entries(queueStats)
+      .map(([name, s]) => ({
+        name,
+        pending: s.pending ?? 0,
+        running: s.running ?? 0,
+        failedTotal: (s.failed ?? 0) + (s.dead ?? 0),
+        paused: pausedSet.has(name),
+      }))
+      .sort((a, b) => b.running + b.pending - (a.running + a.pending))
+      .slice(0, 6);
+  }, [queueStats, paused]);
+
+  if (loading && rows.length === 0) return <Skeleton className="h-56 w-full" />;
+
+  return (
+    <div className="overflow-hidden rounded-[var(--card-radius)] border border-[var(--border)] bg-[var(--surface)] shadow-[var(--card-shadow)]">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Queue</TableHead>
+            <TableHead className="w-[34%]">Mix</TableHead>
+            <TableHead className="text-right">Pending</TableHead>
+            <TableHead className="text-right">Running</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {rows.length === 0 ? (
+            <TableRow>
+              <TableCell colSpan={4} className="h-32 p-0">
+                <EmptyState
+                  icon={Box}
+                  title="No queues with activity yet"
+                  description="Queues populate as jobs are enqueued."
+                />
+              </TableCell>
+            </TableRow>
+          ) : (
+            rows.map((q) => (
+              <TableRow key={q.name}>
+                <TableCell>
+                  <div className="flex items-center gap-2.5">
+                    <span className="font-medium text-[var(--fg)]">{q.name}</span>
+                    {q.paused ? <Badge tone="warning">Paused</Badge> : null}
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <QueueBar pending={q.pending} running={q.running} failedTotal={q.failedTotal} />
+                </TableCell>
+                <TableCell className="text-right font-mono text-[0.82rem] tabular-nums">
+                  {formatCount(q.pending)}
+                </TableCell>
+                <TableCell className="text-right font-mono text-[0.82rem] tabular-nums text-info">
+                  {formatCount(q.running)}
+                </TableCell>
+              </TableRow>
+            ))
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/dashboard/src/features/overview/components/index.ts
+++ b/dashboard/src/features/overview/components/index.ts
@@ -1,4 +1,7 @@
+export { BusiestQueues } from "./busiest-queues";
+export { Pulse } from "./pulse";
 export { QueueBreakdown } from "./queue-breakdown";
 export { RecentJobs } from "./recent-jobs";
 export { StatsGrid } from "./stats-grid";
 export { ThroughputSparkline } from "./throughput-sparkline";
+export { WorkersCard } from "./workers-card";

--- a/dashboard/src/features/overview/components/pulse.tsx
+++ b/dashboard/src/features/overview/components/pulse.tsx
@@ -1,0 +1,75 @@
+import { Heart } from "lucide-react";
+import { LiveDot, Skeleton } from "@/components/ui";
+import type { QueueStats, TimeseriesBucket } from "@/lib/api-types";
+import { formatCount } from "@/lib/number";
+
+interface PulseProps {
+  stats: QueueStats | undefined;
+  throughput: TimeseriesBucket[] | undefined;
+}
+
+const Highlight = ({ children }: { children: React.ReactNode }) => (
+  <span className="font-mono font-semibold text-[var(--accent-ink)]">{children}</span>
+);
+
+/**
+ * The Overview's plain-language health banner — the personality moment. It
+ * summarises the last hour in one sentence with mono-highlighted numbers, and
+ * a status pill driven by the success rate + dead-letter count.
+ */
+export function Pulse({ stats, throughput }: PulseProps) {
+  if (!stats) {
+    return (
+      <div className="rounded-[var(--card-radius)] border border-[var(--border)] bg-[var(--surface)] p-[var(--pad)] shadow-[var(--card-shadow)]">
+        <Skeleton className="h-12 w-full" />
+      </div>
+    );
+  }
+
+  const buckets = throughput ?? [];
+  const lastHour = buckets.reduce((sum, b) => sum + b.count, 0);
+  const failures = buckets.reduce((sum, b) => sum + b.failure, 0);
+  const rate = lastHour > 0 ? ((lastHour - failures) / lastHour) * 100 : 100;
+  const dead = stats.dead;
+  const healthy = dead < 30 && rate > 98;
+
+  return (
+    <div
+      className="flex items-center gap-4 rounded-[var(--card-radius)] border border-[var(--border)] p-[var(--pad)] shadow-[var(--card-shadow)]"
+      style={{
+        background: "linear-gradient(105deg, var(--accent-dim), transparent 46%), var(--surface)",
+      }}
+    >
+      <div className="grid size-[46px] shrink-0 place-items-center rounded-[13px] border border-accent/30 bg-accent-dim text-accent">
+        <Heart className="size-[22px]" aria-hidden />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="text-[1.02rem] font-medium leading-snug tracking-[-0.01em]">
+          {lastHour === 0 ? (
+            <>It's quiet right now — no jobs have run in the last hour.</>
+          ) : (
+            <>
+              {healthy ? "Everything's flowing nicely — " : "Mostly steady — "}
+              <Highlight>{formatCount(lastHour)}</Highlight> jobs ran in the last hour at a{" "}
+              <Highlight>{rate.toFixed(1)}%</Highlight> success rate.
+            </>
+          )}
+        </div>
+        <div className="mt-1 text-[0.82rem] text-[var(--fg-muted)]">
+          {formatCount(stats.running)} in flight right now · {formatCount(stats.pending)} waiting ·{" "}
+          {formatCount(dead)} dead {dead === 1 ? "letter needs" : "letters need"} a look.
+        </div>
+      </div>
+      <span
+        className={`inline-flex shrink-0 items-center gap-2 rounded-full border px-3.5 py-[7px] text-[0.82rem] font-semibold whitespace-nowrap ${
+          healthy
+            ? "border-success/30 bg-success-dim text-success"
+            : "border-warning/30 bg-warning-dim text-warning"
+        }`}
+      >
+        <LiveDot tone={healthy ? "success" : "warning"} size={7} />
+        {healthy ? "All systems go" : "Keep an eye out"}
+      </span>
+    </div>
+  );
+}

--- a/dashboard/src/features/overview/components/recent-jobs.tsx
+++ b/dashboard/src/features/overview/components/recent-jobs.tsx
@@ -2,9 +2,8 @@ import { Link, useNavigate } from "@tanstack/react-router";
 import type { ColumnDef } from "@tanstack/react-table";
 import { ListTree } from "lucide-react";
 import { useMemo } from "react";
-import { Badge, DataTable, EmptyState, ErrorState, Skeleton } from "@/components/ui";
+import { DataTable, EmptyState, ErrorState, Skeleton, StatusBadge } from "@/components/ui";
 import type { Job } from "@/lib/api-types";
-import { JOB_STATUS_LABEL, JOB_STATUS_TONE } from "@/lib/status";
 import { formatRelative } from "@/lib/time";
 
 interface RecentJobsProps {
@@ -50,11 +49,7 @@ export function RecentJobs({ jobs, loading, error, onRetry }: RecentJobsProps) {
       {
         accessorKey: "status",
         header: "Status",
-        cell: ({ row }) => (
-          <Badge tone={JOB_STATUS_TONE[row.original.status]}>
-            {JOB_STATUS_LABEL[row.original.status]}
-          </Badge>
-        ),
+        cell: ({ row }) => <StatusBadge status={row.original.status} />,
       },
       {
         accessorKey: "created_at",

--- a/dashboard/src/features/overview/components/throughput-sparkline.tsx
+++ b/dashboard/src/features/overview/components/throughput-sparkline.tsx
@@ -11,6 +11,21 @@ interface ThroughputSparklineProps {
   onRetry?: () => void;
 }
 
+function Legend() {
+  return (
+    <div className="flex items-center gap-4">
+      <span className="inline-flex items-center gap-1.5 text-[0.76rem] text-[var(--fg-muted)]">
+        <i className="size-2.5 rounded-[3px] bg-accent" />
+        runs
+      </span>
+      <span className="inline-flex items-center gap-1.5 text-[0.76rem] text-[var(--fg-muted)]">
+        <i className="size-2.5 rounded-[3px] bg-danger" />
+        failures
+      </span>
+    </div>
+  );
+}
+
 export function ThroughputSparkline({
   buckets,
   loading,
@@ -29,60 +44,64 @@ export function ThroughputSparkline({
 
   return (
     <Card>
-      <CardHeader className="flex-row items-baseline justify-between gap-4 pb-2">
+      <CardHeader className="flex-row items-center justify-between gap-4">
         <CardTitle>Throughput — last hour</CardTitle>
-        {loading ? (
-          <Skeleton className="h-4 w-24" />
-        ) : (
-          <span className="text-xs text-[var(--fg-subtle)]">
-            {formatCount(total)} runs · peak {formatCount(peak)}/min
-          </span>
-        )}
+        <div className="flex flex-wrap items-center gap-4">
+          <Legend />
+          {loading ? (
+            <Skeleton className="h-4 w-24" />
+          ) : (
+            <span className="text-[0.76rem] tabular-nums text-[var(--fg-subtle)]">
+              {formatCount(total)} runs · peak {formatCount(peak)}/min
+            </span>
+          )}
+        </div>
       </CardHeader>
       <CardContent>
         {loading ? (
-          <Skeleton className="h-20 w-full" />
+          <Skeleton className="h-[150px] w-full" />
         ) : points.length === 0 ? (
-          <div className="grid h-20 place-items-center text-xs text-[var(--fg-subtle)]">
+          <div className="grid h-[150px] place-items-center text-xs text-[var(--fg-subtle)]">
             No activity in this window
           </div>
         ) : (
-          <Sparkline buckets={points} />
+          <AreaChart buckets={points} />
         )}
       </CardContent>
     </Card>
   );
 }
 
-const SPARK_WIDTH = 800;
-const SPARK_HEIGHT = 80;
+const CHART_WIDTH = 1000;
+const CHART_HEIGHT = 150;
 
-function Sparkline({ buckets }: { buckets: TimeseriesBucket[] }) {
+function AreaChart({ buckets }: { buckets: TimeseriesBucket[] }) {
   const [hoverIdx, setHoverIdx] = useState<number | null>(null);
-  // Unique per instance so multiple sparklines don't share one gradient <defs>.
-  const gradientId = `sparkline-fill-${useId().replace(/:/g, "")}`;
+  // Unique per instance so multiple charts don't share one gradient <defs>.
+  const gradientId = `throughput-fill-${useId().replace(/:/g, "")}`;
 
   // Geometry depends only on the data — recompute on new buckets, not on hover.
-  const { areaPath, linePath } = useMemo(() => {
+  const { areaPath, runsPath, failPath } = useMemo(() => {
     const maxCount = Math.max(1, ...buckets.map((b) => b.count));
-    const step = buckets.length > 1 ? SPARK_WIDTH / (buckets.length - 1) : 0;
-    const points = buckets.map((b, i) => {
-      const x = i * step;
-      const y = SPARK_HEIGHT - (b.count / maxCount) * SPARK_HEIGHT;
-      return `${i === 0 ? "M" : "L"} ${x.toFixed(1)} ${y.toFixed(1)}`;
-    });
+    const step = buckets.length > 1 ? CHART_WIDTH / (buckets.length - 1) : 0;
+    const toY = (v: number) => CHART_HEIGHT - (v / maxCount) * (CHART_HEIGHT - 8) - 4;
+    const toPath = (field: "count" | "failure") =>
+      buckets
+        .map(
+          (b, i) => `${i === 0 ? "M" : "L"} ${(i * step).toFixed(1)} ${toY(b[field]).toFixed(1)}`,
+        )
+        .join(" ");
+    const runsPath = toPath("count");
     return {
-      areaPath: points
-        .concat([`L ${SPARK_WIDTH} ${SPARK_HEIGHT}`, `L 0 ${SPARK_HEIGHT}`, "Z"])
-        .join(" "),
-      linePath: points.join(" "),
+      runsPath,
+      failPath: toPath("failure"),
+      areaPath: `${runsPath} L ${CHART_WIDTH} ${CHART_HEIGHT} L 0 ${CHART_HEIGHT} Z`,
     };
   }, [buckets]);
 
-  const startLabel = buckets[0] ? formatRelative(buckets[0].timestamp) : "";
-  const endLabel = "now";
+  const startLabel = buckets[0] ? formatRelative(buckets[0].timestamp) : "60 min ago";
   const midBucket = buckets[Math.floor(buckets.length / 2)];
-  const midLabel = midBucket ? formatRelative(midBucket.timestamp) : "";
+  const midLabel = midBucket ? formatRelative(midBucket.timestamp) : "30 min ago";
 
   function handleMouseMove(e: React.MouseEvent<HTMLDivElement>) {
     if (buckets.length === 0) return;
@@ -98,30 +117,50 @@ function Sparkline({ buckets }: { buckets: TimeseriesBucket[] }) {
   return (
     <div
       role="img"
-      aria-label="Throughput chart with hover details"
+      aria-label="Throughput over the last hour with hover details"
       className="relative"
       onMouseMove={handleMouseMove}
       onMouseLeave={() => setHoverIdx(null)}
     >
       <svg
-        viewBox={`0 0 ${SPARK_WIDTH} ${SPARK_HEIGHT}`}
-        role="img"
-        aria-label="Throughput over the last hour"
-        className="h-20 w-full"
+        viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`}
+        className="block h-[150px] w-full"
         preserveAspectRatio="none"
       >
+        <title>Throughput over the last hour</title>
         <defs>
           <linearGradient id={gradientId} x1="0" x2="0" y1="0" y2="1">
-            <stop offset="0%" stopColor="var(--color-accent)" stopOpacity="0.3" />
-            <stop offset="100%" stopColor="var(--color-accent)" stopOpacity="0" />
+            <stop offset="0%" stopColor="var(--accent)" stopOpacity="0.32" />
+            <stop offset="100%" stopColor="var(--accent)" stopOpacity="0" />
           </linearGradient>
         </defs>
+        {[0.25, 0.5, 0.75].map((g) => (
+          <line
+            key={g}
+            x1="0"
+            x2={CHART_WIDTH}
+            y1={CHART_HEIGHT * g}
+            y2={CHART_HEIGHT * g}
+            stroke="var(--border)"
+            strokeWidth="1"
+            strokeDasharray="2 5"
+            vectorEffect="non-scaling-stroke"
+          />
+        ))}
         <path d={areaPath} fill={`url(#${gradientId})`} />
         <path
-          d={linePath}
+          d={runsPath}
           fill="none"
-          stroke="var(--color-accent)"
-          strokeWidth="1.5"
+          stroke="var(--accent)"
+          strokeWidth="2"
+          vectorEffect="non-scaling-stroke"
+        />
+        <path
+          d={failPath}
+          fill="none"
+          stroke="var(--danger)"
+          strokeWidth="1.6"
+          strokeOpacity="0.85"
           vectorEffect="non-scaling-stroke"
         />
       </svg>
@@ -133,20 +172,21 @@ function Sparkline({ buckets }: { buckets: TimeseriesBucket[] }) {
             aria-hidden
           />
           <div
-            className="pointer-events-none absolute -top-1 -translate-x-1/2 -translate-y-full whitespace-nowrap rounded-md bg-[var(--surface-3)] px-2 py-1 text-[11px] text-[var(--fg)] shadow-sm ring-1 ring-inset ring-[var(--border)]"
+            className="pointer-events-none absolute -top-1.5 -translate-x-1/2 -translate-y-full whitespace-nowrap rounded-md border border-[var(--border)] bg-[var(--surface-3)] px-2.5 py-1.5 text-[11px] text-[var(--fg)] shadow-md"
             style={{ left: `${hoverX}%` }}
           >
             <div className="text-[var(--fg-subtle)]">{formatRelative(hovered.timestamp)}</div>
             <div className="font-mono tabular-nums">
-              {formatCount(hovered.count)} runs · {formatCount(hovered.failure)} failed
+              {formatCount(hovered.count)} runs ·{" "}
+              <span className="text-danger">{formatCount(hovered.failure)} failed</span>
             </div>
           </div>
         </>
       ) : null}
-      <div className="mt-1 flex justify-between text-[10px] uppercase tracking-wider text-[var(--fg-subtle)]">
+      <div className="mt-1.5 flex justify-between font-mono text-[0.66rem] uppercase tracking-[0.06em] text-[var(--fg-subtle)]">
         <span>{startLabel}</span>
         <span>{midLabel}</span>
-        <span>{endLabel}</span>
+        <span>now</span>
       </div>
     </div>
   );

--- a/dashboard/src/features/overview/components/workers-card.tsx
+++ b/dashboard/src/features/overview/components/workers-card.tsx
@@ -1,0 +1,71 @@
+import { Server, Skull } from "lucide-react";
+import { Badge, Card, EmptyState, Skeleton } from "@/components/ui";
+import { isWorkerStale } from "@/features/workers/utils";
+import type { Worker } from "@/lib/api-types";
+import { formatRelative } from "@/lib/time";
+
+interface WorkersCardProps {
+  workers: Worker[] | undefined;
+  loading: boolean;
+}
+
+/** A compact worker roster for the Overview — id, queues, and liveness. */
+export function WorkersCard({ workers, loading }: WorkersCardProps) {
+  if (loading && !workers) return <Skeleton className="h-56 w-full" />;
+
+  const list = workers ?? [];
+  if (list.length === 0) {
+    return (
+      <Card>
+        <EmptyState
+          icon={Server}
+          title="No active workers"
+          description="Workers register when you call q.start() or run taskito worker."
+        />
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <div className="flex flex-col gap-2.5 p-[var(--pad)]">
+        {list.slice(0, 6).map((w) => {
+          const stale = isWorkerStale(w);
+          const queues = w.queues
+            .split(",")
+            .map((q) => q.trim())
+            .filter(Boolean)
+            .join(" · ");
+          return (
+            <div key={w.worker_id} className="flex items-center gap-3">
+              <span
+                className={`grid size-[30px] shrink-0 place-items-center rounded-[9px] ${
+                  stale ? "bg-danger-dim text-danger" : "bg-success-dim text-success"
+                }`}
+              >
+                {stale ? <Skull className="size-4" /> : <Server className="size-4" />}
+              </span>
+              <div className="min-w-0 flex-1">
+                <div className="truncate font-mono text-[0.78rem] text-[var(--fg)]">
+                  {w.worker_id}
+                </div>
+                <div className="truncate text-[0.72rem] text-[var(--fg-subtle)]">
+                  {queues || "no queues"}
+                </div>
+              </div>
+              {stale ? (
+                <Badge tone="danger" dot>
+                  Stale
+                </Badge>
+              ) : (
+                <span className="font-mono text-[0.74rem] tabular-nums text-[var(--fg-muted)]">
+                  {formatRelative(w.last_heartbeat)}
+                </span>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </Card>
+  );
+}

--- a/dashboard/src/features/queues/components/queues-table.tsx
+++ b/dashboard/src/features/queues/components/queues-table.tsx
@@ -1,7 +1,15 @@
 import type { ColumnDef } from "@tanstack/react-table";
 import { Box, Pause, Play } from "lucide-react";
 import { useMemo } from "react";
-import { Badge, Button, DataTable, EmptyState, ErrorState, TableSkeleton } from "@/components/ui";
+import {
+  Badge,
+  Button,
+  DataTable,
+  EmptyState,
+  ErrorState,
+  QueueBar,
+  TableSkeleton,
+} from "@/components/ui";
 import type { QueueStatsMap } from "@/lib/api-types";
 import { formatCount } from "@/lib/number";
 import { usePauseQueue, useResumeQueue } from "../hooks";
@@ -24,6 +32,8 @@ interface QueuesTableProps {
   error: Error | null;
   onRetry: () => void;
 }
+
+const NUM_CELL = "block w-full text-right font-mono text-[0.82rem] tabular-nums";
 
 export function QueuesTable({ stats, paused, loading, error, onRetry }: QueuesTableProps) {
   const rows = useMemo<QueueRow[]>(() => {
@@ -55,29 +65,43 @@ export function QueuesTable({ stats, paused, loading, error, onRetry }: QueuesTa
         cell: ({ row }) => (
           <div className="flex items-center gap-2">
             <span className="font-medium text-[var(--fg)]">{row.original.name}</span>
-            {row.original.paused ? <Badge tone="warning">Paused</Badge> : null}
+            {row.original.paused ? (
+              <Badge tone="warning" dot>
+                Paused
+              </Badge>
+            ) : null}
           </div>
+        ),
+      },
+      {
+        id: "mix",
+        header: "Mix",
+        cell: ({ row }) => (
+          <QueueBar
+            pending={row.original.pending}
+            running={row.original.running}
+            failedTotal={row.original.failedTotal}
+            className="min-w-[120px]"
+          />
         ),
       },
       {
         accessorKey: "pending",
         header: "Pending",
-        cell: ({ getValue }) => (
-          <span className="tabular-nums">{formatCount(getValue<number>())}</span>
-        ),
+        cell: ({ getValue }) => <span className={NUM_CELL}>{formatCount(getValue<number>())}</span>,
       },
       {
         accessorKey: "running",
         header: "Running",
         cell: ({ getValue }) => (
-          <span className="tabular-nums text-info">{formatCount(getValue<number>())}</span>
+          <span className={`${NUM_CELL} text-info`}>{formatCount(getValue<number>())}</span>
         ),
       },
       {
         accessorKey: "completed",
         header: "Completed",
         cell: ({ getValue }) => (
-          <span className="tabular-nums text-[var(--fg-muted)]">
+          <span className={`${NUM_CELL} text-[var(--fg-muted)]`}>
             {formatCount(getValue<number>())}
           </span>
         ),
@@ -88,9 +112,7 @@ export function QueuesTable({ stats, paused, loading, error, onRetry }: QueuesTa
         cell: ({ getValue }) => {
           const total = getValue<number>();
           return (
-            <span
-              className={`tabular-nums ${total > 0 ? "text-danger" : "text-[var(--fg-muted)]"}`}
-            >
+            <span className={`${NUM_CELL} ${total > 0 ? "text-danger" : "text-[var(--fg-muted)]"}`}>
               {formatCount(total)}
             </span>
           );
@@ -100,7 +122,9 @@ export function QueuesTable({ stats, paused, loading, error, onRetry }: QueuesTa
         id: "actions",
         header: "",
         cell: ({ row }) => (
-          <PauseResumeCell name={row.original.name} paused={row.original.paused} />
+          <div className="flex justify-end">
+            <PauseResumeCell name={row.original.name} paused={row.original.paused} />
+          </div>
         ),
       },
     ],
@@ -114,7 +138,9 @@ export function QueuesTable({ stats, paused, loading, error, onRetry }: QueuesTa
   }
 
   if (loading && rows.length === 0) {
-    return <TableSkeleton rows={6} columns={["w-32", "w-16", "w-16", "w-20", "w-20", "w-20"]} />;
+    return (
+      <TableSkeleton rows={6} columns={["w-32", "w-28", "w-16", "w-16", "w-20", "w-20", "w-20"]} />
+    );
   }
 
   if (rows.length === 0) {
@@ -141,7 +167,7 @@ function PauseResumeCell({ name, paused }: { name: string; paused: boolean }) {
   if (paused) {
     return (
       <Button
-        variant="outline"
+        variant="ghost"
         size="sm"
         onClick={(e) => {
           e.stopPropagation();
@@ -155,7 +181,7 @@ function PauseResumeCell({ name, paused }: { name: string; paused: boolean }) {
   }
   return (
     <Button
-      variant="secondary"
+      variant="ghost"
       size="sm"
       onClick={(e) => {
         e.stopPropagation();

--- a/dashboard/src/features/resources/components/resources-table.tsx
+++ b/dashboard/src/features/resources/components/resources-table.tsx
@@ -1,7 +1,13 @@
-import type { ColumnDef } from "@tanstack/react-table";
 import { Activity } from "lucide-react";
-import { useMemo } from "react";
-import { Badge, DataTable, EmptyState, ErrorState, TableSkeleton } from "@/components/ui";
+import {
+  Badge,
+  Card,
+  CardContent,
+  EmptyState,
+  ErrorState,
+  MeterBar,
+  Skeleton,
+} from "@/components/ui";
 import type { ResourceStatus } from "@/lib/api-types";
 import { resourceTone } from "@/lib/status";
 import { formatDuration } from "@/lib/time";
@@ -14,92 +20,6 @@ interface ResourcesTableProps {
 }
 
 export function ResourcesTable({ resources, loading, error, onRetry }: ResourcesTableProps) {
-  const columns = useMemo<ColumnDef<ResourceStatus>[]>(
-    () => [
-      {
-        accessorKey: "name",
-        header: "Resource",
-        cell: ({ getValue }) => (
-          <span className="font-medium text-[var(--fg)]">{getValue<string>()}</span>
-        ),
-      },
-      {
-        accessorKey: "scope",
-        header: "Scope",
-        cell: ({ getValue }) => (
-          <span className="text-xs uppercase tracking-wider text-[var(--fg-subtle)]">
-            {getValue<string>()}
-          </span>
-        ),
-      },
-      {
-        accessorKey: "health",
-        header: "Health",
-        cell: ({ getValue }) => {
-          const health = getValue<string>();
-          return <Badge tone={resourceTone(health)}>{health}</Badge>;
-        },
-      },
-      {
-        accessorKey: "init_duration_ms",
-        header: "Init",
-        cell: ({ getValue }) => (
-          <span className="text-xs tabular-nums text-[var(--fg-muted)]">
-            {formatDuration(getValue<number>())}
-          </span>
-        ),
-      },
-      {
-        accessorKey: "recreations",
-        header: "Recreations",
-        cell: ({ getValue }) => {
-          const n = getValue<number>();
-          return (
-            <span className={`tabular-nums ${n > 0 ? "text-warning" : "text-[var(--fg-muted)]"}`}>
-              {n}
-            </span>
-          );
-        },
-      },
-      {
-        id: "pool",
-        header: "Pool",
-        cell: ({ row }) => {
-          const p = row.original.pool;
-          if (!p) return <span className="text-[var(--fg-subtle)]">—</span>;
-          return (
-            <span className="text-xs tabular-nums text-[var(--fg-muted)]">
-              {p.active}/{p.size} active · {p.idle} idle
-              {p.total_timeouts > 0 ? (
-                <span className="ml-1 text-danger">· {p.total_timeouts} timeouts</span>
-              ) : null}
-            </span>
-          );
-        },
-      },
-      {
-        accessorKey: "depends_on",
-        header: "Depends on",
-        cell: ({ getValue }) => {
-          const deps = getValue<string[]>();
-          if (!deps || deps.length === 0) {
-            return <span className="text-[var(--fg-subtle)]">—</span>;
-          }
-          return (
-            <div className="flex flex-wrap gap-1">
-              {deps.map((d) => (
-                <Badge key={d} tone="neutral">
-                  {d}
-                </Badge>
-              ))}
-            </div>
-          );
-        },
-      },
-    ],
-    [],
-  );
-
   if (error) {
     return (
       <ErrorState title="Couldn't load resources" description={error.message} onRetry={onRetry} />
@@ -108,7 +28,12 @@ export function ResourcesTable({ resources, loading, error, onRetry }: Resources
 
   if (loading && !resources) {
     return (
-      <TableSkeleton rows={4} columns={["w-32", "w-16", "w-16", "w-16", "w-16", "w-40", "w-24"]} />
+      <div className="grid gap-[var(--gap)] [grid-template-columns:repeat(auto-fill,minmax(290px,1fr))]">
+        {Array.from({ length: 4 }, (_, i) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: fixed-length skeleton placeholders
+          <Skeleton key={i} className="h-44 w-full" />
+        ))}
+      </div>
     );
   }
 
@@ -122,5 +47,87 @@ export function ResourcesTable({ resources, loading, error, onRetry }: Resources
     );
   }
 
-  return <DataTable columns={columns} data={resources} rowKey={(r) => r.name} />;
+  return (
+    <div className="grid gap-[var(--gap)] [grid-template-columns:repeat(auto-fill,minmax(290px,1fr))]">
+      {resources.map((resource) => (
+        <ResourceCard key={resource.name} resource={resource} />
+      ))}
+    </div>
+  );
+}
+
+function ResourceCard({ resource }: { resource: ResourceStatus }) {
+  const { name, scope, health, depends_on, pool, init_duration_ms, recreations } = resource;
+  const util = pool && pool.size > 0 ? (pool.active / pool.size) * 100 : 0;
+
+  return (
+    <Card className="transition-shadow hover:shadow-[var(--card-hover-shadow)]">
+      <CardContent className="flex flex-col gap-3.5">
+        <div className="flex items-center justify-between gap-2.5">
+          <span className="truncate font-mono text-[0.86rem] font-semibold text-[var(--fg)]">
+            {name}
+          </span>
+          <Badge tone={resourceTone(health)} dot>
+            {health}
+          </Badge>
+        </div>
+
+        <div className="flex flex-wrap gap-1.5">
+          <Badge tone="neutral">{scope}</Badge>
+          {depends_on.map((dep) => (
+            <Badge key={dep} tone="accent">
+              ↳ {dep}
+            </Badge>
+          ))}
+        </div>
+
+        {pool ? (
+          <div className="flex flex-col gap-1.5">
+            <div className="flex items-baseline justify-between gap-2 text-xs text-[var(--fg-muted)]">
+              <span>Pool usage</span>
+              <span className="font-mono tabular-nums" title={`${pool.idle} idle`}>
+                {pool.active} / {pool.size} busy
+              </span>
+            </div>
+            <MeterBar value={util} tone={util > 85 ? "danger" : "info"} />
+          </div>
+        ) : null}
+
+        <div className="grid grid-cols-3 gap-2 border-t border-[var(--border)] pt-3">
+          <ResourceMeta label="Init" value={formatDuration(init_duration_ms)} />
+          <ResourceMeta
+            label="Recreations"
+            value={String(recreations)}
+            className={recreations > 0 ? "text-warning" : undefined}
+          />
+          <ResourceMeta
+            label="Timeouts"
+            value={pool ? String(pool.total_timeouts) : "—"}
+            className={pool && pool.total_timeouts > 0 ? "text-danger" : undefined}
+          />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function ResourceMeta({
+  label,
+  value,
+  className,
+}: {
+  label: string;
+  value: string;
+  className?: string;
+}) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span className="text-[0.68rem] uppercase tracking-wide text-[var(--fg-subtle)]">
+        {label}
+      </span>
+      <span className={`font-mono text-[0.78rem] tabular-nums ${className ?? "text-[var(--fg)]"}`}>
+        {value}
+      </span>
+    </div>
+  );
 }

--- a/dashboard/src/features/settings/components/branding-section.tsx
+++ b/dashboard/src/features/settings/components/branding-section.tsx
@@ -50,8 +50,8 @@ export function BrandingSection({ settings }: { settings: SettingsSnapshot }) {
       </CardHeader>
       <CardContent className="divide-y divide-[var(--border)]">
         <SettingRow
-          label="Dashboard title"
-          description="Shown in the sidebar header. Leave blank for the default."
+          label="Instance name"
+          description="Shown in the sidebar header and browser tab. Leave blank for the default."
           htmlFor="brand-title"
         >
           <Input
@@ -67,13 +67,23 @@ export function BrandingSection({ settings }: { settings: SettingsSnapshot }) {
           description="Hex color for buttons, active links, and highlights (e.g. #6366f1)."
           htmlFor="brand-accent"
         >
-          <Input
-            id="brand-accent"
-            placeholder="#6366f1"
-            value={accent}
-            onChange={(e) => setAccent(e.target.value)}
-            maxLength={9}
-          />
+          <div className="flex items-center gap-2">
+            <input
+              type="color"
+              aria-label="Accent color swatch"
+              value={/^#[0-9a-fA-F]{6}$/.test(accent) ? accent : "#6366f1"}
+              onChange={(e) => setAccent(e.target.value)}
+              className="size-9 shrink-0 cursor-pointer rounded-[var(--btn-radius)] border border-[var(--border-strong)] bg-transparent p-0.5"
+            />
+            <Input
+              id="brand-accent"
+              placeholder="#6366f1"
+              value={accent}
+              onChange={(e) => setAccent(e.target.value)}
+              maxLength={9}
+              className="font-mono"
+            />
+          </div>
         </SettingRow>
         <div className="flex justify-end pt-4">
           <Button onClick={onSave} disabled={!dirty || update.isPending}>

--- a/dashboard/src/features/settings/components/refresh-interval-section.tsx
+++ b/dashboard/src/features/settings/components/refresh-interval-section.tsx
@@ -1,5 +1,12 @@
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui";
-import { cn } from "@/lib/cn";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Segmented,
+  type SegmentedOption,
+} from "@/components/ui";
 import { type RefreshOption, useRefreshInterval } from "@/providers";
 import { SettingRow } from "./setting-row";
 
@@ -9,6 +16,11 @@ const OPTIONS: Array<{ value: RefreshOption; label: string; hint: string }> = [
   { value: "10s", label: "10s", hint: "Light — fewer requests" },
   { value: "off", label: "Off", hint: "Refresh manually only" },
 ];
+
+const SEGMENTS: SegmentedOption<RefreshOption>[] = OPTIONS.map(({ value, label }) => ({
+  value,
+  label,
+}));
 
 /**
  * Auto-refresh interval for all polled queries. Persisted to ``localStorage``
@@ -22,37 +34,17 @@ export function RefreshIntervalSection() {
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Refresh interval</CardTitle>
+        <CardTitle>Dashboard</CardTitle>
         <CardDescription>How often the dashboard re-polls the backend for updates.</CardDescription>
       </CardHeader>
       <CardContent>
-        <SettingRow label="Polling cadence" description={hint} htmlFor="refresh-interval">
-          <div
-            id="refresh-interval"
-            role="toolbar"
+        <SettingRow label="Auto-refresh" description={hint}>
+          <Segmented
+            options={SEGMENTS}
+            value={option}
+            onChange={setOption}
             aria-label="Refresh interval"
-            className="inline-flex items-center gap-0.5 rounded-md bg-[var(--surface-2)] p-0.5 ring-1 ring-inset ring-[var(--border)]"
-          >
-            {OPTIONS.map(({ value, label }) => {
-              const active = option === value;
-              return (
-                <button
-                  key={value}
-                  type="button"
-                  aria-pressed={active}
-                  onClick={() => setOption(value)}
-                  className={cn(
-                    "rounded-sm px-3 py-1 text-xs font-medium transition-colors",
-                    active
-                      ? "bg-[var(--surface)] text-[var(--fg)] shadow-xs"
-                      : "text-[var(--fg-subtle)] hover:text-[var(--fg)]",
-                  )}
-                >
-                  {label}
-                </button>
-              );
-            })}
-          </div>
+          />
         </SettingRow>
       </CardContent>
     </Card>

--- a/dashboard/src/features/settings/derived.ts
+++ b/dashboard/src/features/settings/derived.ts
@@ -90,7 +90,11 @@ export function useApplyAccent(): void {
     }
     root.style.setProperty("--accent", value);
     root.style.setProperty("--accent-dim", `color-mix(in oklch, ${value} 16%, transparent)`);
-    root.style.setProperty("--accent-ink", value);
+    // Ink is the accent used as small text on the dim tint (badges, segmented).
+    // It needs more contrast than the raw accent, so blend toward the theme's
+    // foreground — which darkens it in light mode and lightens it in dark mode,
+    // preserving the default --accent vs --accent-ink lightness shift.
+    root.style.setProperty("--accent-ink", `color-mix(in oklch, ${value} 72%, var(--fg))`);
     root.style.setProperty("--accent-strong", value);
     root.style.setProperty("--ring", `color-mix(in oklch, ${value} 45%, transparent)`);
     return clear;

--- a/dashboard/src/features/settings/derived.ts
+++ b/dashboard/src/features/settings/derived.ts
@@ -65,28 +65,34 @@ export function useBranding(): { title: string } {
 }
 
 /**
- * Apply the configured accent color as a CSS variable on the root
- * element. Invalid colors are silently ignored — the dashboard keeps
- * the bundled default rather than producing broken styling.
+ * Apply the configured accent color by overriding the accent token set on
+ * the root element. Invalid colors are silently ignored — the dashboard
+ * keeps the bundled emerald rather than producing broken styling.
  *
- * The dim variant (used for muted badges and hover states) is derived
- * via ``color-mix`` so the override stays coherent with the base color.
+ * We drive the base `--accent` (which `--color-accent` and every Tailwind
+ * `*-accent` utility resolve through) plus the derived `-dim`/`-ink`/
+ * `-strong`/ring variants via ``color-mix`` so the override stays coherent
+ * across badges, buttons, links, and charts.
  */
+const ACCENT_TOKENS = ["--accent", "--accent-dim", "--accent-ink", "--accent-strong", "--ring"];
+
 export function useApplyAccent(): void {
   const { data } = useSettings();
   const value = data?.[SETTING_KEYS.brandAccent]?.trim();
   useEffect(() => {
     const root = document.documentElement;
+    const clear = () => {
+      for (const token of ACCENT_TOKENS) root.style.removeProperty(token);
+    };
     if (!value || !CSS.supports("color", value)) {
-      root.style.removeProperty("--color-accent");
-      root.style.removeProperty("--color-accent-dim");
+      clear();
       return;
     }
-    root.style.setProperty("--color-accent", value);
-    root.style.setProperty("--color-accent-dim", `color-mix(in srgb, ${value} 18%, transparent)`);
-    return () => {
-      root.style.removeProperty("--color-accent");
-      root.style.removeProperty("--color-accent-dim");
-    };
+    root.style.setProperty("--accent", value);
+    root.style.setProperty("--accent-dim", `color-mix(in oklch, ${value} 16%, transparent)`);
+    root.style.setProperty("--accent-ink", value);
+    root.style.setProperty("--accent-strong", value);
+    root.style.setProperty("--ring", `color-mix(in oklch, ${value} 45%, transparent)`);
+    return clear;
   }, [value]);
 }

--- a/dashboard/src/features/system/components/interception-table.tsx
+++ b/dashboard/src/features/system/components/interception-table.tsx
@@ -1,15 +1,10 @@
-import type { ColumnDef } from "@tanstack/react-table";
 import { ListFilter } from "lucide-react";
 import { useMemo } from "react";
-import { DataTable, EmptyState, ErrorState, TableSkeleton } from "@/components/ui";
+import { Card, CardContent, EmptyState, ErrorState, Skeleton } from "@/components/ui";
 import type { InterceptionStats } from "@/lib/api-types";
 import { formatCount } from "@/lib/number";
-
-interface Row {
-  strategy: string;
-  count: number;
-  share: number;
-}
+import { TONE_VAR, type Tone } from "@/lib/status";
+import { formatDuration } from "@/lib/time";
 
 interface InterceptionTableProps {
   stats: InterceptionStats | undefined;
@@ -19,6 +14,9 @@ interface InterceptionTableProps {
 }
 
 const STRATEGY_LABEL: Record<string, string> = {
+  reconstruct: "Reconstruct",
+  passthrough: "Passthrough",
+  deny: "Deny",
   pass: "Pass",
   convert: "Convert",
   proxy: "Proxy",
@@ -26,49 +24,36 @@ const STRATEGY_LABEL: Record<string, string> = {
   reject: "Reject",
 };
 
+/** Fixed tones for known strategies; unknown keys cycle these fallbacks. */
+const STRATEGY_TONE: Record<string, Tone> = {
+  reconstruct: "accent",
+  passthrough: "info",
+  deny: "danger",
+};
+const FALLBACK_TONES: Tone[] = ["warning", "success", "info", "accent"];
+
+interface StrategySegment {
+  key: string;
+  count: number;
+  share: number;
+  tone: Tone;
+}
+
 export function InterceptionTable({ stats, loading, error, onRetry }: InterceptionTableProps) {
-  const rows = useMemo<Row[]>(() => {
+  const segments = useMemo<StrategySegment[]>(() => {
     if (!stats?.strategy_counts) return [];
-    const total = Object.values(stats.strategy_counts).reduce((sum, n) => sum + n, 0);
-    return Object.entries(stats.strategy_counts)
-      .map(([strategy, count]) => ({
-        strategy,
+    const entries = Object.entries(stats.strategy_counts).filter(([, count]) => count > 0);
+    const total = entries.reduce((sum, [, count]) => sum + count, 0);
+    let fallback = 0;
+    return entries
+      .sort((a, b) => b[1] - a[1])
+      .map(([key, count]) => ({
+        key,
         count,
         share: total > 0 ? count / total : 0,
-      }))
-      .filter((r) => r.count > 0)
-      .sort((a, b) => b.count - a.count);
+        tone: STRATEGY_TONE[key] ?? FALLBACK_TONES[fallback++ % FALLBACK_TONES.length] ?? "neutral",
+      }));
   }, [stats]);
-
-  const columns = useMemo<ColumnDef<Row>[]>(
-    () => [
-      {
-        accessorKey: "strategy",
-        header: "Strategy",
-        cell: ({ getValue }) => {
-          const key = getValue<string>();
-          return <span className="font-medium text-[var(--fg)]">{STRATEGY_LABEL[key] ?? key}</span>;
-        },
-      },
-      {
-        accessorKey: "count",
-        header: "Count",
-        cell: ({ getValue }) => (
-          <span className="tabular-nums">{formatCount(getValue<number>())}</span>
-        ),
-      },
-      {
-        accessorKey: "share",
-        header: "Share",
-        cell: ({ getValue }) => (
-          <span className="tabular-nums text-[var(--fg-muted)]">
-            {(getValue<number>() * 100).toFixed(1)}%
-          </span>
-        ),
-      },
-    ],
-    [],
-  );
 
   if (error) {
     return (
@@ -80,7 +65,7 @@ export function InterceptionTable({ stats, loading, error, onRetry }: Intercepti
     );
   }
   if (loading && !stats) {
-    return <TableSkeleton rows={4} columns={["w-28", "w-16", "w-16"]} />;
+    return <Skeleton className="h-40 w-full" />;
   }
   if (!stats || stats.total_intercepts === 0) {
     return (
@@ -91,38 +76,61 @@ export function InterceptionTable({ stats, loading, error, onRetry }: Intercepti
       />
     );
   }
+
   return (
-    <div className="flex flex-col gap-3">
-      <div className="flex flex-wrap gap-x-6 gap-y-1 text-xs text-[var(--fg-muted)]">
-        <span>
-          <span className="text-[var(--fg-subtle)]">Total intercepts:</span>{" "}
-          <span className="tabular-nums text-[var(--fg)]">
-            {formatCount(stats.total_intercepts)}
-          </span>
-        </span>
-        <span>
-          <span className="text-[var(--fg-subtle)]">Avg duration:</span>{" "}
-          <span className="tabular-nums text-[var(--fg)]">
-            {stats.avg_duration_ms.toFixed(2)}ms
-          </span>
-        </span>
-        <span>
-          <span className="text-[var(--fg-subtle)]">Max depth:</span>{" "}
-          <span className="tabular-nums text-[var(--fg)]">{stats.max_depth_reached}</span>
-        </span>
-      </div>
-      <DataTable
-        columns={columns}
-        data={rows}
-        rowKey={(r) => r.strategy}
-        empty={
-          <EmptyState
-            icon={ListFilter}
-            title="No strategy hits yet"
-            description="Strategy counts populate as arguments are walked."
-          />
-        }
-      />
+    <Card>
+      <CardContent className="flex flex-col gap-[var(--gap)]">
+        <div className="grid grid-cols-3 gap-2">
+          <Meta label="Total intercepts" value={formatCount(stats.total_intercepts)} />
+          <Meta label="Avg duration" value={formatDuration(stats.avg_duration_ms)} />
+          <Meta label="Max depth" value={String(stats.max_depth_reached)} />
+        </div>
+
+        <div className="flex flex-col gap-2.5">
+          <div className="text-xs text-[var(--fg-muted)]">Strategy breakdown</div>
+          <div className="flex h-3 overflow-hidden rounded-full bg-[var(--surface-3)]">
+            {segments.map((s) => (
+              <span
+                key={s.key}
+                className="h-full first:rounded-l-full last:rounded-r-full"
+                style={{ width: `${s.share * 100}%`, background: TONE_VAR[s.tone] }}
+                title={`${STRATEGY_LABEL[s.key] ?? s.key}: ${s.count}`}
+              />
+            ))}
+          </div>
+          <div className="flex flex-wrap gap-x-5 gap-y-2">
+            {segments.map((s) => (
+              <span
+                key={s.key}
+                className="inline-flex items-center gap-1.5 text-xs text-[var(--fg-muted)]"
+              >
+                <span
+                  className="size-2 shrink-0 rounded-full"
+                  style={{ background: TONE_VAR[s.tone] }}
+                  aria-hidden
+                />
+                {STRATEGY_LABEL[s.key] ?? s.key} ·{" "}
+                <span className="font-mono tabular-nums text-[var(--fg)]">
+                  {formatCount(s.count)}
+                </span>
+              </span>
+            ))}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function Meta({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="text-[0.68rem] uppercase tracking-wide text-[var(--fg-subtle)]">
+        {label}
+      </span>
+      <span className="font-mono text-[1.05rem] font-semibold tabular-nums text-[var(--fg)]">
+        {value}
+      </span>
     </div>
   );
 }

--- a/dashboard/src/features/system/components/proxy-table.tsx
+++ b/dashboard/src/features/system/components/proxy-table.tsx
@@ -1,9 +1,20 @@
-import type { ColumnDef } from "@tanstack/react-table";
 import { Shuffle } from "lucide-react";
 import { useMemo } from "react";
-import { DataTable, EmptyState, ErrorState, TableSkeleton } from "@/components/ui";
+import {
+  Card,
+  EmptyState,
+  ErrorState,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+  TableSkeleton,
+} from "@/components/ui";
 import type { ProxyHandlerStats, ProxyStats } from "@/lib/api-types";
 import { formatCount } from "@/lib/number";
+import { formatDuration } from "@/lib/time";
 
 interface ProxyTableProps {
   stats: ProxyStats | undefined;
@@ -12,61 +23,13 @@ interface ProxyTableProps {
   onRetry: () => void;
 }
 
+const NUM_CELL = "text-right font-mono text-[0.82rem] tabular-nums";
+
 export function ProxyTable({ stats, loading, error, onRetry }: ProxyTableProps) {
   const rows = useMemo<ProxyHandlerStats[]>(() => {
     if (!stats) return [];
     return [...stats].sort((a, b) => b.total_reconstructions - a.total_reconstructions);
   }, [stats]);
-
-  const columns = useMemo<ColumnDef<ProxyHandlerStats>[]>(
-    () => [
-      {
-        accessorKey: "handler",
-        header: "Handler",
-        cell: ({ getValue }) => (
-          <span className="font-medium text-[var(--fg)]">{getValue<string>()}</span>
-        ),
-      },
-      {
-        accessorKey: "total_reconstructions",
-        header: "Reconstructions",
-        cell: ({ getValue }) => (
-          <span className="tabular-nums">{formatCount(getValue<number>())}</span>
-        ),
-      },
-      {
-        accessorKey: "avg_duration_ms",
-        header: "Avg",
-        cell: ({ getValue }) => (
-          <span className="tabular-nums text-[var(--fg-muted)]">
-            {getValue<number>().toFixed(2)}ms
-          </span>
-        ),
-      },
-      {
-        accessorKey: "p95_duration_ms",
-        header: "p95",
-        cell: ({ getValue }) => (
-          <span className="tabular-nums text-[var(--fg-muted)]">
-            {getValue<number>().toFixed(2)}ms
-          </span>
-        ),
-      },
-      {
-        accessorKey: "total_errors",
-        header: "Errors",
-        cell: ({ getValue }) => {
-          const n = getValue<number>();
-          return (
-            <span className={`tabular-nums ${n > 0 ? "text-danger" : "text-[var(--fg-muted)]"}`}>
-              {n}
-            </span>
-          );
-        },
-      },
-    ],
-    [],
-  );
 
   if (error) {
     return (
@@ -74,20 +37,66 @@ export function ProxyTable({ stats, loading, error, onRetry }: ProxyTableProps) 
     );
   }
   if (loading && rows.length === 0) {
-    return <TableSkeleton rows={5} columns={["w-28", "w-24", "w-16", "w-16", "w-12"]} />;
+    return (
+      <TableSkeleton rows={5} columns={["w-28", "w-24", "w-16", "w-20", "w-16", "w-16", "w-16"]} />
+    );
   }
+  if (rows.length === 0) {
+    return (
+      <EmptyState
+        icon={Shuffle}
+        title="No proxy reconstructions recorded"
+        description="Proxy stats appear once tasks reconstruct non-serializable arguments."
+      />
+    );
+  }
+
   return (
-    <DataTable
-      columns={columns}
-      data={rows}
-      rowKey={(r) => r.handler}
-      empty={
-        <EmptyState
-          icon={Shuffle}
-          title="No proxy reconstructions recorded"
-          description="Proxy stats appear once tasks reconstruct non-serializable arguments."
-        />
-      }
-    />
+    <Card className="overflow-hidden">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Handler</TableHead>
+            <TableHead className="text-right">Reconstructions</TableHead>
+            <TableHead className="text-right">Errors</TableHead>
+            <TableHead className="text-right">Checksum fails</TableHead>
+            <TableHead className="text-right">Avg</TableHead>
+            <TableHead className="text-right">p95</TableHead>
+            <TableHead className="text-right">Max</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {rows.map((p) => (
+            <TableRow key={p.handler}>
+              <TableCell className="font-mono text-[0.82rem] font-medium">{p.handler}</TableCell>
+              <TableCell className={NUM_CELL}>{formatCount(p.total_reconstructions)}</TableCell>
+              <TableCell
+                className={`${NUM_CELL} ${
+                  p.total_errors > 0 ? "text-danger" : "text-[var(--fg-muted)]"
+                }`}
+              >
+                {p.total_errors}
+              </TableCell>
+              <TableCell
+                className={`${NUM_CELL} ${
+                  p.total_checksum_failures > 0 ? "text-warning" : "text-[var(--fg-muted)]"
+                }`}
+              >
+                {p.total_checksum_failures}
+              </TableCell>
+              <TableCell className={`${NUM_CELL} text-[var(--fg-muted)]`}>
+                {formatDuration(p.avg_duration_ms)}
+              </TableCell>
+              <TableCell className={`${NUM_CELL} text-[var(--fg-muted)]`}>
+                {formatDuration(p.p95_duration_ms)}
+              </TableCell>
+              <TableCell className={`${NUM_CELL} text-[var(--fg-subtle)]`}>
+                {formatDuration(p.max_duration_ms)}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </Card>
   );
 }

--- a/dashboard/src/features/tasks/components/task-list-table.tsx
+++ b/dashboard/src/features/tasks/components/task-list-table.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import {
   Badge,
   Button,
+  Card,
   EmptyState,
   Sheet,
   SheetContent,
@@ -13,12 +14,15 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui";
+import { formatDuration } from "@/lib/time";
 import type { TaskEntry } from "../types";
 import { TaskOverrideForm } from "./task-override-form";
 
 interface Props {
   tasks: TaskEntry[];
 }
+
+const numCell = "text-right font-mono text-[0.82rem] tabular-nums";
 
 export function TaskListTable({ tasks }: Props) {
   const [editing, setEditing] = useState<TaskEntry | null>(null);
@@ -35,74 +39,67 @@ export function TaskListTable({ tasks }: Props) {
 
   return (
     <>
-      <div className="overflow-x-auto rounded-lg border border-[var(--border)] bg-[var(--surface-1)]">
+      <Card className="overflow-x-auto">
         <Table>
           <TableHeader>
             <TableRow>
               <TableHead>Task</TableHead>
               <TableHead>Queue</TableHead>
+              <TableHead className="text-right">Priority</TableHead>
+              <TableHead className="text-right">Max retries</TableHead>
+              <TableHead className="text-right">Timeout</TableHead>
               <TableHead>Rate limit</TableHead>
-              <TableHead>Concurrency</TableHead>
-              <TableHead>Retries</TableHead>
-              <TableHead>Timeout</TableHead>
-              <TableHead>Override</TableHead>
-              <TableHead className="w-24" />
+              <TableHead className="text-right">Config</TableHead>
+              <TableHead className="w-20" />
             </TableRow>
           </TableHeader>
           <TableBody>
-            {tasks.map((task) => (
-              <TableRow key={task.name}>
-                <TableCell className="font-mono text-xs">{task.name}</TableCell>
-                <TableCell>
-                  <Badge tone="neutral">{task.queue}</Badge>
-                </TableCell>
-                <TableCell>
-                  <EffectiveCell
-                    effective={task.effective.rate_limit}
-                    decoratorDefault={task.defaults.rate_limit}
-                    formatter={(v) => (v == null ? "—" : String(v))}
-                  />
-                </TableCell>
-                <TableCell>
-                  <EffectiveCell
-                    effective={task.effective.max_concurrent}
-                    decoratorDefault={task.defaults.max_concurrent}
-                    formatter={(v) => (v == null ? "—" : String(v))}
-                  />
-                </TableCell>
-                <TableCell>
-                  <EffectiveCell
-                    effective={task.effective.max_retries}
-                    decoratorDefault={task.defaults.max_retries}
-                    formatter={(v) => String(v)}
-                  />
-                </TableCell>
-                <TableCell>
-                  <EffectiveCell
-                    effective={task.effective.timeout}
-                    decoratorDefault={task.defaults.timeout}
-                    formatter={(v) => `${v}s`}
-                  />
-                </TableCell>
-                <TableCell>
-                  {task.paused ? (
-                    <Badge tone="warning">Paused</Badge>
-                  ) : task.override ? (
-                    <Badge tone="info">Override</Badge>
-                  ) : (
-                    <span className="text-[11px] text-[var(--fg-subtle)]">Default</span>
-                  )}
-                </TableCell>
-                <TableCell>
-                  <Button variant="ghost" size="sm" onClick={() => setEditing(task)}>
-                    Edit
-                  </Button>
-                </TableCell>
-              </TableRow>
-            ))}
+            {tasks.map((task) => {
+              const rateLimit = task.effective.rate_limit;
+              return (
+                <TableRow key={task.name}>
+                  <TableCell className="font-mono text-[0.82rem] font-medium text-[var(--fg)]">
+                    {task.name}
+                  </TableCell>
+                  <TableCell className="text-[var(--fg-muted)]">{task.queue}</TableCell>
+                  <TableCell className={numCell}>{task.effective.priority}</TableCell>
+                  <TableCell className={`${numCell} text-[var(--fg-muted)]`}>
+                    {task.effective.max_retries}
+                  </TableCell>
+                  <TableCell className={`${numCell} text-[var(--fg-muted)]`}>
+                    {formatDuration(task.effective.timeout * 1000)}
+                  </TableCell>
+                  <TableCell>
+                    {rateLimit ? (
+                      <Badge tone="warning">{rateLimit}</Badge>
+                    ) : (
+                      <span className="text-[var(--fg-subtle)]">—</span>
+                    )}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    {task.paused ? (
+                      <Badge tone="warning" dot>
+                        Paused
+                      </Badge>
+                    ) : task.override ? (
+                      <Badge tone="info" dot>
+                        Override
+                      </Badge>
+                    ) : (
+                      <span className="text-[0.78rem] text-[var(--fg-subtle)]">default</span>
+                    )}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <Button variant="ghost" size="sm" onClick={() => setEditing(task)}>
+                      Edit
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              );
+            })}
           </TableBody>
         </Table>
-      </div>
+      </Card>
 
       <Sheet open={editing !== null} onOpenChange={(open) => !open && setEditing(null)}>
         <SheetContent side="right" className="w-full sm:max-w-md overflow-y-auto">
@@ -110,23 +107,5 @@ export function TaskListTable({ tasks }: Props) {
         </SheetContent>
       </Sheet>
     </>
-  );
-}
-
-interface CellProps<T> {
-  effective: T;
-  decoratorDefault: T;
-  formatter: (v: T) => string;
-}
-
-function EffectiveCell<T>({ effective, decoratorDefault, formatter }: CellProps<T>) {
-  const overridden = effective !== decoratorDefault;
-  return (
-    <span
-      className={`font-mono text-xs ${overridden ? "text-accent" : "text-[var(--fg-muted)]"}`}
-      title={overridden ? `default: ${formatter(decoratorDefault)}` : undefined}
-    >
-      {formatter(effective)}
-    </span>
   );
 }

--- a/dashboard/src/features/webhooks/components/create-webhook-dialog.tsx
+++ b/dashboard/src/features/webhooks/components/create-webhook-dialog.tsx
@@ -10,6 +10,8 @@ import {
   DialogTitle,
   DialogTrigger,
   Input,
+  Stepper,
+  Switch,
 } from "@/components/ui";
 import { ApiError } from "@/lib/api-client";
 import { useCreateWebhook } from "../hooks";
@@ -18,6 +20,10 @@ import { EventTypeMultiSelect } from "./event-type-multi-select";
 import { SecretReveal } from "./secret-reveal";
 import { TaskFilterInput } from "./task-filter-input";
 
+const DEFAULT_RETRIES = 3;
+const DEFAULT_TIMEOUT = 10;
+const DEFAULT_BACKOFF = 2;
+
 export function CreateWebhookDialog() {
   const [open, setOpen] = useState(false);
   const [url, setUrl] = useState("");
@@ -25,6 +31,9 @@ export function CreateWebhookDialog() {
   const [events, setEvents] = useState<string[]>([]);
   const [taskFilter, setTaskFilter] = useState<string[] | null>(null);
   const [generateSecret, setGenerateSecret] = useState(true);
+  const [maxRetries, setMaxRetries] = useState(DEFAULT_RETRIES);
+  const [timeoutSeconds, setTimeoutSeconds] = useState(DEFAULT_TIMEOUT);
+  const [retryBackoff, setRetryBackoff] = useState(DEFAULT_BACKOFF);
   const [createdWebhook, setCreatedWebhook] = useState<Webhook | null>(null);
   const create = useCreateWebhook();
 
@@ -34,6 +43,9 @@ export function CreateWebhookDialog() {
     setEvents([]);
     setTaskFilter(null);
     setGenerateSecret(true);
+    setMaxRetries(DEFAULT_RETRIES);
+    setTimeoutSeconds(DEFAULT_TIMEOUT);
+    setRetryBackoff(DEFAULT_BACKOFF);
     setCreatedWebhook(null);
     create.reset();
   }
@@ -52,6 +64,9 @@ export function CreateWebhookDialog() {
         events,
         task_filter: taskFilter,
         generate_secret: generateSecret,
+        max_retries: maxRetries,
+        timeout_seconds: timeoutSeconds,
+        retry_backoff: retryBackoff,
       },
       { onSuccess: (webhook) => setCreatedWebhook(webhook) },
     );
@@ -78,12 +93,19 @@ export function CreateWebhookDialog() {
           <form onSubmit={onSubmit} className="flex flex-col gap-4">
             <DialogHeader>
               <DialogTitle>New webhook</DialogTitle>
-              <DialogDescription>
-                Subscribe an HTTP endpoint to job lifecycle events.
-              </DialogDescription>
+              <DialogDescription>Push events to an endpoint you control.</DialogDescription>
             </DialogHeader>
+            <label htmlFor="webhook-desc" className="flex flex-col gap-1.5 text-sm">
+              <span className="font-medium">Description</span>
+              <Input
+                id="webhook-desc"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="What is this for?"
+              />
+            </label>
             <label htmlFor="webhook-url" className="flex flex-col gap-1.5 text-sm">
-              <span className="font-medium">URL</span>
+              <span className="font-medium">Endpoint URL</span>
               <Input
                 id="webhook-url"
                 type="url"
@@ -91,15 +113,6 @@ export function CreateWebhookDialog() {
                 onChange={(e) => setUrl(e.target.value)}
                 placeholder="https://your-service.example.com/hooks"
                 required
-              />
-            </label>
-            <label htmlFor="webhook-desc" className="flex flex-col gap-1.5 text-sm">
-              <span className="font-medium">Description</span>
-              <Input
-                id="webhook-desc"
-                value={description}
-                onChange={(e) => setDescription(e.target.value)}
-                placeholder="Optional — e.g. ops failures"
               />
             </label>
             <div className="flex flex-col gap-1.5 text-sm">
@@ -110,14 +123,50 @@ export function CreateWebhookDialog() {
               </span>
             </div>
             <TaskFilterInput value={taskFilter} onChange={setTaskFilter} />
-            <label className="flex items-center gap-2 text-sm">
-              <input
-                type="checkbox"
+            <div className="grid grid-cols-3 gap-3">
+              <div className="flex flex-col gap-1.5 text-sm">
+                <span className="font-medium">Max retries</span>
+                <Stepper
+                  value={maxRetries}
+                  onChange={setMaxRetries}
+                  min={0}
+                  aria-label="max retries"
+                />
+              </div>
+              <div className="flex flex-col gap-1.5 text-sm">
+                <span className="font-medium">Timeout</span>
+                <Stepper
+                  value={timeoutSeconds}
+                  onChange={setTimeoutSeconds}
+                  min={1}
+                  format={(v) => `${v}s`}
+                  aria-label="timeout seconds"
+                />
+              </div>
+              <div className="flex flex-col gap-1.5 text-sm">
+                <span className="font-medium">Backoff ×</span>
+                <Stepper
+                  value={retryBackoff}
+                  onChange={setRetryBackoff}
+                  min={1}
+                  step={0.5}
+                  aria-label="retry backoff"
+                />
+              </div>
+            </div>
+            <div className="flex items-center justify-between gap-4 border-t border-[var(--border)] pt-4">
+              <div className="flex flex-col gap-1">
+                <span className="text-sm font-medium">Generate signing secret</span>
+                <span className="text-xs text-[var(--fg-subtle)]">
+                  HMAC-sign every payload so receivers can verify it. Shown once on create.
+                </span>
+              </div>
+              <Switch
                 checked={generateSecret}
-                onChange={(e) => setGenerateSecret(e.target.checked)}
+                onCheckedChange={setGenerateSecret}
+                aria-label="Generate signing secret"
               />
-              Auto-generate a signing secret (HMAC-SHA256)
-            </label>
+            </div>
             {errorMessage ? (
               <div
                 role="alert"

--- a/dashboard/src/features/webhooks/components/secret-reveal.tsx
+++ b/dashboard/src/features/webhooks/components/secret-reveal.tsx
@@ -1,6 +1,6 @@
-import { Check, Copy, Eye, EyeOff, KeyRound } from "lucide-react";
+import { Check, Copy, Eye, EyeOff, KeyRound, Shield } from "lucide-react";
 import { useState } from "react";
-import { Button } from "@/components/ui";
+import { Button, Callout } from "@/components/ui";
 
 interface Props {
   secret: string;
@@ -28,37 +28,43 @@ export function SecretReveal({ secret, hint }: Props) {
   }
 
   return (
-    <div className="flex flex-col gap-2 rounded-md border border-[var(--border)] bg-[var(--surface-2)] p-3">
-      <div className="flex items-center gap-2 text-xs font-medium text-[var(--fg)]">
-        <KeyRound className="size-3.5" aria-hidden />
-        {hint ?? "Signing secret"}
+    <div className="flex flex-col gap-3">
+      <Callout tone="warning" icon={<Shield aria-hidden />}>
+        For security, taskito stores only a hash of this secret. If you lose it you'll need to
+        rotate to a new one.
+      </Callout>
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center gap-2 text-xs font-medium text-[var(--fg)]">
+          <KeyRound className="size-3.5" aria-hidden />
+          {hint ?? "Signing secret"}
+        </div>
+        <div className="flex items-center gap-2 rounded-md border border-[var(--border)] bg-[var(--bg-subtle)] p-1.5">
+          <code className="grow break-all px-1.5 font-mono text-xs">
+            {shown ? secret : "•".repeat(Math.min(secret.length, 48))}
+          </code>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            aria-label={shown ? "Hide secret" : "Show secret"}
+            onClick={() => setShown((v) => !v)}
+          >
+            {shown ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            aria-label="Copy secret"
+            onClick={copyToClipboard}
+          >
+            {copied ? <Check className="size-4 text-success" /> : <Copy className="size-4" />}
+          </Button>
+        </div>
+        <p className="text-[11px] text-[var(--fg-subtle)]">
+          Store this securely — it will not be shown again.
+        </p>
       </div>
-      <div className="flex items-center gap-2">
-        <code className="grow rounded bg-[var(--bg)] px-2 py-1.5 text-xs font-mono break-all">
-          {shown ? secret : "•".repeat(Math.min(secret.length, 48))}
-        </code>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          aria-label={shown ? "Hide secret" : "Show secret"}
-          onClick={() => setShown((v) => !v)}
-        >
-          {shown ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
-        </Button>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          aria-label="Copy secret"
-          onClick={copyToClipboard}
-        >
-          {copied ? <Check className="size-4 text-success" /> : <Copy className="size-4" />}
-        </Button>
-      </div>
-      <p className="text-[11px] text-[var(--fg-subtle)]">
-        Store this securely — it will not be shown again.
-      </p>
     </div>
   );
 }

--- a/dashboard/src/features/webhooks/components/webhook-list-table.tsx
+++ b/dashboard/src/features/webhooks/components/webhook-list-table.tsx
@@ -1,14 +1,7 @@
-import { Webhook as WebhookIcon } from "lucide-react";
-import {
-  Badge,
-  EmptyState,
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui";
+import { Send, Shield, Webhook as WebhookIcon } from "lucide-react";
+import { Badge, Button, EmptyState, LiveDot, Switch } from "@/components/ui";
+import { formatRelative } from "@/lib/time";
+import { useTestWebhook, useUpdateWebhook } from "../hooks";
 import type { Webhook } from "../types";
 import { WebhookRowActions } from "./webhook-row-actions";
 
@@ -28,84 +21,92 @@ export function WebhookListTable({ webhooks }: Props) {
   }
 
   return (
-    <div className="overflow-x-auto rounded-lg border border-[var(--border)] bg-[var(--surface-1)]">
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead>URL</TableHead>
-            <TableHead>Events</TableHead>
-            <TableHead>Task filter</TableHead>
-            <TableHead>Retries</TableHead>
-            <TableHead>Status</TableHead>
-            <TableHead className="w-12" />
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {webhooks.map((wh) => (
-            <TableRow key={wh.id}>
-              <TableCell className="max-w-md">
-                <div className="flex flex-col">
-                  <span className="font-mono text-xs break-all">{wh.url}</span>
-                  {wh.description ? (
-                    <span className="text-[11px] text-[var(--fg-subtle)]">{wh.description}</span>
-                  ) : null}
-                </div>
-              </TableCell>
-              <TableCell>
-                {wh.events.length === 0 ? (
-                  <Badge tone="neutral">All events</Badge>
-                ) : (
-                  <div className="flex flex-wrap gap-1">
-                    {wh.events.slice(0, 3).map((event) => (
-                      <Badge key={event} tone="info" className="font-mono text-[10px]">
-                        {event}
-                      </Badge>
-                    ))}
-                    {wh.events.length > 3 ? (
-                      <Badge tone="neutral" className="text-[10px]">
-                        +{wh.events.length - 3} more
-                      </Badge>
-                    ) : null}
-                  </div>
-                )}
-              </TableCell>
-              <TableCell>
-                {wh.task_filter === null ? (
-                  <span className="text-xs text-[var(--fg-subtle)]">All tasks</span>
-                ) : wh.task_filter.length === 0 ? (
-                  <Badge tone="danger">Disabled</Badge>
-                ) : (
-                  <div className="flex flex-wrap gap-1">
-                    {wh.task_filter.slice(0, 2).map((task) => (
-                      <Badge key={task} tone="neutral" className="font-mono text-[10px]">
-                        {task}
-                      </Badge>
-                    ))}
-                    {wh.task_filter.length > 2 ? (
-                      <Badge tone="neutral" className="text-[10px]">
-                        +{wh.task_filter.length - 2}
-                      </Badge>
-                    ) : null}
-                  </div>
-                )}
-              </TableCell>
-              <TableCell className="text-xs text-[var(--fg-muted)]">
-                {wh.max_retries}× / {wh.timeout_seconds}s
-              </TableCell>
-              <TableCell>
-                {wh.enabled ? (
-                  <Badge tone="success">Enabled</Badge>
-                ) : (
-                  <Badge tone="neutral">Disabled</Badge>
-                )}
-              </TableCell>
-              <TableCell>
-                <WebhookRowActions webhook={wh} />
-              </TableCell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+    <div className="grid gap-[var(--gap)] [grid-template-columns:repeat(auto-fill,minmax(290px,1fr))]">
+      {webhooks.map((wh) => (
+        <WebhookCard key={wh.id} webhook={wh} />
+      ))}
+    </div>
+  );
+}
+
+function WebhookCard({ webhook }: { webhook: Webhook }) {
+  const update = useUpdateWebhook();
+  const test = useTestWebhook();
+
+  const events = webhook.events;
+  const shownEvents = events.slice(0, 4);
+  const extraEvents = events.length - shownEvents.length;
+
+  return (
+    <div
+      className={`flex flex-col rounded-[var(--card-radius)] border border-[var(--border)] bg-[var(--surface)] shadow-[var(--card-shadow)] transition-shadow hover:shadow-[var(--card-hover-shadow)] ${
+        webhook.enabled ? "" : "opacity-60"
+      }`}
+    >
+      <div className="flex flex-col gap-3 p-[var(--pad)]">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div className="font-semibold text-[0.92rem] leading-snug">
+              {webhook.description || "Untitled webhook"}
+            </div>
+            <div className="truncate font-mono text-[0.74rem] text-[var(--fg-subtle)]">
+              {webhook.url}
+            </div>
+          </div>
+          <div className="flex shrink-0 items-center gap-1">
+            <Switch
+              checked={webhook.enabled}
+              disabled={update.isPending}
+              aria-label={webhook.enabled ? "Disable webhook" : "Enable webhook"}
+              onCheckedChange={(enabled) => update.mutate({ id: webhook.id, input: { enabled } })}
+            />
+            <WebhookRowActions webhook={webhook} />
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-1.5">
+          {events.length === 0 ? (
+            <Badge tone="accent">all events</Badge>
+          ) : (
+            <>
+              {shownEvents.map((event) => (
+                <Badge key={event} tone="neutral" className="font-mono text-[10px]">
+                  {event}
+                </Badge>
+              ))}
+              {extraEvents > 0 ? (
+                <Badge tone="neutral" className="text-[10px]">
+                  +{extraEvents}
+                </Badge>
+              ) : null}
+            </>
+          )}
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between gap-2 border-t border-[var(--border)] px-[var(--pad)] py-3">
+        <span className="inline-flex items-center gap-2 text-[0.74rem] text-[var(--fg-muted)]">
+          <LiveDot tone={webhook.enabled ? "success" : "danger"} pulse={false} />
+          created {formatRelative(webhook.created_at)}
+        </span>
+        <div className="flex items-center gap-3">
+          {webhook.has_secret ? (
+            <span className="inline-flex items-center gap-1 text-[0.72rem] text-[var(--fg-subtle)]">
+              <Shield className="size-3.5" aria-hidden />
+              signed
+            </span>
+          ) : null}
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => test.mutate(webhook.id)}
+            disabled={test.isPending || !webhook.enabled}
+          >
+            <Send className="size-3.5" aria-hidden />
+            Test
+          </Button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/dashboard/src/features/webhooks/components/webhook-row-actions.tsx
+++ b/dashboard/src/features/webhooks/components/webhook-row-actions.tsx
@@ -1,14 +1,5 @@
 import { Link } from "@tanstack/react-router";
-import {
-  Eye,
-  History,
-  MoreHorizontal,
-  Power,
-  PowerOff,
-  RotateCcw,
-  Send,
-  Trash2,
-} from "lucide-react";
+import { Eye, History, MoreHorizontal, RotateCcw, Trash2 } from "lucide-react";
 import { useState } from "react";
 import {
   Button,
@@ -25,7 +16,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui";
 import { DestructiveConfirmDialog } from "@/components/ui/destructive-confirm-dialog";
-import { useDeleteWebhook, useRotateSecret, useTestWebhook, useUpdateWebhook } from "../hooks";
+import { useDeleteWebhook, useRotateSecret } from "../hooks";
 import type { Webhook } from "../types";
 import { SecretReveal } from "./secret-reveal";
 
@@ -34,21 +25,12 @@ interface Props {
 }
 
 export function WebhookRowActions({ webhook }: Props) {
-  const update = useUpdateWebhook();
   const remove = useDeleteWebhook();
   const rotate = useRotateSecret();
-  const test = useTestWebhook();
 
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [confirmRotate, setConfirmRotate] = useState(false);
   const [revealedSecret, setRevealedSecret] = useState<string | null>(null);
-
-  function onToggleEnabled() {
-    update.mutate({
-      id: webhook.id,
-      input: { enabled: !webhook.enabled },
-    });
-  }
 
   function onRotate() {
     rotate.mutate(webhook.id, {
@@ -75,23 +57,6 @@ export function WebhookRowActions({ webhook }: Props) {
             >
               <History aria-hidden /> View deliveries
             </Link>
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            onClick={() => test.mutate(webhook.id)}
-            disabled={test.isPending || !webhook.enabled}
-          >
-            <Send aria-hidden /> Send test
-          </DropdownMenuItem>
-          <DropdownMenuItem onClick={onToggleEnabled} disabled={update.isPending}>
-            {webhook.enabled ? (
-              <>
-                <PowerOff aria-hidden /> Disable
-              </>
-            ) : (
-              <>
-                <Power aria-hidden /> Enable
-              </>
-            )}
           </DropdownMenuItem>
           <DropdownMenuItem onClick={() => setConfirmRotate(true)}>
             <RotateCcw aria-hidden /> Rotate secret

--- a/dashboard/src/features/workers/components/workers-table.tsx
+++ b/dashboard/src/features/workers/components/workers-table.tsx
@@ -3,10 +3,8 @@ import { Server } from "lucide-react";
 import { useMemo } from "react";
 import { Badge, DataTable, EmptyState, ErrorState, TableSkeleton } from "@/components/ui";
 import type { Worker } from "@/lib/api-types";
-import { cn } from "@/lib/cn";
 import { formatRelative } from "@/lib/time";
-
-const STALE_AFTER_MS = 30_000;
+import { isWorkerStale } from "../utils";
 
 interface WorkersTableProps {
   workers: Worker[] | undefined;
@@ -14,6 +12,9 @@ interface WorkersTableProps {
   error: Error | null;
   onRetry: () => void;
 }
+
+const TIME_CELL =
+  "block w-full text-right font-mono text-[0.82rem] tabular-nums text-[var(--fg-muted)]";
 
 export function WorkersTable({ workers, loading, error, onRetry }: WorkersTableProps) {
   const columns = useMemo<ColumnDef<Worker>[]>(
@@ -29,8 +30,7 @@ export function WorkersTable({ workers, loading, error, onRetry }: WorkersTableP
         accessorKey: "queues",
         header: "Queues",
         cell: ({ getValue }) => {
-          const raw = getValue<string>();
-          const parts = raw
+          const parts = getValue<string>()
             .split(",")
             .map((s) => s.trim())
             .filter(Boolean);
@@ -46,35 +46,6 @@ export function WorkersTable({ workers, loading, error, onRetry }: WorkersTableP
         },
       },
       {
-        accessorKey: "last_heartbeat",
-        header: "Heartbeat",
-        cell: ({ getValue }) => {
-          const ts = getValue<number>();
-          const stale = Date.now() - ts > STALE_AFTER_MS;
-          return (
-            <div className="flex items-center gap-2">
-              <span
-                className={cn(
-                  "size-2 rounded-full",
-                  stale ? "bg-warning" : "bg-success animate-pulse",
-                )}
-                aria-hidden
-              />
-              <span className="text-xs text-[var(--fg-muted)]">{formatRelative(ts)}</span>
-            </div>
-          );
-        },
-      },
-      {
-        accessorKey: "registered_at",
-        header: "Registered",
-        cell: ({ getValue }) => (
-          <span className="text-xs text-[var(--fg-muted)]">
-            {formatRelative(getValue<number>())}
-          </span>
-        ),
-      },
-      {
         accessorKey: "tags",
         header: "Tags",
         cell: ({ getValue }) => {
@@ -82,6 +53,40 @@ export function WorkersTable({ workers, loading, error, onRetry }: WorkersTableP
           if (!tags) return <span className="text-[var(--fg-subtle)]">—</span>;
           return <span className="text-xs text-[var(--fg-muted)]">{tags}</span>;
         },
+      },
+      {
+        accessorKey: "registered_at",
+        header: "Registered",
+        cell: ({ getValue }) => (
+          <span className={TIME_CELL}>{formatRelative(getValue<number>())}</span>
+        ),
+      },
+      {
+        accessorKey: "last_heartbeat",
+        header: "Last heartbeat",
+        cell: ({ getValue }) => (
+          <span className={TIME_CELL}>{formatRelative(getValue<number>())}</span>
+        ),
+      },
+      {
+        id: "status",
+        header: "Status",
+        // Recompute staleness against the wall clock on every render so a
+        // worker ages from Online to Stale as its heartbeat goes cold (the
+        // query refetches on the user interval, re-rendering this table).
+        cell: ({ row }) => (
+          <div className="flex justify-end">
+            {isWorkerStale(row.original) ? (
+              <Badge tone="danger" dot>
+                Stale
+              </Badge>
+            ) : (
+              <Badge tone="success" dot>
+                Online
+              </Badge>
+            )}
+          </div>
+        ),
       },
     ],
     [],
@@ -94,7 +99,7 @@ export function WorkersTable({ workers, loading, error, onRetry }: WorkersTableP
   }
 
   if (loading && !workers) {
-    return <TableSkeleton rows={4} columns={["w-32", "w-40", "w-24", "w-24", "w-20"]} />;
+    return <TableSkeleton rows={4} columns={["w-32", "w-40", "w-24", "w-24", "w-24", "w-20"]} />;
   }
 
   if (!workers || workers.length === 0) {

--- a/dashboard/src/features/workers/index.ts
+++ b/dashboard/src/features/workers/index.ts
@@ -1,2 +1,3 @@
 export * from "./components";
 export * from "./hooks";
+export * from "./utils";

--- a/dashboard/src/features/workers/utils.ts
+++ b/dashboard/src/features/workers/utils.ts
@@ -1,0 +1,13 @@
+import type { Worker } from "@/lib/api-types";
+
+/** A worker is "stale" once its last heartbeat is older than this. */
+export const WORKER_STALE_AFTER_MS = 30_000;
+
+/**
+ * Whether a worker has missed its heartbeat window. Computed against a
+ * caller-supplied `now` so callers that re-render on a clock tick keep the
+ * status fresh (the heartbeat ages relative to wall-clock, not a frozen ref).
+ */
+export function isWorkerStale(worker: Worker, now: number = Date.now()): boolean {
+  return now - worker.last_heartbeat > WORKER_STALE_AFTER_MS;
+}

--- a/dashboard/src/globals.css
+++ b/dashboard/src/globals.css
@@ -1,69 +1,122 @@
 @import "tailwindcss";
 
 /*
-  Design tokens — Supabase/Planetscale-ish.
+  taskito — "Friendly ops" design tokens.
 
-  - Airy, data-forward, soft dividers over hard borders
-  - Single emerald accent (soft enough for extended screen time)
-  - Inter for UI, JetBrains Mono for code/IDs
-  - Light + dark paired; dark is the daily driver
+  Warm paper neutrals (not cold blue-gray), emerald as the healthy-queue
+  signal, IBM Plex (sans for UI, mono for numbers/IDs, serif for titles),
+  structured-but-soft surfaces. Light + dark paired; theme flips `html.dark`.
+
+  The "warm" vibe and "regular" density are baked in directly — every value
+  the prototype exposed behind a switcher is hard-coded here as its default.
 */
 
 @theme {
-  --font-sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-  --font-mono: "JetBrains Mono", "Fira Code", "SF Mono", Menlo, monospace;
+  --font-sans: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-mono: "IBM Plex Mono", "SF Mono", Menlo, monospace;
+  --font-serif: "IBM Plex Serif", Georgia, serif;
 
-  --radius-sm: 0.375rem;
+  --radius-sm: 0.3rem;
   --radius-md: 0.5rem;
-  --radius-lg: 0.75rem;
-
-  /* accent (emerald) */
-  --color-accent: oklch(0.72 0.17 162);
-  --color-accent-fg: oklch(0.22 0.04 160);
-  --color-accent-dim: oklch(0.72 0.17 162 / 0.18);
-
-  /* status semantics */
-  --color-success: oklch(0.72 0.17 162);
-  --color-success-dim: oklch(0.72 0.17 162 / 0.18);
-  --color-warning: oklch(0.8 0.14 75);
-  --color-warning-dim: oklch(0.8 0.14 75 / 0.18);
-  --color-danger: oklch(0.68 0.22 22);
-  --color-danger-dim: oklch(0.68 0.22 22 / 0.18);
-  --color-info: oklch(0.72 0.13 232);
-  --color-info-dim: oklch(0.72 0.13 232 / 0.18);
+  --radius-lg: 0.875rem;
 }
 
-/* Light theme (default) */
+/* ---- Light (default) : warm paper -------------------------------------- */
 :root {
-  --bg: oklch(0.985 0.003 240);
-  --bg-subtle: oklch(0.97 0.004 240);
-  --surface: oklch(1 0 0);
-  --surface-2: oklch(0.98 0.003 240);
-  --surface-3: oklch(0.955 0.004 240);
-  --fg: oklch(0.22 0.015 240);
-  --fg-muted: oklch(0.48 0.015 240);
-  --fg-subtle: oklch(0.62 0.012 240);
-  --border: oklch(0.92 0.005 240);
-  --border-strong: oklch(0.86 0.007 240);
-  --ring: oklch(0.72 0.17 162 / 0.4);
+  --bg: oklch(0.984 0.007 84);
+  --bg-subtle: oklch(0.965 0.009 84);
+  --surface: oklch(0.998 0.003 84);
+  --surface-2: oklch(0.96 0.009 84);
+  --surface-3: oklch(0.935 0.011 82);
+  --fg: oklch(0.275 0.016 62);
+  --fg-muted: oklch(0.475 0.015 62);
+  --fg-subtle: oklch(0.6 0.013 64);
+  --border: oklch(0.9 0.011 80);
+  --border-strong: oklch(0.83 0.015 76);
+  --shadow-warm: 28 25% 12%;
+
+  /* accent — emerald, the brand / healthy signal */
+  --accent: oklch(0.6 0.13 158);
+  --accent-strong: oklch(0.53 0.15 158);
+  --accent-ink: oklch(0.46 0.13 158);
+  --accent-dim: oklch(0.6 0.13 158 / 0.12);
+  --accent-fg: oklch(0.99 0.01 158);
+  --ring: oklch(0.6 0.13 158 / 0.45);
+
+  /* status — warmed; -dim is the same color at the light tint alpha (0.12) */
+  --success: oklch(0.55 0.13 158);
+  --success-dim: oklch(0.55 0.13 158 / 0.12);
+  --warning: oklch(0.62 0.14 72);
+  --warning-dim: oklch(0.62 0.14 72 / 0.12);
+  --danger: oklch(0.56 0.18 28);
+  --danger-dim: oklch(0.56 0.18 28 / 0.12);
+  --info: oklch(0.56 0.12 236);
+  --info-dim: oklch(0.56 0.12 236 / 0.12);
 }
 
-/* Dark theme */
+/* ---- Dark : warm espresso ---------------------------------------------- */
 html.dark {
-  --bg: oklch(0.17 0.012 240);
-  --bg-subtle: oklch(0.195 0.013 240);
-  --surface: oklch(0.205 0.014 240);
-  --surface-2: oklch(0.23 0.014 240);
-  --surface-3: oklch(0.26 0.015 240);
-  --fg: oklch(0.96 0.005 240);
-  --fg-muted: oklch(0.72 0.012 240);
-  --fg-subtle: oklch(0.58 0.012 240);
-  --border: oklch(0.3 0.01 240 / 0.5);
-  --border-strong: oklch(0.35 0.01 240 / 0.7);
-  --ring: oklch(0.72 0.17 162 / 0.45);
+  --bg: oklch(0.185 0.009 58);
+  --bg-subtle: oklch(0.21 0.01 58);
+  --surface: oklch(0.227 0.012 58);
+  --surface-2: oklch(0.262 0.013 58);
+  --surface-3: oklch(0.3 0.014 58);
+  --fg: oklch(0.955 0.007 82);
+  --fg-muted: oklch(0.74 0.012 76);
+  --fg-subtle: oklch(0.6 0.012 70);
+  --border: oklch(0.36 0.01 60 / 0.6);
+  --border-strong: oklch(0.45 0.012 60 / 0.85);
+  --shadow-warm: 30 30% 2%;
+
+  /* accent lightness rises in dark for legibility */
+  --accent: oklch(0.76 0.13 158);
+  --accent-strong: oklch(0.66 0.15 158);
+  --accent-ink: oklch(0.8 0.13 158);
+  --accent-dim: oklch(0.76 0.13 158 / 0.2);
+  --accent-fg: oklch(0.17 0.03 158);
+  --ring: oklch(0.76 0.13 158 / 0.45);
+
+  /* status — dark lightness, tint alpha 0.2 */
+  --success: oklch(0.76 0.13 158);
+  --success-dim: oklch(0.76 0.13 158 / 0.2);
+  --warning: oklch(0.78 0.14 72);
+  --warning-dim: oklch(0.78 0.14 72 / 0.2);
+  --danger: oklch(0.7 0.18 28);
+  --danger-dim: oklch(0.7 0.18 28 / 0.2);
+  --info: oklch(0.72 0.12 236);
+  --info-dim: oklch(0.72 0.12 236 / 0.2);
 }
 
-/* Map semantic vars onto @theme's color system so Tailwind utilities work. */
+/* ---- Surfaces / shape / density (baked: warm vibe, regular density) ---- */
+:root {
+  --card-radius: var(--radius-lg);
+  --card-shadow: 0 1px 1px hsl(var(--shadow-warm) / 0.05),
+    0 10px 26px -18px hsl(var(--shadow-warm) / 0.5);
+  --card-hover-shadow: 0 1px 1px hsl(var(--shadow-warm) / 0.06),
+    0 16px 34px -18px hsl(var(--shadow-warm) / 0.6);
+  --chip-radius: 999px;
+  --btn-radius: 0.625rem;
+
+  /* editorial labels / titles */
+  --label-font: var(--font-sans);
+  --label-transform: none;
+  --label-tracking: 0.005em;
+  --label-weight: 500;
+  --label-size: 0.78rem;
+  --title-font: var(--font-serif);
+
+  /* density (regular) */
+  --pad: 18px;
+  --pad-lg: 22px;
+  --gap: 16px;
+  --row-h: 46px;
+  --stat-size: 2.3rem;
+  --page-gap: 26px;
+}
+
+/* Map semantic vars onto @theme's color system so Tailwind utilities work
+   (bg-accent, text-success, bg-accent-dim, …). Inline so they track the
+   live theme/accent vars instead of baking a single value at build time. */
 @theme inline {
   --color-bg: var(--bg);
   --color-bg-subtle: var(--bg-subtle);
@@ -76,6 +129,21 @@ html.dark {
   --color-border: var(--border);
   --color-border-strong: var(--border-strong);
   --color-ring: var(--ring);
+
+  --color-accent: var(--accent);
+  --color-accent-fg: var(--accent-fg);
+  --color-accent-dim: var(--accent-dim);
+  --color-accent-strong: var(--accent-strong);
+  --color-accent-ink: var(--accent-ink);
+
+  --color-success: var(--success);
+  --color-success-dim: var(--success-dim);
+  --color-warning: var(--warning);
+  --color-warning-dim: var(--warning-dim);
+  --color-danger: var(--danger);
+  --color-danger-dim: var(--danger-dim);
+  --color-info: var(--info);
+  --color-info-dim: var(--info-dim);
 }
 
 * {
@@ -93,23 +161,23 @@ body {
   font-family: var(--font-sans);
   background: var(--bg);
   color: var(--fg);
-  font-feature-settings: "cv02", "cv03", "cv04", "cv11";
+  font-feature-settings: "ss03";
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
 }
 
-/* Subtle scrollbars */
+/* Warm scrollbars */
 ::-webkit-scrollbar {
-  width: 10px;
-  height: 10px;
+  width: 11px;
+  height: 11px;
 }
 ::-webkit-scrollbar-track {
   background: transparent;
 }
 ::-webkit-scrollbar-thumb {
   background: var(--border-strong);
-  border: 2px solid var(--bg);
-  border-radius: 8px;
+  border: 3px solid var(--bg);
+  border-radius: 9px;
 }
 ::-webkit-scrollbar-thumb:hover {
   background: var(--fg-subtle);
@@ -117,15 +185,15 @@ body {
 
 /* Focus rings */
 *:focus-visible {
-  outline: 2px solid var(--color-accent);
+  outline: 2px solid var(--accent);
   outline-offset: 2px;
   border-radius: var(--radius-sm);
 }
 
-/* Monospace helper */
+/* Mono helper — slashed zero, structural numbers/IDs */
 .font-mono {
   font-family: var(--font-mono);
-  font-feature-settings: "zero", "ss02";
+  font-feature-settings: "zero";
 }
 
 /* Animations */
@@ -147,6 +215,17 @@ body {
     transform: translateY(0);
   }
 }
+/* Transform-only page entrance. Never animate opacity from 0 here: a
+   background tab freezes the animation at frame 0 and the page would stay
+   invisible. Resting opacity is always 1. */
+@keyframes page-rise {
+  from {
+    transform: translateY(6px);
+  }
+  to {
+    transform: none;
+  }
+}
 @keyframes shimmer {
   from {
     background-position: -200% 0;
@@ -155,12 +234,31 @@ body {
     background-position: 200% 0;
   }
 }
+/* Live "pulse" ring for status dots. Drives box-shadow off currentColor so
+   the same keyframe works for success / info / accent dots. */
+@keyframes pulse-dot {
+  0% {
+    box-shadow: 0 0 0 0 color-mix(in oklch, currentColor 70%, transparent);
+  }
+  70% {
+    box-shadow: 0 0 0 6px transparent;
+  }
+  100% {
+    box-shadow: 0 0 0 0 transparent;
+  }
+}
 
 .animate-fade-in {
   animation: fade-in 0.2s ease-out;
 }
 .animate-slide-up {
   animation: slide-up 0.24s ease-out;
+}
+.animate-page-rise {
+  animation: page-rise 0.32s cubic-bezier(0.2, 0.7, 0.2, 1);
+}
+.pulse-ring {
+  animation: pulse-dot 2.4s infinite;
 }
 .animate-shimmer {
   background: linear-gradient(

--- a/dashboard/src/globals.css
+++ b/dashboard/src/globals.css
@@ -270,3 +270,16 @@ body {
   background-size: 200% 100%;
   animation: shimmer 1.4s infinite;
 }
+
+/* Respect users who prefer reduced motion — drop the looping/entrance
+   animations (resting states already have opacity 1, so content stays
+   visible). */
+@media (prefers-reduced-motion: reduce) {
+  .animate-fade-in,
+  .animate-slide-up,
+  .animate-page-rise,
+  .pulse-ring,
+  .animate-shimmer {
+    animation: none !important;
+  }
+}

--- a/dashboard/src/lib/status.ts
+++ b/dashboard/src/lib/status.ts
@@ -8,6 +8,16 @@ export type ResourceHealth = "healthy" | "degraded" | "unhealthy" | "unknown";
 
 export type Tone = "neutral" | "accent" | "info" | "success" | "warning" | "danger";
 
+/** The CSS variable for a tone — for inline `style` use (bars, charts, dots). */
+export const TONE_VAR: Record<Tone, string> = {
+  neutral: "var(--fg-subtle)",
+  accent: "var(--accent)",
+  info: "var(--info)",
+  success: "var(--success)",
+  warning: "var(--warning)",
+  danger: "var(--danger)",
+};
+
 export const JOB_STATUS_TONE: Record<JobStatus, Tone> = {
   pending: "neutral",
   running: "info",

--- a/dashboard/src/main.tsx
+++ b/dashboard/src/main.tsx
@@ -4,6 +4,16 @@ import { createRoot } from "react-dom/client";
 import { createQueryClient } from "@/lib/query-client";
 import { Providers } from "@/providers";
 import { routeTree } from "./routeTree.gen";
+// IBM Plex — sans for UI, mono for numbers/IDs, serif for titles. Latin
+// subsets only; self-hosted so the bundled dashboard works offline.
+import "@fontsource/ibm-plex-sans/latin-400.css";
+import "@fontsource/ibm-plex-sans/latin-500.css";
+import "@fontsource/ibm-plex-sans/latin-600.css";
+import "@fontsource/ibm-plex-mono/latin-400.css";
+import "@fontsource/ibm-plex-mono/latin-500.css";
+import "@fontsource/ibm-plex-mono/latin-600.css";
+import "@fontsource/ibm-plex-serif/latin-500.css";
+import "@fontsource/ibm-plex-serif/latin-600.css";
 import "./globals.css";
 
 const queryClient = createQueryClient();

--- a/dashboard/src/routes/circuit-breakers.tsx
+++ b/dashboard/src/routes/circuit-breakers.tsx
@@ -1,10 +1,13 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { CheckCircle2, CircuitBoard, Zap } from "lucide-react";
 import { PageHeader } from "@/components/layout";
+import { StatCard } from "@/components/ui";
 import {
   CircuitBreakersTable,
   circuitBreakersQuery,
   useCircuitBreakers,
 } from "@/features/circuit-breakers";
+import { formatCount } from "@/lib/number";
 
 export const Route = createFileRoute("/circuit-breakers")({
   loader: ({ context: { queryClient } }) => queryClient.ensureQueryData(circuitBreakersQuery()),
@@ -13,19 +16,46 @@ export const Route = createFileRoute("/circuit-breakers")({
 
 function CircuitBreakersPage() {
   const breakers = useCircuitBreakers();
+  const all = breakers.data ?? [];
+  const tripped = all.filter((b) => b.state !== "closed").length;
+  const closed = all.length - tripped;
 
   return (
     <>
       <PageHeader
+        eyebrow="Reliability"
         title="Circuit breakers"
-        description="State, thresholds, and cooldowns by task."
+        description="When a task fails too often, taskito trips its breaker to give the downstream a rest."
       />
-      <CircuitBreakersTable
-        breakers={breakers.data}
-        loading={breakers.isLoading}
-        error={breakers.error}
-        onRetry={() => breakers.refetch()}
-      />
+      <div className="flex flex-col gap-[var(--page-gap)]">
+        <div className="grid gap-[var(--gap)] grid-cols-[repeat(auto-fit,minmax(186px,1fr))]">
+          <StatCard
+            label="Breakers"
+            tone="neutral"
+            icon={<CircuitBoard />}
+            value={formatCount(all.length)}
+          />
+          <StatCard
+            label="Tripped"
+            tone={tripped > 0 ? "danger" : "success"}
+            icon={<Zap />}
+            value={formatCount(tripped)}
+            hint={tripped > 0 ? "open or half-open" : "all healthy"}
+          />
+          <StatCard
+            label="Closed"
+            tone="success"
+            icon={<CheckCircle2 />}
+            value={formatCount(closed)}
+          />
+        </div>
+        <CircuitBreakersTable
+          breakers={breakers.data}
+          loading={breakers.isLoading}
+          error={breakers.error}
+          onRetry={() => breakers.refetch()}
+        />
+      </div>
     </>
   );
 }

--- a/dashboard/src/routes/dead-letters.tsx
+++ b/dashboard/src/routes/dead-letters.tsx
@@ -89,7 +89,7 @@ function DeadLettersPage() {
       <div className="flex flex-col gap-[var(--page-gap)]">
         <div className="grid gap-[var(--gap)] grid-cols-[repeat(auto-fit,minmax(186px,1fr))]">
           <StatCard
-            label="In the queue"
+            label="On this page"
             tone="danger"
             icon={<Skull />}
             value={formatCount(items?.length ?? 0)}
@@ -100,9 +100,10 @@ function DeadLettersPage() {
             tone="warning"
             icon={<ListTree />}
             value={formatCount(taskCount)}
+            hint="on this page"
           />
           <StatCard
-            label="Oldest"
+            label="Oldest on this page"
             tone="neutral"
             icon={<Clock />}
             value={oldestFailedAt != null ? formatRelative(oldestFailedAt) : "—"}

--- a/dashboard/src/routes/dead-letters.tsx
+++ b/dashboard/src/routes/dead-letters.tsx
@@ -1,8 +1,8 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { List, Rows3, Trash2 } from "lucide-react";
-import { useState } from "react";
+import { Clock, List, ListTree, Rows3, Skull, Trash2 } from "lucide-react";
+import { useMemo, useState } from "react";
 import { PageHeader } from "@/components/layout";
-import { Button, DestructiveConfirmDialog, Pagination } from "@/components/ui";
+import { Button, DestructiveConfirmDialog, Pagination, StatCard } from "@/components/ui";
 import {
   DeadLetterList,
   type DeadLetterView,
@@ -11,6 +11,8 @@ import {
   usePurgeDeadLetters,
 } from "@/features/dead-letters";
 import { cn } from "@/lib/cn";
+import { formatCount } from "@/lib/number";
+import { formatRelative } from "@/lib/time";
 
 const PAGE_SIZE = 25;
 const DEAD_LETTER_VIEWS: readonly DeadLetterView[] = ["grouped", "flat"];
@@ -53,11 +55,22 @@ function DeadLettersPage() {
   const items = query.data;
   const hasMore = items ? items.length >= PAGE_SIZE : false;
 
+  const { taskCount, oldestFailedAt } = useMemo(() => {
+    const tasks = new Set<string>();
+    let oldest: number | null = null;
+    for (const item of items ?? []) {
+      tasks.add(item.task_name);
+      if (oldest == null || item.failed_at < oldest) oldest = item.failed_at;
+    }
+    return { taskCount: tasks.size, oldestFailedAt: oldest };
+  }, [items]);
+
   return (
     <>
       <PageHeader
+        eyebrow="Reliability"
         title="Dead letters"
-        description="Failures that exhausted their retries. Retry individually or purge all."
+        description="Jobs that exhausted every retry. Inspect the failure, replay them, or let them go."
         actions={
           <>
             <ViewToggle value={view} onChange={setView} />
@@ -73,15 +86,39 @@ function DeadLettersPage() {
         }
       />
 
-      <div className="flex flex-col gap-4">
-        <DeadLetterList
-          items={items}
-          view={view}
-          loading={query.isLoading || (query.isFetching && !items)}
-          error={query.error}
-          onRetry={() => query.refetch()}
-        />
-        <Pagination page={page} hasMore={hasMore} onChange={setPage} />
+      <div className="flex flex-col gap-[var(--page-gap)]">
+        <div className="grid gap-[var(--gap)] grid-cols-[repeat(auto-fit,minmax(186px,1fr))]">
+          <StatCard
+            label="In the queue"
+            tone="danger"
+            icon={<Skull />}
+            value={formatCount(items?.length ?? 0)}
+            hint="awaiting a decision"
+          />
+          <StatCard
+            label="Affected tasks"
+            tone="warning"
+            icon={<ListTree />}
+            value={formatCount(taskCount)}
+          />
+          <StatCard
+            label="Oldest"
+            tone="neutral"
+            icon={<Clock />}
+            value={oldestFailedAt != null ? formatRelative(oldestFailedAt) : "—"}
+          />
+        </div>
+
+        <div className="flex flex-col gap-4">
+          <DeadLetterList
+            items={items}
+            view={view}
+            loading={query.isLoading || (query.isFetching && !items)}
+            error={query.error}
+            onRetry={() => query.refetch()}
+          />
+          <Pagination page={page} hasMore={hasMore} onChange={setPage} />
+        </div>
       </div>
 
       <DestructiveConfirmDialog

--- a/dashboard/src/routes/index.tsx
+++ b/dashboard/src/routes/index.tsx
@@ -1,9 +1,11 @@
-import { createFileRoute } from "@tanstack/react-router";
-import { PageHeader } from "@/components/layout";
-import { Separator } from "@/components/ui";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { ChevronRight, RefreshCw } from "lucide-react";
+import { PageHeader, SectionHeading } from "@/components/layout";
+import { Badge, Button } from "@/components/ui";
 import {
+  BusiestQueues,
+  Pulse,
   pausedQueuesQuery,
-  QueueBreakdown,
   queueStatsQuery,
   RecentJobs,
   recentJobsQuery,
@@ -16,7 +18,10 @@ import {
   useRecentJobs,
   useStats,
   useThroughput,
+  WorkersCard,
 } from "@/features/overview";
+import { useWorkers, workersQuery } from "@/features/workers";
+import { isWorkerStale } from "@/features/workers/utils";
 
 export const Route = createFileRoute("/")({
   loader: ({ context: { queryClient } }) =>
@@ -26,6 +31,7 @@ export const Route = createFileRoute("/")({
       queryClient.ensureQueryData(pausedQueuesQuery()),
       queryClient.ensureQueryData(recentJobsQuery(10)),
       queryClient.ensureQueryData(throughputQuery(60, 3600)),
+      queryClient.ensureQueryData(workersQuery()),
     ]),
   component: OverviewPage,
 });
@@ -36,61 +42,96 @@ function OverviewPage() {
   const paused = usePausedQueues();
   const jobs = useRecentJobs(10);
   const throughput = useThroughput(60, 3600);
+  const workers = useWorkers();
+
+  const refreshAll = () => {
+    stats.refetch();
+    queueStats.refetch();
+    paused.refetch();
+    jobs.refetch();
+    throughput.refetch();
+    workers.refetch();
+  };
+
+  const onlineWorkers = (workers.data ?? []).filter((w) => !isWorkerStale(w)).length;
 
   return (
     <>
       <PageHeader
         eyebrow="Dashboard"
         title="Overview"
-        description="A live pulse on your queues, jobs, and workers."
+        description="A friendly, live pulse on everything your workers are chewing through."
+        actions={
+          <Button variant="outline" onClick={refreshAll}>
+            <RefreshCw aria-hidden />
+            Refresh
+          </Button>
+        }
       />
 
-      <div className="flex flex-col gap-6">
-        <div className="animate-slide-up" style={{ animationDelay: "0ms" }}>
-          <StatsGrid
-            stats={stats.data}
-            pausedCount={paused.data?.length}
-            throughput={throughput.data}
-            loading={stats.isLoading}
-            error={stats.error}
-            onRetry={() => stats.refetch()}
-          />
+      <div className="flex flex-col gap-[var(--page-gap)]">
+        <Pulse stats={stats.data} throughput={throughput.data} />
+
+        <StatsGrid
+          stats={stats.data}
+          pausedCount={paused.data?.length}
+          throughput={throughput.data}
+          loading={stats.isLoading}
+          error={stats.error}
+          onRetry={() => stats.refetch()}
+        />
+
+        <ThroughputSparkline
+          buckets={throughput.data}
+          loading={throughput.isLoading}
+          error={throughput.error}
+          onRetry={() => throughput.refetch()}
+        />
+
+        <div className="grid gap-[var(--gap)] lg:grid-cols-[1.5fr_1fr]">
+          <section>
+            <SectionHeading
+              title="Busiest queues"
+              action={
+                <Button variant="ghost" size="sm" asChild>
+                  <Link to="/queues">
+                    View all
+                    <ChevronRight aria-hidden />
+                  </Link>
+                </Button>
+              }
+            />
+            <BusiestQueues
+              queueStats={queueStats.data}
+              paused={paused.data}
+              loading={queueStats.isLoading}
+            />
+          </section>
+          <section>
+            <SectionHeading
+              title="Workers"
+              action={
+                <Badge tone="success" dot>
+                  {onlineWorkers} online
+                </Badge>
+              }
+            />
+            <WorkersCard workers={workers.data} loading={workers.isLoading} />
+          </section>
         </div>
 
-        <div className="animate-slide-up" style={{ animationDelay: "60ms" }}>
-          <ThroughputSparkline
-            buckets={throughput.data}
-            loading={throughput.isLoading}
-            error={throughput.error}
-            onRetry={() => throughput.refetch()}
+        <section>
+          <SectionHeading
+            title="Recent jobs"
+            action={
+              <Button variant="ghost" size="sm" asChild>
+                <Link to="/jobs" search={{ page: 0, pageSize: 25 }}>
+                  Open Jobs
+                  <ChevronRight aria-hidden />
+                </Link>
+              </Button>
+            }
           />
-        </div>
-
-        <Separator />
-
-        <section
-          className="flex flex-col gap-3 animate-slide-up"
-          style={{ animationDelay: "120ms" }}
-        >
-          <div className="flex items-center justify-between">
-            <h2 className="text-sm font-semibold tracking-tight text-[var(--fg)]">Queues</h2>
-          </div>
-          <QueueBreakdown
-            queueStats={queueStats.data}
-            paused={paused.data}
-            loading={queueStats.isLoading}
-            error={queueStats.error}
-            onRetry={() => queueStats.refetch()}
-          />
-        </section>
-
-        <section
-          className="flex flex-col gap-3 animate-slide-up"
-          style={{ animationDelay: "180ms" }}
-        >
-          <div className="flex items-center justify-between">
-            <h2 className="text-sm font-semibold tracking-tight text-[var(--fg)]">Recent jobs</h2>
-          </div>
           <RecentJobs
             jobs={jobs.data}
             loading={jobs.isLoading}

--- a/dashboard/src/routes/queues.tsx
+++ b/dashboard/src/routes/queues.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { ListTree, Pause, ShieldCheck } from "lucide-react";
+import { Clock, ListTree, Pause } from "lucide-react";
 import { PageHeader } from "@/components/layout";
 import { StatCard } from "@/components/ui";
 import {
@@ -32,29 +32,31 @@ function QueuesPage() {
     : 0;
 
   return (
-    <>
+    <div className="flex flex-col gap-[var(--page-gap)]">
       <PageHeader
+        eyebrow="Infrastructure"
         title="Queues"
         description="Inspect throughput and pause or resume traffic per queue."
       />
-      <div className="mb-4 grid gap-3 grid-cols-[repeat(auto-fit,minmax(180px,1fr))]">
+      <div className="grid gap-[var(--gap)] grid-cols-[repeat(auto-fit,minmax(186px,1fr))]">
         <StatCard
           label="Queues"
           tone="neutral"
-          icon={<ListTree className="size-4" />}
+          icon={<ListTree />}
           value={formatCount(totalQueues)}
         />
         <StatCard
-          label="Pending"
+          label="Total pending"
           tone="info"
-          icon={<ShieldCheck className="size-4" />}
+          icon={<Clock />}
           value={formatCount(totalPending)}
         />
         <StatCard
           label="Paused"
           tone="warning"
-          icon={<Pause className="size-4" />}
+          icon={<Pause />}
           value={formatCount(pausedCount)}
+          hint="not pulling work"
         />
       </div>
       <QueuesTable
@@ -67,6 +69,6 @@ function QueuesPage() {
           paused.refetch();
         }}
       />
-    </>
+    </div>
   );
 }

--- a/dashboard/src/routes/resources.tsx
+++ b/dashboard/src/routes/resources.tsx
@@ -1,6 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { Activity, CheckCircle2, Server } from "lucide-react";
 import { PageHeader } from "@/components/layout";
+import { StatCard } from "@/components/ui";
 import { ResourcesTable, resourcesQuery, useResources } from "@/features/resources";
+import { formatCount } from "@/lib/number";
 
 export const Route = createFileRoute("/resources")({
   loader: ({ context: { queryClient } }) => queryClient.ensureQueryData(resourcesQuery()),
@@ -9,19 +12,46 @@ export const Route = createFileRoute("/resources")({
 
 function ResourcesPage() {
   const resources = useResources();
+  const all = resources.data ?? [];
+  const healthy = all.filter((r) => r.health.toLowerCase() === "healthy").length;
+  const pools = all.filter((r) => r.pool).length;
 
   return (
     <>
       <PageHeader
+        eyebrow="Infrastructure"
         title="Resources"
-        description="Worker-side DI: health, pools, and dependency graph."
+        description="Connection pools, init timings, and the dependency graph your tasks rely on."
       />
-      <ResourcesTable
-        resources={resources.data}
-        loading={resources.isLoading}
-        error={resources.error}
-        onRetry={() => resources.refetch()}
-      />
+      <div className="flex flex-col gap-[var(--page-gap)]">
+        <div className="grid gap-[var(--gap)] grid-cols-[repeat(auto-fit,minmax(186px,1fr))]">
+          <StatCard
+            label="Resources"
+            tone="neutral"
+            icon={<Activity />}
+            value={formatCount(all.length)}
+          />
+          <StatCard
+            label="Healthy"
+            tone={all.length > 0 && healthy === all.length ? "success" : "warning"}
+            icon={<CheckCircle2 />}
+            value={`${healthy}/${all.length}`}
+          />
+          <StatCard
+            label="Pools"
+            tone="info"
+            icon={<Server />}
+            value={formatCount(pools)}
+            hint="with connection pooling"
+          />
+        </div>
+        <ResourcesTable
+          resources={resources.data}
+          loading={resources.isLoading}
+          error={resources.error}
+          onRetry={() => resources.refetch()}
+        />
+      </div>
     </>
   );
 }

--- a/dashboard/src/routes/settings.tsx
+++ b/dashboard/src/routes/settings.tsx
@@ -19,17 +19,18 @@ function SettingsPage() {
   const { data, isLoading, error, refetch } = useSettings();
 
   return (
-    <>
+    <div className="flex flex-col gap-[var(--page-gap)]">
       <PageHeader
+        eyebrow="Configuration"
         title="Settings"
-        description="Customize the dashboard's appearance and configure external integrations."
+        description="Branding, dashboard behaviour, integrations, and quick links — shared across every worker."
       />
 
       {isLoading || !data ? (
-        <div className="flex flex-col gap-4">
-          <Skeleton className="h-48 rounded-lg" />
-          <Skeleton className="h-48 rounded-lg" />
-          <Skeleton className="h-64 rounded-lg" />
+        <div className="flex flex-col gap-[var(--gap)]">
+          <Skeleton className="h-48 rounded-[var(--card-radius)]" />
+          <Skeleton className="h-48 rounded-[var(--card-radius)]" />
+          <Skeleton className="h-64 rounded-[var(--card-radius)]" />
         </div>
       ) : error ? (
         <ErrorState
@@ -38,13 +39,13 @@ function SettingsPage() {
           onRetry={() => refetch()}
         />
       ) : (
-        <div className="flex flex-col gap-6">
-          <RefreshIntervalSection />
+        <div className="flex flex-col gap-[var(--gap)]">
           <BrandingSection settings={data} />
-          <ExternalLinksSection settings={data} />
+          <RefreshIntervalSection />
           <IntegrationsSection settings={data} />
+          <ExternalLinksSection settings={data} />
         </div>
       )}
-    </>
+    </div>
   );
 }

--- a/dashboard/src/routes/system.tsx
+++ b/dashboard/src/routes/system.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { PageHeader } from "@/components/layout";
+import { PageHeader, SectionHeading } from "@/components/layout";
 import {
   InterceptionTable,
   interceptionStatsQuery,
@@ -25,12 +25,20 @@ function SystemPage() {
   return (
     <>
       <PageHeader
+        eyebrow="Reliability"
         title="System"
-        description="Proxy reconstruction and argument interception metrics."
+        description="Core internals — resource-proxy reconstruction and call interception."
       />
-      <div className="grid gap-6 lg:grid-cols-2">
-        <section className="flex flex-col gap-3">
-          <h2 className="text-sm font-semibold tracking-tight text-[var(--fg)]">Proxy handlers</h2>
+      <div className="flex flex-col gap-[var(--page-gap)]">
+        <section>
+          <SectionHeading
+            title="Resource proxies"
+            action={
+              <span className="text-xs text-[var(--fg-subtle)]">
+                reconstructed across worker boundaries
+              </span>
+            }
+          />
           <ProxyTable
             stats={proxy.data}
             loading={proxy.isLoading}
@@ -38,10 +46,9 @@ function SystemPage() {
             onRetry={() => proxy.refetch()}
           />
         </section>
-        <section className="flex flex-col gap-3">
-          <h2 className="text-sm font-semibold tracking-tight text-[var(--fg)]">
-            Interception strategies
-          </h2>
+
+        <section>
+          <SectionHeading title="Call interception" />
           <InterceptionTable
             stats={interception.data}
             loading={interception.isLoading}

--- a/dashboard/src/routes/tasks.tsx
+++ b/dashboard/src/routes/tasks.tsx
@@ -1,7 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { ListTree, Search, Settings2, Zap } from "lucide-react";
+import { useMemo, useState } from "react";
 import { PageHeader } from "@/components/layout/page-header";
-import { ErrorState, Skeleton } from "@/components/ui";
-import { TaskListTable, useTasks } from "@/features/tasks";
+import { ErrorState, Input, Skeleton, StatCard } from "@/components/ui";
+import { type TaskEntry, TaskListTable, useTasks } from "@/features/tasks";
 
 export const Route = createFileRoute("/tasks")({
   component: TasksPage,
@@ -9,23 +11,72 @@ export const Route = createFileRoute("/tasks")({
 
 function TasksPage() {
   const { data, isLoading, error } = useTasks();
+  const [query, setQuery] = useState("");
+
+  const tasks = useMemo<TaskEntry[]>(() => data ?? [], [data]);
+
+  const overrides = tasks.filter((t) => t.override != null).length;
+  const rateLimited = tasks.filter((t) => t.effective.rate_limit != null).length;
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return tasks;
+    return tasks.filter(
+      (t) => t.name.toLowerCase().includes(q) || t.queue.toLowerCase().includes(q),
+    );
+  }, [tasks, query]);
 
   return (
-    <div className="flex flex-col gap-5">
+    <>
       <PageHeader
+        eyebrow="Configuration"
         title="Tasks"
-        description="Every registered task with its decorator defaults and any runtime overrides. Changes apply on the next worker restart; pausing takes effect immediately."
+        description="Every registered task handler, its defaults, and any operator overrides. Changes apply on the next worker restart; pausing takes effect immediately."
+        actions={
+          <div className="relative w-60">
+            <Search
+              className="pointer-events-none absolute left-2.5 top-1/2 size-[15px] -translate-y-1/2 text-[var(--fg-subtle)]"
+              aria-hidden
+            />
+            <Input
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search tasks…"
+              className="pl-8"
+            />
+          </div>
+        }
       />
-      {isLoading ? (
-        <Skeleton className="h-48" />
-      ) : error ? (
-        <ErrorState
-          title="Failed to load tasks"
-          description={error instanceof Error ? error.message : String(error)}
-        />
-      ) : (
-        <TaskListTable tasks={data ?? []} />
-      )}
-    </div>
+      <div className="flex flex-col gap-[var(--page-gap)]">
+        {error ? (
+          <ErrorState
+            title="Failed to load tasks"
+            description={error instanceof Error ? error.message : String(error)}
+          />
+        ) : isLoading ? (
+          <Skeleton className="h-48" />
+        ) : (
+          <>
+            <div className="grid gap-[var(--gap)] grid-cols-[repeat(auto-fit,minmax(186px,1fr))]">
+              <StatCard
+                label="Registered"
+                tone="neutral"
+                icon={<ListTree />}
+                value={tasks.length}
+              />
+              <StatCard
+                label="With overrides"
+                tone="info"
+                icon={<Settings2 />}
+                value={overrides}
+                hint="operator-tuned"
+              />
+              <StatCard label="Rate limited" tone="warning" icon={<Zap />} value={rateLimited} />
+            </div>
+            <TaskListTable tasks={filtered} />
+          </>
+        )}
+      </div>
+    </>
   );
 }

--- a/dashboard/src/routes/tasks.tsx
+++ b/dashboard/src/routes/tasks.tsx
@@ -39,6 +39,8 @@ function TasksPage() {
               aria-hidden
             />
             <Input
+              type="search"
+              aria-label="Search tasks"
               value={query}
               onChange={(e) => setQuery(e.target.value)}
               placeholder="Search tasks…"

--- a/dashboard/src/routes/webhooks.tsx
+++ b/dashboard/src/routes/webhooks.tsx
@@ -1,7 +1,13 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { CheckCircle2, Webhook as WebhookIcon, Zap } from "lucide-react";
 import { PageHeader } from "@/components/layout/page-header";
-import { ErrorState, Skeleton } from "@/components/ui";
-import { CreateWebhookDialog, useWebhooks, WebhookListTable } from "@/features/webhooks";
+import { ErrorState, Skeleton, StatCard } from "@/components/ui";
+import {
+  CreateWebhookDialog,
+  useEventTypes,
+  useWebhooks,
+  WebhookListTable,
+} from "@/features/webhooks";
 
 export const Route = createFileRoute("/webhooks")({
   component: WebhooksPage,
@@ -9,14 +15,33 @@ export const Route = createFileRoute("/webhooks")({
 
 function WebhooksPage() {
   const { data, isLoading, error } = useWebhooks();
+  const { data: eventTypes } = useEventTypes();
+
+  const webhooks = data ?? [];
+  const activeCount = webhooks.filter((wh) => wh.enabled).length;
+  const eventTypeCount = eventTypes?.length ?? 0;
 
   return (
-    <div className="flex flex-col gap-5">
+    <div className="flex flex-col gap-[var(--page-gap)]">
       <PageHeader
+        eyebrow="Configuration"
         title="Webhooks"
-        description="HTTP endpoints that receive job lifecycle events. Configure URLs, event filters, and signing secrets without redeploying."
+        description="Push job, worker, and workflow events to your own endpoints — configure URLs, filters, and signing secrets without redeploying."
         actions={<CreateWebhookDialog />}
       />
+
+      <div className="grid gap-[var(--gap)] grid-cols-[repeat(auto-fit,minmax(186px,1fr))]">
+        <StatCard label="Endpoints" tone="neutral" icon={<WebhookIcon />} value={webhooks.length} />
+        <StatCard label="Active" tone="success" icon={<CheckCircle2 />} value={activeCount} />
+        <StatCard
+          label="Event types"
+          tone="info"
+          icon={<Zap />}
+          value={eventTypeCount}
+          hint="available to subscribe"
+        />
+      </div>
+
       {isLoading ? (
         <Skeleton className="h-48" />
       ) : error ? (
@@ -25,7 +50,7 @@ function WebhooksPage() {
           description={error instanceof Error ? error.message : String(error)}
         />
       ) : (
-        <WebhookListTable webhooks={data ?? []} />
+        <WebhookListTable webhooks={webhooks} />
       )}
     </div>
   );

--- a/dashboard/src/routes/workers.tsx
+++ b/dashboard/src/routes/workers.tsx
@@ -1,11 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { Activity, AlertCircle, Server } from "lucide-react";
+import { CheckCircle2, Server, Skull } from "lucide-react";
 import { PageHeader } from "@/components/layout";
 import { StatCard } from "@/components/ui";
-import { useWorkers, WorkersTable, workersQuery } from "@/features/workers";
+import { isWorkerStale, useWorkers, WorkersTable, workersQuery } from "@/features/workers";
 import { formatCount } from "@/lib/number";
-
-const STALE_AFTER_MS = 30_000;
 
 export const Route = createFileRoute("/workers")({
   loader: ({ context: { queryClient } }) => queryClient.ensureQueryData(workersQuery()),
@@ -15,39 +13,38 @@ export const Route = createFileRoute("/workers")({
 function WorkersPage() {
   const workers = useWorkers();
   const all = workers.data ?? [];
-  const count = workers.data?.length;
+  // Compute against the wall clock at render so workers "age out" between
+  // refetches: the query re-renders on the user interval, refreshing these.
   const now = Date.now();
-  const stale = all.filter((w) => now - w.last_heartbeat > STALE_AFTER_MS).length;
-  const healthy = all.length - stale;
+  const stale = all.filter((w) => isWorkerStale(w, now)).length;
+  const online = all.length - stale;
 
   return (
-    <>
+    <div className="flex flex-col gap-[var(--page-gap)]">
       <PageHeader
+        eyebrow="Infrastructure"
         title="Workers"
-        description={
-          count != null
-            ? `${formatCount(count)} registered worker${count === 1 ? "" : "s"}`
-            : "Active workers, heartbeats, and assignments."
-        }
+        description="Every worker process, what it's pulling, and when it last checked in."
       />
-      <div className="mb-4 grid gap-3 grid-cols-[repeat(auto-fit,minmax(180px,1fr))]">
+      <div className="grid gap-[var(--gap)] grid-cols-[repeat(auto-fit,minmax(186px,1fr))]">
         <StatCard
-          label="Registered"
+          label="Workers"
           tone="neutral"
-          icon={<Server className="size-4" />}
+          icon={<Server />}
           value={formatCount(all.length)}
         />
         <StatCard
-          label="Healthy"
+          label="Online"
           tone="success"
-          icon={<Activity className="size-4" />}
-          value={formatCount(healthy)}
+          icon={<CheckCircle2 />}
+          value={formatCount(online)}
         />
         <StatCard
           label="Stale"
-          tone="warning"
-          icon={<AlertCircle className="size-4" />}
+          tone="danger"
+          icon={<Skull />}
           value={formatCount(stale)}
+          hint="no recent heartbeat"
         />
       </div>
       <WorkersTable
@@ -56,6 +53,6 @@ function WorkersPage() {
         error={workers.error}
         onRetry={() => workers.refetch()}
       />
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

A full visual revamp of the dashboard from the generic cold blue-gray developer-tool look to a warmer, friendlier identity ("Friendly ops"), while keeping the same information architecture, data model, and component vocabulary. This is a **re-skin, not a rewrite** — every TanStack Query hook, route loader, mutation, and search-param schema is preserved; only presentation changed.

Covers the app shell (sidebar + header + command palette) and all 13 views: Overview, Jobs, Queues, Workers, Resources, Dead letters, Circuit breakers, System, Metrics, Logs, Tasks, Webhooks, Settings.

## What changed

- **Design tokens** (`globals.css`): warm-paper light / warm-espresso dark neutrals, emerald accent, warmed status colors — all `oklch`, theme-switching via `@theme inline`. The "warm" vibe + "regular" density are baked in as token defaults (no user-facing vibe/density switcher; the light/dark toggle and custom-accent override are kept and made coherent with the new token set).
- **Fonts**: IBM Plex Sans/Mono/Serif self-hosted via `@fontsource` (latin subsets) so the bundled dashboard renders offline. Mono is used structurally for all stat numbers / IDs / counts; serif for page + section titles.
- **New shared primitives**: `Switch`, `QueueBar` (live mix bar), `MeterBar`, `Segmented`, `Stepper`, `KvList`, `Callout`, `LiveDot`, `StatusBadge`, `BrandMark`, `SectionHeading`; `Badge` gains an optional dot, `Button` gains `asChild` + an accent-strong primary.
- **Restyled** the shared shell (card, stat-card, table, data-table, page-header, sidebar with the brand mark + live dead-letter count, header) and every page — including new card-grid layouts for Circuit breakers / Resources / Webhooks, a KvList + strategy bar for System, and a pulse health banner + workers card + busiest-queues mix table on Overview.

## Honest fidelity notes

A few prototype elements have no backing API, so they were **not** faked: System has no Runtime/Autoscaler card (no `/api/scaler` or system-info endpoint), webhook cards show created time instead of delivery stats (the API exposes none), and Settings has no danger zone (no purge/reset mutation). Everything rendered is wired to a real endpoint.

## Verification

`pnpm run ci` is green — biome (223 files), typecheck, 106 vitest tests, and the production build all pass.

## Notes for reviewers

- 9 focused commits, ordered foundation → shared shell → page-by-page (the pre-commit hook runs a whole-tree typecheck, so each commit compiles independently).
- The design handoff lives in the untracked `taskito dashboard/design_handoff_taskito_redesign/` folder and is not part of this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live/pause toggle for logs; configurable webhook retry settings; searchable tasks

* **UI Improvements**
  * Overview: health metrics, worker status, busiest queues, stat tiles
  * Many lists converted to card/grid views (circuits, resources, webhooks, proxies)
  * New status visuals: badges, live dots, progress/meter bars, segmented controls, steppers, switches

* **Styling & Animation**
  * New warm “taskito” theme, IBM Plex fonts, updated page-rise animation and responsive tokens
<!-- end of auto-generated comment: release notes by coderabbit.ai -->