### PR TITLE
fix(ci): replace twine check with check-wheel-contents

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -223,11 +223,11 @@ jobs:
 
       - name: Validate wheels
         run: |
-          pip install "twine>=6.1,<6.2"
+          pip install check-wheel-contents
           for whl in dist/*.whl; do
             unzip -qt "$whl"
           done
-          twine check dist/*
+          check-wheel-contents dist/*.whl
 
       - name: Check PyPI for existing version
         id: pypi-check

--- a/docs/content/docs/more/changelog.mdx
+++ b/docs/content/docs/more/changelog.mdx
@@ -14,8 +14,10 @@ Patch release: publish workflow hardening.
 - **PyPI publish pre-check.** Publish job now queries PyPI before uploading,
   compares SHA-256 hashes per artifact, and skips upload when all wheels are
   already present. Prevents `400 File already exists` on workflow reruns.
-- **PEP 639 compatibility.** Dropped `twine check --strict` which rejected the
-  `License-File` metadata emitted by maturin 1.13.3. Pinned `twine>=6.1`.
+- **PEP 639 compatibility.** Replaced `twine check` with `check-wheel-contents`
+  for wheel validation. `twine check` broke on PEP 639 `License-File` metadata
+  emitted by maturin 1.13.3 (`packaging` library incompatibility). Structural
+  validation via `check-wheel-contents`; PyPI validates metadata on upload.
 - **Timeout guards.** Added `timeout=30` on PyPI API calls and
   `--connect-timeout 10 --max-time 30` on verification curl.
 - **Dashboard artifact download retry.** Extracted dashboard download into a


### PR DESCRIPTION
## Summary

- Replace `twine check` with `check-wheel-contents` for wheel validation
- `twine check` breaks on PEP 639 `License-File` metadata across multiple versions — `packaging` library incompatibility with metadata 2.4 emitted by maturin 1.13.3
- `check-wheel-contents` validates wheel structure (duplicates, bytecode, module layout) without parsing METADATA
- PyPI validates metadata on upload — no gap in coverage
- Also includes version bump to 0.16.1 and artifact download retry from prior merged PR #244

## Why not just pin twine + packaging?

Tried across 3 PRs: `--strict` removal, `<6.2` pin, `>=6.1,<6.2`. Root cause is `packaging` library not parsing metadata 2.4 without `>=24.2`, and twine's metadata parsing is a side effect of `PackageFile.from_filename()` called even by `twine check`. Eliminating the dependency is more maintainable than version-chasing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved release workflow and package validation processes.

* **Documentation**
  * Updated release notes to reflect tooling updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->