### PR TITLE
fix(ci): drop twine check --strict for PEP 639 compat

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -263,11 +263,11 @@ jobs:
 
       - name: Validate wheels
         run: |
-          pip install twine
+          pip install "twine>=6.1"
           for whl in dist/*.whl; do
             unzip -qt "$whl"
           done
-          twine check --strict dist/*
+          twine check dist/*
 
       - name: Check PyPI for existing version
         id: pypi-check


### PR DESCRIPTION
## Summary
- Drop `--strict` from `twine check` — maturin 1.13.3 emits PEP 639 `License-File` metadata which twine 6.1.0 rejects as unrecognized under strict mode
- Pin `twine>=6.1` explicitly
- Wheel integrity still validated by `unzip -qt`

## Test plan
- [ ] Publish workflow passes on next tag push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced package publishing validation to ensure improved quality assurance during release processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->