### PR TITLE
fix(ci): ignore W009/W010 in check-wheel-contents

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -227,7 +227,7 @@ jobs:
           for whl in dist/*.whl; do
             unzip -qt "$whl"
           done
-          check-wheel-contents dist/*.whl
+          check-wheel-contents --ignore W009,W010 dist/*.whl
 
       - name: Check PyPI for existing version
         id: pypi-check


### PR DESCRIPTION
## Summary

- Add `--ignore W009,W010` to `check-wheel-contents` — auditwheel bundles shared libs into `taskito.libs/` for musllinux wheels
- Lost in squash merge of #246

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package validation process during publishing to adjust validation checks for wheel files, improving the build workflow efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->