### PR TITLE
fix(ci): publish via uv to avoid OIDC token expiry

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -338,12 +338,13 @@ jobs:
                   print(f"::notice::{len(missing)}/{len(local)} artifact(s) missing on PyPI")
           PYCHECK
 
+      - name: Set up uv
+        if: steps.pypi-check.outputs.all_uploaded != 'true' && !inputs.dry-run
+        uses: astral-sh/setup-uv@v7
+
       - name: Publish to PyPI
         if: steps.pypi-check.outputs.all_uploaded != 'true' && !inputs.dry-run
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
-        with:
-          packages-dir: dist/
-          skip-existing: true
+        run: uv publish --trusted-publishing always dist/*
 
       - name: Verify version on PyPI
         if: "!inputs.dry-run"


### PR DESCRIPTION
## Summary

- Disable sigstore attestations in pypi-publish step
- OIDC token expires (~5min TTL) before signing completes with 21 artifacts (~10s each)
- `sigstore.oidc.ExpiredIdentity` crashed publish before any upload

## Test plan

- [ ] Rerun publish: `gh workflow run publish.yml -f version=0.16.1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated PyPI publishing workflow: replaced the previous publish mechanism with a new publish step that sets up and runs the updated publisher, and adjusted publishing conditions and flags to control artifact upload and trusted publishing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->