### PR TITLE
fix(docs): prefix basePath on markdown and OG URLs

### DIFF
--- a/docs/src/lib/shared.ts
+++ b/docs/src/lib/shared.ts
@@ -3,6 +3,11 @@ export const docsRoute = "/";
 export const docsImageRoute = "/og";
 export const docsContentRoute = "/llms.mdx";
 
+// Raw href strings (markdown/OG routes) are not run through Next's router,
+// so basePath is not auto-applied — prepend it ourselves when deployed under
+// a sub-path (e.g. /taskito on GitHub Pages).
+export const basePath = process.env.NEXT_PUBLIC_DOCS_BASE_PATH ?? "";
+
 export const gitConfig = {
   user: "ByteVeda",
   repo: "taskito",

--- a/docs/src/lib/source.ts
+++ b/docs/src/lib/source.ts
@@ -1,6 +1,11 @@
 import { docs } from "collections/server";
 import { loader } from "fumadocs-core/source";
-import { docsContentRoute, docsImageRoute, docsRoute } from "./shared";
+import {
+  basePath,
+  docsContentRoute,
+  docsImageRoute,
+  docsRoute,
+} from "./shared";
 
 // See https://fumadocs.dev/docs/headless/source-api for more info
 export const source = loader({
@@ -14,7 +19,7 @@ export function getPageImage(page: (typeof source)["$inferPage"]) {
 
   return {
     segments,
-    url: `${docsImageRoute}/${segments.join("/")}`,
+    url: `${basePath}${docsImageRoute}/${segments.join("/")}`,
   };
 }
 
@@ -23,7 +28,7 @@ export function getPageMarkdownUrl(page: (typeof source)["$inferPage"]) {
 
   return {
     segments,
-    url: `${docsContentRoute}/${segments.join("/")}`,
+    url: `${basePath}${docsContentRoute}/${segments.join("/")}`,
   };
 }
 


### PR DESCRIPTION
## Problem

On the deployed docs (`docs.byteveda.org`, served under the `/taskito` basePath), every "View as Markdown" link 404s, e.g. `/llms.mdx/getting-started/installation/content.md`. The actual file lives at `/taskito/llms.mdx/.../content.md`.

`getPageMarkdownUrl().url` (and `getPageImage().url` for OG) are raw href strings. Next.js only auto-applies `basePath` to router-driven links (`<Link>`), not to plain string hrefs handed to `MarkdownCopyButton` / `ViewOptionsPopover` / OG metadata — so the prefix was dropped.

## Fix

Prepend `basePath` (from `NEXT_PUBLIC_DOCS_BASE_PATH`) to both `.url` values. Route-param `segments` stay unprefixed, so `generateStaticParams` and the emitted static files are unchanged.

Verified: built HTML now references `/taskito/llms.mdx/.../content.md`; static files still emit at the same paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL handling for sub-path deployments to ensure images and markdown files are correctly referenced when the application is hosted under a non-root location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->