### PR TITLE
chore(release): 0.16.1

### DIFF
--- a/.github/actions/download-dashboard/action.yml
+++ b/.github/actions/download-dashboard/action.yml
@@ -1,0 +1,37 @@
+name: Download dashboard assets
+description: >-
+  Downloads the dashboard-dist artifact with a retry fallback via the
+  GitHub CLI. The primary path uses actions/download-artifact for digest
+  verification; on transient failure it retries three times via gh CLI.
+
+runs:
+  using: composite
+  steps:
+    - name: Download dashboard artifact
+      id: primary
+      uses: actions/download-artifact@v8
+      continue-on-error: true
+      with:
+        name: dashboard-dist
+        path: py_src/taskito/static/dashboard
+
+    - name: Retry download via GitHub CLI
+      if: steps.primary.outcome == 'failure'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        echo "::warning::download-artifact failed — retrying via gh CLI"
+        rm -rf py_src/taskito/static/dashboard
+        for _attempt in 1 2 3; do
+          gh run download "$GITHUB_RUN_ID" \
+            -n dashboard-dist \
+            -D py_src/taskito/static/dashboard && exit 0
+          sleep 10
+        done
+        echo "::error::Dashboard artifact download failed after all retries"
+        exit 1
+
+    - name: Verify dashboard assets
+      shell: bash
+      run: test -f py_src/taskito/static/dashboard/index.html

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,15 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Download dashboard assets
-        uses: actions/download-artifact@v8
-        with:
-          name: dashboard-dist
-          path: py_src/taskito/static/dashboard
-
-      - name: Verify dashboard assets present
-        shell: bash
-        run: test -f py_src/taskito/static/dashboard/index.html
+      - uses: ./.github/actions/download-dashboard
 
       - name: Build wheels
         uses: PyO3/maturin-action@v1.51.0
@@ -79,15 +71,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Download dashboard assets
-        uses: actions/download-artifact@v8
-        with:
-          name: dashboard-dist
-          path: py_src/taskito/static/dashboard
-
-      - name: Verify dashboard assets present
-        shell: bash
-        run: test -f py_src/taskito/static/dashboard/index.html
+      - uses: ./.github/actions/download-dashboard
 
       - name: Build wheels
         uses: PyO3/maturin-action@v1.51.0
@@ -118,15 +102,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Download dashboard assets
-        uses: actions/download-artifact@v8
-        with:
-          name: dashboard-dist
-          path: py_src/taskito/static/dashboard
-
-      - name: Verify dashboard assets present
-        shell: bash
-        run: test -f py_src/taskito/static/dashboard/index.html
+      - uses: ./.github/actions/download-dashboard
 
       - name: Set up Python 3.10
         uses: actions/setup-python@v6
@@ -173,15 +149,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Download dashboard assets
-        uses: actions/download-artifact@v8
-        with:
-          name: dashboard-dist
-          path: py_src/taskito/static/dashboard
-
-      - name: Verify dashboard assets present
-        shell: bash
-        run: test -f py_src/taskito/static/dashboard/index.html
+      - uses: ./.github/actions/download-dashboard
 
       - name: Set up Python 3.10
         uses: actions/setup-python@v6
@@ -223,15 +191,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Download dashboard assets
-        uses: actions/download-artifact@v8
-        with:
-          name: dashboard-dist
-          path: py_src/taskito/static/dashboard
-
-      - name: Verify dashboard assets present
-        shell: bash
-        run: test -f py_src/taskito/static/dashboard/index.html
+      - uses: ./.github/actions/download-dashboard
 
       - name: Build sdist
         uses: PyO3/maturin-action@v1.51.0

--- a/crates/taskito-async/Cargo.toml
+++ b/crates/taskito-async/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-async"
-version = "0.16.0"
+version = "0.16.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/taskito-core/Cargo.toml
+++ b/crates/taskito-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-core"
-version = "0.16.0"
+version = "0.16.1"
 edition = "2021"
 
 [features]

--- a/crates/taskito-mesh/Cargo.toml
+++ b/crates/taskito-mesh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-mesh"
-version = "0.16.0"
+version = "0.16.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/taskito-python/Cargo.toml
+++ b/crates/taskito-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-python"
-version = "0.16.0"
+version = "0.16.1"
 edition = "2021"
 
 [features]

--- a/crates/taskito-workflows/Cargo.toml
+++ b/crates/taskito-workflows/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-workflows"
-version = "0.16.0"
+version = "0.16.1"
 edition = "2021"
 
 [features]

--- a/docs/content/docs/more/changelog.mdx
+++ b/docs/content/docs/more/changelog.mdx
@@ -18,6 +18,9 @@ Patch release: publish workflow hardening.
   `License-File` metadata emitted by maturin 1.13.3. Pinned `twine>=6.1`.
 - **Timeout guards.** Added `timeout=30` on PyPI API calls and
   `--connect-timeout 10 --max-time 30` on verification curl.
+- **Dashboard artifact download retry.** Extracted dashboard download into a
+  reusable composite action with `gh` CLI fallback on transient
+  `download-artifact` failures (hit on Windows in 0.16.0 publish).
 
 ## 0.16.0
 

--- a/docs/content/docs/more/changelog.mdx
+++ b/docs/content/docs/more/changelog.mdx
@@ -5,6 +5,20 @@ description: "Release history for taskito — every notable change, fix, and fea
 
 All notable changes to taskito are documented here.
 
+## 0.16.1
+
+Patch release: publish workflow hardening.
+
+### Fixed
+
+- **PyPI publish pre-check.** Publish job now queries PyPI before uploading,
+  compares SHA-256 hashes per artifact, and skips upload when all wheels are
+  already present. Prevents `400 File already exists` on workflow reruns.
+- **PEP 639 compatibility.** Dropped `twine check --strict` which rejected the
+  `License-File` metadata emitted by maturin 1.13.3. Pinned `twine>=6.1`.
+- **Timeout guards.** Added `timeout=30` on PyPI API calls and
+  `--connect-timeout 10 --max-time 30` on verification curl.
+
 ## 0.16.0
 
 Feature release: mesh scheduling, DLQ policies, and a full dashboard redesign.

--- a/docs/src/lib/release.ts
+++ b/docs/src/lib/release.ts
@@ -1,4 +1,4 @@
-export const RELEASE_VERSION = "0.16.0";
+export const RELEASE_VERSION = "0.16.1";
 export const RELEASE_TAGLINE =
   "mesh scheduling, DLQ policies, dashboard redesign";
 export const RELEASE_BADGE = `v${RELEASE_VERSION.replace(/\.\d+$/, "")} — ${RELEASE_TAGLINE}`;

--- a/py_src/taskito/__init__.py
+++ b/py_src/taskito/__init__.py
@@ -122,4 +122,4 @@ try:
 
     __version__ = _get_version("taskito")
 except PackageNotFoundError:
-    __version__ = "0.16.0"
+    __version__ = "0.16.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "taskito"
-version = "0.16.0"
+version = "0.16.1"
 description = "Rust-powered task queue for Python. No broker required."
 requires-python = ">=3.10"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary

- Bump version to 0.16.1 across all 9 locations (5 crates, pyproject.toml, `__init__.py`, release.ts, changelog)
- Changelog documents publish workflow fixes shipped in #241 and #243

## Changes since 0.16.0

- PyPI publish pre-check with SHA-256 hash comparison (skip upload when already present)
- PEP 639 compatibility (`twine check` without `--strict`)
- Timeout guards on PyPI API calls and verification curl

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped package version to 0.16.1 across the project and updated the release badge/version constants.
* **Bug Fixes**
  * Skip redundant PyPI uploads via a pre-check; relax twine strictness and pin compatibility.
  * Add timeouts for PyPI calls and a dashboard artifact download retry with CLI fallback.
* **Documentation**
  * Added 0.16.1 changelog entry describing these fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->