### PR TITLE
fix(ci): make GitHub release step idempotent

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -374,6 +374,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "$VERSION" \
-            --title "v${VERSION}" \
-            --generate-notes
+          if gh release view "$VERSION" >/dev/null 2>&1; then
+            echo "::notice::Release ${VERSION} already exists — skipping"
+          else
+            gh release create "$VERSION" \
+              --title "v${VERSION}" \
+              --generate-notes
+          fi


### PR DESCRIPTION
## Problem

Run [27393170986](https://github.com/ByteVeda/taskito/actions/runs/27393170986) published 0.16.1 to PyPI successfully, but the `publish` job still went red. The final `Create GitHub release` step failed with `HTTP 422: Release.tag_name already exists` because a release for the tag already existed.

A red job after a successful upload is misleading and breaks reruns.

## Fix

Skip `gh release create` when the release already exists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the release process to prevent duplicate releases by verifying release existence before creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->