### PR TITLE
fix(redis): write-path atomicity races

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,9 +268,9 @@ jobs:
             python-version: "3.13"
           - os: macos-latest
             python-version: "3.10"
-          - os: windows-latest
+          - os: windows-2025
             python-version: "3.13"
-          - os: windows-latest
+          - os: windows-2025
             python-version: "3.10"
     steps:
       - name: Check out repository

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -201,7 +201,7 @@ jobs:
 
   build-wheels-windows:
     needs: build-dashboard
-    runs-on: windows-latest
+    runs-on: windows-2025
     strategy:
       fail-fast: false
       matrix:

--- a/crates/taskito-core/Cargo.toml
+++ b/crates/taskito-core/Cargo.toml
@@ -32,3 +32,7 @@ redis = { workspace = true, optional = true }
 
 [dev-dependencies]
 tempfile = "3"
+# Raw connection access in the Redis contract tests, to set up race-window
+# state and assert on internal index keys. Only used by `#[cfg(feature = "redis")]`
+# tests; harmless when the feature is off.
+redis = { workspace = true }

--- a/crates/taskito-core/src/storage/redis_backend/dead_letter.rs
+++ b/crates/taskito-core/src/storage/redis_backend/dead_letter.rs
@@ -89,18 +89,23 @@ impl RedisStorage {
         let dlq_key = self.key(&["dlq", &dlq_id]);
         let dlq_all = self.key(&["dlq", "all"]);
 
-        let pipe = &mut redis::pipe();
-        pipe.set(&dlq_key, &json);
-        pipe.zadd(&dlq_all, &dlq_id, now as f64);
-        pipe.query::<()>(&mut conn).map_err(map_err)?;
-
-        // Archive the now-Dead job out of the live indices.
+        // Commit the DLQ entry and the live→archive move in one atomic pipeline,
+        // so a crash can't leave the job both DLQ'd and still live-Running (which
+        // a reaper would dead-letter again, or retry_dead would duplicate).
         let mut dead_job = job.clone();
         let old_status = dead_job.status;
         dead_job.status = JobStatus::Dead;
         dead_job.error = Some(error.to_string());
         dead_job.completed_at = Some(now);
-        self.archive_job_immediately(&mut conn, &dead_job, old_status)?;
+        let dead_json =
+            serde_json::to_string(&dead_job).map_err(|e| QueueError::Other(e.to_string()))?;
+
+        let pipe = &mut redis::pipe();
+        pipe.atomic();
+        pipe.set(&dlq_key, &json);
+        pipe.zadd(&dlq_all, &dlq_id, now as f64);
+        self.push_archive_ops(pipe, &dead_job, old_status, &dead_json);
+        pipe.query::<()>(&mut conn).map_err(map_err)?;
 
         // Cascade cancel dependents
         drop(conn);

--- a/crates/taskito-core/src/storage/redis_backend/dead_letter.rs
+++ b/crates/taskito-core/src/storage/redis_backend/dead_letter.rs
@@ -89,9 +89,6 @@ impl RedisStorage {
         let dlq_key = self.key(&["dlq", &dlq_id]);
         let dlq_all = self.key(&["dlq", "all"]);
 
-        // Commit the DLQ entry and the live→archive move in one atomic pipeline,
-        // so a crash can't leave the job both DLQ'd and still live-Running (which
-        // a reaper would dead-letter again, or retry_dead would duplicate).
         let mut dead_job = job.clone();
         let old_status = dead_job.status;
         dead_job.status = JobStatus::Dead;
@@ -100,16 +97,30 @@ impl RedisStorage {
         let dead_json =
             serde_json::to_string(&dead_job).map_err(|e| QueueError::Other(e.to_string()))?;
 
-        let pipe = &mut redis::pipe();
-        pipe.atomic();
-        pipe.set(&dlq_key, &json);
-        pipe.zadd(&dlq_all, &dlq_id, now as f64);
-        self.push_archive_ops(pipe, &dead_job, old_status, &dead_json);
-        pipe.query::<()>(&mut conn).map_err(map_err)?;
+        // Commit the DLQ entry and the live→archive move together, but only if the
+        // job is still live in its expected state. A racing complete/fail or the
+        // stale-job reaper may have archived it first; WATCH aborts the EXEC if
+        // `job:<id>` changes between the liveness check and the commit, so we never
+        // create a duplicate DLQ entry or overwrite a terminal archive.
+        let job_live_key = self.key(&["job", &job.id]);
+        let dead_lettered: bool =
+            redis::transaction(&mut conn, &[job_live_key.as_str()], |conn, pipe| {
+                if !conn.exists::<_, bool>(&job_live_key)? {
+                    return Ok(Some(false));
+                }
+                pipe.set(&dlq_key, &json).ignore();
+                pipe.zadd(&dlq_all, &dlq_id, now as f64).ignore();
+                self.push_archive_ops(pipe, &dead_job, old_status, &dead_json);
+                Ok(pipe.query::<Option<()>>(conn)?.map(|()| true))
+            })
+            .map_err(map_err)?;
 
-        // Cascade cancel dependents
+        // Cascade-cancel dependents only if we actually dead-lettered the job
+        // (skipped when a racer had already archived it).
         drop(conn);
-        self.cascade_cancel(&job.id, "dependency failed")?;
+        if dead_lettered {
+            self.cascade_cancel(&job.id, "dependency failed")?;
+        }
 
         Ok(())
     }

--- a/crates/taskito-core/src/storage/redis_backend/jobs/dequeue.rs
+++ b/crates/taskito-core/src/storage/redis_backend/jobs/dequeue.rs
@@ -6,7 +6,54 @@ use crate::error::{QueueError, Result};
 use crate::job::{Job, JobStatus};
 use crate::storage::redis_backend::{map_err, RedisStorage};
 
+/// Lua: claim a candidate by flipping it Pending→Running, but only if it is
+/// still a member of the pending status set (`jobs:status:0`). This is the
+/// Redis equivalent of the Diesel `UPDATE ... WHERE status = Pending`
+/// affected-row guard: a concurrent cancel/expire that already archived the
+/// job has removed it from `jobs:status:0`, so the claim is refused (returns 0)
+/// instead of resurrecting the job as a Running orphan. Redis runs the script
+/// atomically, which also closes the double-claim window between schedulers.
+///
+/// KEYS: job_key, pending_status_set, running_status_set, pending_zset
+/// ARGV: job_id, running_json
+const CLAIM_JOB_SCRIPT: &str = r#"
+    if redis.call('SISMEMBER', KEYS[2], ARGV[1]) == 0 then return 0 end
+    redis.call('SET', KEYS[1], ARGV[2])
+    redis.call('SREM', KEYS[2], ARGV[1])
+    redis.call('SADD', KEYS[3], ARGV[1])
+    redis.call('ZREM', KEYS[4], ARGV[1])
+    return 1
+"#;
+
 impl RedisStorage {
+    /// Atomically claim a candidate job (Pending→Running) via [`CLAIM_JOB_SCRIPT`].
+    /// The caller must have already set `job.status = Running` and `started_at`.
+    /// Returns `false` if the job was concurrently cancelled/expired/claimed, so
+    /// the dequeue scan should skip it.
+    fn claim_pending(
+        &self,
+        conn: &mut redis::Connection,
+        job: &Job,
+        queue_key: &str,
+    ) -> Result<bool> {
+        let job_json = serde_json::to_string(job).map_err(|e| QueueError::Other(e.to_string()))?;
+        let job_key = self.key(&["job", &job.id]);
+        let pending_status =
+            self.key(&["jobs", "status", &(JobStatus::Pending as i32).to_string()]);
+        let running_status =
+            self.key(&["jobs", "status", &(JobStatus::Running as i32).to_string()]);
+        let claimed: i32 = redis::Script::new(CLAIM_JOB_SCRIPT)
+            .key(&job_key)
+            .key(&pending_status)
+            .key(&running_status)
+            .key(queue_key)
+            .arg(&job.id)
+            .arg(&job_json)
+            .invoke(conn)
+            .map_err(map_err)?;
+        Ok(claimed == 1)
+    }
+
     pub fn dequeue(
         &self,
         queue_name: &str,
@@ -101,14 +148,13 @@ impl RedisStorage {
                 }
             }
 
-            // Claim the job
+            // Claim the job atomically; if we lost the race (cancelled / expired
+            // / claimed by another scheduler) skip to the next candidate.
             job.status = JobStatus::Running;
             job.started_at = Some(now);
-            self.save_job_and_move_status(&mut conn, &job, JobStatus::Pending)?;
-            conn.zrem::<_, _, ()>(&queue_key, &job_id)
-                .map_err(map_err)?;
-
-            return Ok(Some(job));
+            if self.claim_pending(&mut conn, &job, &queue_key)? {
+                return Ok(Some(job));
+            }
         }
 
         Ok(None)
@@ -240,14 +286,13 @@ impl RedisStorage {
                 }
             }
 
-            // Claim the job
+            // Claim the job atomically; skip candidates lost to a concurrent
+            // cancel / expire / claim instead of resurrecting them.
             job.status = JobStatus::Running;
             job.started_at = Some(now);
-            self.save_job_and_move_status(&mut conn, &job, JobStatus::Pending)?;
-            conn.zrem::<_, _, ()>(&queue_key, &job_id)
-                .map_err(map_err)?;
-
-            claimed.push(job);
+            if self.claim_pending(&mut conn, &job, &queue_key)? {
+                claimed.push(job);
+            }
         }
 
         Ok(claimed)

--- a/crates/taskito-core/src/storage/redis_backend/jobs/helpers.rs
+++ b/crates/taskito-core/src/storage/redis_backend/jobs/helpers.rs
@@ -229,20 +229,14 @@ impl RedisStorage {
         pipe.del(&errors_key);
         pipe.del(&deps_key);
         pipe.del(&dependents_key);
-
-        // Only release the unique-key pointer if it still points at THIS job.
-        // `enqueue_unique` stores the job id at `jobs:unique:<uk>`; a newer live
-        // job may have reused the same `unique_key` after this row was archived,
-        // and deleting the pointer would clobber the new job's lock.
-        if let Some(ref uk) = job.unique_key {
-            let unique_key = self.key(&["jobs", "unique", uk]);
-            let owner: Option<String> = conn.get(&unique_key).map_err(map_err)?;
-            if owner.as_deref() == Some(job.id.as_str()) {
-                pipe.del(&unique_key);
-            }
-        }
-
         pipe.query::<()>(conn).map_err(map_err)?;
+
+        // Release the unique-key pointer through the atomic compare-and-delete so
+        // a `enqueue_unique` that reused the key between a plain GET and DEL can't
+        // have its lock clobbered.
+        if let Some(ref uk) = job.unique_key {
+            self.release_unique_key(conn, uk, &job.id)?;
+        }
 
         Ok(())
     }

--- a/crates/taskito-core/src/storage/redis_backend/jobs/helpers.rs
+++ b/crates/taskito-core/src/storage/redis_backend/jobs/helpers.rs
@@ -166,20 +166,23 @@ impl RedisStorage {
         let archived_by_queue = self.key(&["archived", "by_queue", &job.queue]);
         let archived_all = self.key(&["archived", "all"]);
 
-        pipe.del(&job_key);
-        pipe.srem(&status_key, &job.id);
-        pipe.srem(&by_queue_key, &job.id);
-        pipe.srem(&by_task_key, &job.id);
-        pipe.zrem(&all_key, &job.id);
+        // Results are ignored so callers can query the pipe as `()` (or
+        // `Option<()>` inside a WATCH transaction).
+        pipe.del(&job_key).ignore();
+        pipe.srem(&status_key, &job.id).ignore();
+        pipe.srem(&by_queue_key, &job.id).ignore();
+        pipe.srem(&by_task_key, &job.id).ignore();
+        pipe.zrem(&all_key, &job.id).ignore();
         // Pending jobs still sit in the per-queue pending zset; running jobs
         // were removed at dequeue, so only remove on a Pending→terminal move.
         if old_status == JobStatus::Pending {
-            pipe.zrem(&pending_key, &job.id);
+            pipe.zrem(&pending_key, &job.id).ignore();
         }
-        pipe.set(&archived_key, job_json);
-        pipe.sadd(&archived_status_key, &job.id);
-        pipe.sadd(&archived_by_queue, &job.id);
-        pipe.zadd(&archived_all, &job.id, completed_at as f64);
+        pipe.set(&archived_key, job_json).ignore();
+        pipe.sadd(&archived_status_key, &job.id).ignore();
+        pipe.sadd(&archived_by_queue, &job.id).ignore();
+        pipe.zadd(&archived_all, &job.id, completed_at as f64)
+            .ignore();
     }
 
     /// Move a terminal job out of the live indices into the archive in one

--- a/crates/taskito-core/src/storage/redis_backend/jobs/helpers.rs
+++ b/crates/taskito-core/src/storage/redis_backend/jobs/helpers.rs
@@ -140,22 +140,18 @@ impl RedisStorage {
         Ok(())
     }
 
-    /// Move a terminal job out of the live indices into the archive in a single
-    /// pipeline. Removes it from `job:<id>`, the live status / by_queue /
-    /// by_task sets and the `jobs:all` zset, then writes `archived:<id>`, adds
-    /// it to `archived:status:<n>` and scores it into `archived:all` by
-    /// completed_at.
-    ///
-    /// `old_status` is the status the job held in the live `jobs:status:<n>`
-    /// set; the caller must have already set the job's terminal `status`,
-    /// `completed_at` (and `error`/`result` as appropriate).
-    pub(in crate::storage::redis_backend) fn archive_job_immediately(
+    /// Append the live→archive command sequence to `pipe` (no MULTI/EXEC of its
+    /// own). Removes the job from the live indices and writes the archived row.
+    /// Shared by `archive_job_immediately` and `move_to_dlq` so the DLQ write and
+    /// the archive can commit in one transaction. The caller must have already
+    /// set the terminal `status`/`completed_at` and serialized `job_json`.
+    pub(in crate::storage::redis_backend) fn push_archive_ops(
         &self,
-        conn: &mut redis::Connection,
+        pipe: &mut redis::Pipeline,
         job: &Job,
         old_status: JobStatus,
-    ) -> Result<()> {
-        let job_json = serde_json::to_string(job).map_err(|e| QueueError::Other(e.to_string()))?;
+        job_json: &str,
+    ) {
         let completed_at = job.completed_at.unwrap_or_else(crate::job::now_millis);
 
         let job_key = self.key(&["job", &job.id]);
@@ -170,10 +166,6 @@ impl RedisStorage {
         let archived_by_queue = self.key(&["archived", "by_queue", &job.queue]);
         let archived_all = self.key(&["archived", "all"]);
 
-        // `.atomic()` wraps the live→archive move in MULTI/EXEC so the job is
-        // never observable in both the live and archived indices at once.
-        let pipe = &mut redis::pipe();
-        pipe.atomic();
         pipe.del(&job_key);
         pipe.srem(&status_key, &job.id);
         pipe.srem(&by_queue_key, &job.id);
@@ -184,10 +176,25 @@ impl RedisStorage {
         if old_status == JobStatus::Pending {
             pipe.zrem(&pending_key, &job.id);
         }
-        pipe.set(&archived_key, &job_json);
+        pipe.set(&archived_key, job_json);
         pipe.sadd(&archived_status_key, &job.id);
         pipe.sadd(&archived_by_queue, &job.id);
         pipe.zadd(&archived_all, &job.id, completed_at as f64);
+    }
+
+    /// Move a terminal job out of the live indices into the archive in one
+    /// atomic pipeline (`.atomic()` MULTI/EXEC), so it is never observable in
+    /// both the live and archived indices at once.
+    pub(in crate::storage::redis_backend) fn archive_job_immediately(
+        &self,
+        conn: &mut redis::Connection,
+        job: &Job,
+        old_status: JobStatus,
+    ) -> Result<()> {
+        let job_json = serde_json::to_string(job).map_err(|e| QueueError::Other(e.to_string()))?;
+        let pipe = &mut redis::pipe();
+        pipe.atomic();
+        self.push_archive_ops(pipe, job, old_status, &job_json);
         pipe.query::<()>(conn).map_err(map_err)?;
 
         Ok(())

--- a/crates/taskito-core/src/storage/redis_backend/jobs/helpers.rs
+++ b/crates/taskito-core/src/storage/redis_backend/jobs/helpers.rs
@@ -7,6 +7,18 @@ use crate::error::{QueueError, Result};
 use crate::job::{Job, JobStatus};
 use crate::storage::redis_backend::{map_err, RedisStorage};
 
+/// Lua: release a unique-key pointer only if it still points at `ARGV[1]`.
+/// A newer job may have reused the same `unique_key` after this job left the
+/// live indices, so an unconditional `DEL` would clobber the new job's dedup
+/// lock. Mirrors `RELEASE_LOCK_SCRIPT` in `locks.rs`.
+const RELEASE_UNIQUE_IF_OWNER: &str = r#"
+    if redis.call('GET', KEYS[1]) == ARGV[1] then
+        redis.call('DEL', KEYS[1])
+        return 1
+    end
+    return 0
+"#;
+
 impl RedisStorage {
     pub(in crate::storage::redis_backend) fn load_job(
         &self,
@@ -107,6 +119,24 @@ impl RedisStorage {
         pipe.zadd(&queue_key, &job.id, score);
         pipe.query::<()>(conn).map_err(map_err)?;
 
+        Ok(())
+    }
+
+    /// Release a job's unique-key pointer iff it still belongs to this job, via
+    /// an atomic compare-and-delete (mirrors `RELEASE_LOCK_SCRIPT`). Safe to
+    /// call when a newer job may have reused the same `unique_key`.
+    pub(in crate::storage::redis_backend) fn release_unique_key(
+        &self,
+        conn: &mut redis::Connection,
+        unique_key: &str,
+        job_id: &str,
+    ) -> Result<()> {
+        let key = self.key(&["jobs", "unique", unique_key]);
+        redis::Script::new(RELEASE_UNIQUE_IF_OWNER)
+            .key(&key)
+            .arg(job_id)
+            .invoke::<i32>(conn)
+            .map_err(map_err)?;
         Ok(())
     }
 

--- a/crates/taskito-core/src/storage/redis_backend/jobs/helpers.rs
+++ b/crates/taskito-core/src/storage/redis_backend/jobs/helpers.rs
@@ -2,6 +2,7 @@
 
 use redis::Commands;
 
+use super::dequeue_score;
 use crate::error::{QueueError, Result};
 use crate::job::{Job, JobStatus};
 use crate::storage::redis_backend::{map_err, RedisStorage};
@@ -69,6 +70,41 @@ impl RedisStorage {
             pipe.srem(&old_status_key, &job.id);
             pipe.sadd(&new_status_key, &job.id);
         }
+        pipe.query::<()>(conn).map_err(map_err)?;
+
+        Ok(())
+    }
+
+    /// Reset a job to `Pending` and (re)insert it into the per-queue pending
+    /// zset in a single MULTI/EXEC. Folding the status-set move and the zset
+    /// add into one transaction means a crash can no longer strand the job as
+    /// `Pending` in the status set but absent from the queue zset (where it
+    /// would never be dequeued and never reaped).
+    ///
+    /// The caller must have already set the job's `status = Pending`,
+    /// `scheduled_at`, and cleared `started_at`/`completed_at`/`error`.
+    pub(in crate::storage::redis_backend) fn requeue_pending(
+        &self,
+        conn: &mut redis::Connection,
+        job: &Job,
+        old_status: JobStatus,
+    ) -> Result<()> {
+        let job_json = serde_json::to_string(job).map_err(|e| QueueError::Other(e.to_string()))?;
+        let job_key = self.key(&["job", &job.id]);
+        let old_status_key = self.key(&["jobs", "status", &(old_status as i32).to_string()]);
+        let pending_status_key =
+            self.key(&["jobs", "status", &(JobStatus::Pending as i32).to_string()]);
+        let queue_key = self.key(&["queue", &job.queue, "pending"]);
+        let score = dequeue_score(job.priority, job.scheduled_at);
+
+        let pipe = &mut redis::pipe();
+        pipe.atomic();
+        pipe.set(&job_key, &job_json);
+        if old_status != JobStatus::Pending {
+            pipe.srem(&old_status_key, &job.id);
+            pipe.sadd(&pending_status_key, &job.id);
+        }
+        pipe.zadd(&queue_key, &job.id, score);
         pipe.query::<()>(conn).map_err(map_err)?;
 
         Ok(())

--- a/crates/taskito-core/src/storage/redis_backend/jobs/state.rs
+++ b/crates/taskito-core/src/storage/redis_backend/jobs/state.rs
@@ -3,7 +3,6 @@
 
 use redis::Commands;
 
-use super::dequeue_score;
 use crate::error::{QueueError, Result};
 use crate::job::{now_millis, JobStatus};
 use crate::storage::redis_backend::{map_err, RedisStorage};
@@ -61,13 +60,8 @@ impl RedisStorage {
         job.completed_at = None;
         job.error = None;
 
-        self.save_job_and_move_status(&mut conn, &job, old_status)?;
-
-        // Re-add to pending queue
-        let queue_key = self.key(&["queue", &job.queue, "pending"]);
-        let score = dequeue_score(job.priority, job.scheduled_at);
-        conn.zadd::<_, _, _, ()>(&queue_key, &job.id, score)
-            .map_err(map_err)?;
+        // Atomic status-move + pending-zset insert (see `requeue_pending`).
+        self.requeue_pending(&mut conn, &job, old_status)?;
 
         Ok(())
     }
@@ -86,13 +80,8 @@ impl RedisStorage {
         job.completed_at = None;
         job.error = None;
 
-        self.save_job_and_move_status(&mut conn, &job, old_status)?;
-
-        // Re-add to pending queue
-        let queue_key = self.key(&["queue", &job.queue, "pending"]);
-        let score = dequeue_score(job.priority, job.scheduled_at);
-        conn.zadd::<_, _, _, ()>(&queue_key, &job.id, score)
-            .map_err(map_err)?;
+        // Atomic status-move + pending-zset insert (see `requeue_pending`).
+        self.requeue_pending(&mut conn, &job, old_status)?;
 
         Ok(())
     }

--- a/crates/taskito-core/src/storage/redis_backend/jobs/state.rs
+++ b/crates/taskito-core/src/storage/redis_backend/jobs/state.rs
@@ -7,6 +7,26 @@ use crate::error::{QueueError, Result};
 use crate::job::{now_millis, JobStatus};
 use crate::storage::redis_backend::{map_err, RedisStorage};
 
+/// Lua: write the precomputed job JSON only if the job is still live (its
+/// `job:<id>` key exists). Guards `update_progress` so a concurrent archive
+/// (complete/fail/reap) can't be clobbered into a resurrected orphan key that
+/// belongs to no index. Returns 1 on write, 0 if the job is already gone.
+const SET_IF_LIVE: &str = r#"
+    if redis.call('EXISTS', KEYS[1]) == 0 then return 0 end
+    redis.call('SET', KEYS[1], ARGV[1])
+    return 1
+"#;
+
+/// Lua: mark a job cancel-requested (write JSON + add to the cancel set) only
+/// if it is still live-Running (member of `jobs:status:1`). Prevents resurrecting
+/// a job that was archived concurrently. Returns 1 if applied, 0 otherwise.
+const REQUEST_CANCEL_IF_RUNNING: &str = r#"
+    if redis.call('SISMEMBER', KEYS[2], ARGV[1]) == 0 then return 0 end
+    redis.call('SET', KEYS[1], ARGV[2])
+    redis.call('SADD', KEYS[3], ARGV[1])
+    return 1
+"#;
+
 impl RedisStorage {
     pub fn complete(&self, id: &str, result_bytes: Option<Vec<u8>>) -> Result<()> {
         let mut conn = self.conn()?;
@@ -129,12 +149,22 @@ impl RedisStorage {
         job.cancel_requested = true;
         let job_json = serde_json::to_string(&job).map_err(|e| QueueError::Other(e.to_string()))?;
         let job_key = self.key(&["job", id]);
-        conn.set::<_, _, ()>(&job_key, &job_json).map_err(map_err)?;
-
+        let running_key = self.key(&["jobs", "status", &(JobStatus::Running as i32).to_string()]);
         let cancel_set = self.key(&["jobs", "cancel_requested"]);
-        conn.sadd::<_, _, ()>(&cancel_set, id).map_err(map_err)?;
 
-        Ok(true)
+        // Guarded write: only mark the job if it is still live-Running. If it was
+        // archived between the read above and here, the script is a no-op (returns
+        // 0) and we report "not cancellable" rather than resurrecting it.
+        let applied: i32 = redis::Script::new(REQUEST_CANCEL_IF_RUNNING)
+            .key(&job_key)
+            .key(&running_key)
+            .key(&cancel_set)
+            .arg(id)
+            .arg(&job_json)
+            .invoke(&mut conn)
+            .map_err(map_err)?;
+
+        Ok(applied == 1)
     }
 
     pub fn is_cancel_requested(&self, id: &str) -> Result<bool> {
@@ -231,7 +261,15 @@ impl RedisStorage {
         job.progress = Some(progress);
         let job_json = serde_json::to_string(&job).map_err(|e| QueueError::Other(e.to_string()))?;
         let job_key = self.key(&["job", id]);
-        conn.set::<_, _, ()>(&job_key, &job_json).map_err(map_err)?;
+
+        // Guarded write: only update if `job:<id>` still exists. If the job was
+        // archived (completed/failed/reaped) between the read and here, the plain
+        // SET would otherwise recreate it as a Running orphan outside every index.
+        redis::Script::new(SET_IF_LIVE)
+            .key(&job_key)
+            .arg(&job_json)
+            .invoke::<i32>(&mut conn)
+            .map_err(map_err)?;
         Ok(())
     }
 }

--- a/crates/taskito-core/src/storage/redis_backend/jobs/state.rs
+++ b/crates/taskito-core/src/storage/redis_backend/jobs/state.rs
@@ -22,10 +22,12 @@ impl RedisStorage {
         job.result = result_bytes;
         self.archive_job_immediately(&mut conn, &job, old_status)?;
 
-        // Clean up unique key if present
+        // Release the unique-key pointer only if it still points at THIS job —
+        // a concurrent enqueue_unique reusing the key after the archive removed
+        // `job:<id>` may have already repointed it to a new job, whose dedup
+        // lock an unconditional DEL would clobber.
         if let Some(ref uk) = job.unique_key {
-            let unique_key = self.key(&["jobs", "unique", uk]);
-            conn.del::<_, ()>(&unique_key).map_err(map_err)?;
+            self.release_unique_key(&mut conn, uk, id)?;
         }
 
         Ok(())

--- a/crates/taskito-core/src/storage/redis_backend/jobs/state.rs
+++ b/crates/taskito-core/src/storage/redis_backend/jobs/state.rs
@@ -265,11 +265,16 @@ impl RedisStorage {
         // Guarded write: only update if `job:<id>` still exists. If the job was
         // archived (completed/failed/reaped) between the read and here, the plain
         // SET would otherwise recreate it as a Running orphan outside every index.
-        redis::Script::new(SET_IF_LIVE)
+        let applied: i32 = redis::Script::new(SET_IF_LIVE)
             .key(&job_key)
             .arg(&job_json)
-            .invoke::<i32>(&mut conn)
+            .invoke(&mut conn)
             .map_err(map_err)?;
+        if applied == 0 {
+            // The job was archived concurrently — surface it like the read path
+            // rather than reporting a silent success that wrote nothing.
+            return Err(QueueError::JobNotFound(id.to_string()));
+        }
         Ok(())
     }
 }

--- a/crates/taskito-core/tests/rust/storage_tests.rs
+++ b/crates/taskito-core/tests/rust/storage_tests.rs
@@ -660,6 +660,7 @@ fn redis_storage_tests() {
     redis_claim_skips_job_dropped_from_pending_set(&storage);
     redis_retry_keeps_job_dequeuable(&storage);
     redis_complete_preserves_reused_unique_key(&storage);
+    redis_update_progress_never_resurrects_archived(&storage);
 }
 
 /// Build a raw key under the storage's prefix, matching `RedisStorage::key`.
@@ -753,6 +754,36 @@ fn redis_complete_preserves_reused_unique_key(s: &taskito_core::RedisStorage) {
         "complete must not delete a unique key reused by another job"
     );
     let _: () = conn.del(&ukey).unwrap();
+}
+
+/// #64: a progress update must never recreate `job:<id>` once the job has been
+/// archived. The Lua existence gate (and the live-only required lookup) keep a
+/// stale update from leaving an orphan key outside every index.
+#[cfg(feature = "redis")]
+fn redis_update_progress_never_resurrects_archived(s: &taskito_core::RedisStorage) {
+    use redis::Commands;
+    let q = "q-redis-progress-guard";
+    drain_queue(s, q);
+    let job = s.enqueue(make_job(q, "progress_guard")).unwrap();
+    s.dequeue(q, now_millis() + 1000, None).unwrap();
+
+    // Live update goes through the guard and writes.
+    s.update_progress(&job.id, 42).unwrap();
+    assert_eq!(s.get_job(&job.id).unwrap().unwrap().progress, Some(42));
+
+    // After archival the job key is gone; a stale update must not resurrect it.
+    s.complete(&job.id, None).unwrap();
+    assert!(matches!(
+        s.update_progress(&job.id, 99),
+        Err(taskito_core::error::QueueError::JobNotFound(_))
+    ));
+    let mut conn = s.conn().unwrap();
+    let jkey = rkey(s, &["job", &job.id]);
+    let exists: bool = conn.exists(&jkey).unwrap();
+    assert!(
+        !exists,
+        "archived job key must not be resurrected by a progress update"
+    );
 }
 
 /// A terminal job has left the live indices, so a mutator that resolves the

--- a/crates/taskito-core/tests/rust/storage_tests.rs
+++ b/crates/taskito-core/tests/rust/storage_tests.rs
@@ -661,6 +661,7 @@ fn redis_storage_tests() {
     redis_retry_keeps_job_dequeuable(&storage);
     redis_complete_preserves_reused_unique_key(&storage);
     redis_update_progress_never_resurrects_archived(&storage);
+    redis_move_to_dlq_leaves_consistent_state(&storage);
 }
 
 /// Build a raw key under the storage's prefix, matching `RedisStorage::key`.
@@ -681,10 +682,10 @@ fn drain_queue(s: &taskito_core::RedisStorage, q: &str) {
     {}
 }
 
-/// #17: the atomic claim must refuse a candidate that a concurrent cancel/expire
-/// already removed from the pending status set, instead of resurrecting it as a
-/// Running orphan. Simulated deterministically by dropping the job from
-/// `jobs:status:0` while it lingers in the pending zset.
+/// The atomic claim must refuse a candidate that a concurrent cancel/expire
+/// already removed from the pending status set, rather than resurrecting it as a
+/// Running orphan. Simulated by dropping the job from `jobs:status:0` while it
+/// lingers in the pending zset.
 #[cfg(feature = "redis")]
 fn redis_claim_skips_job_dropped_from_pending_set(s: &taskito_core::RedisStorage) {
     use redis::Commands;
@@ -706,9 +707,9 @@ fn redis_claim_skips_job_dropped_from_pending_set(s: &taskito_core::RedisStorage
     );
 }
 
-/// #62: retry must leave the job dequeuable — the status-set move and the
-/// pending-zset add now commit together, so the job is never stranded Pending
-/// but absent from the queue.
+/// Retry must leave the job dequeuable — the status-set move and the pending-zset
+/// add commit together, so the job is never stranded Pending but absent from the
+/// queue.
 #[cfg(feature = "redis")]
 fn redis_retry_keeps_job_dequeuable(s: &taskito_core::RedisStorage) {
     let q = "q-redis-retry-requeue";
@@ -726,9 +727,9 @@ fn redis_retry_keeps_job_dequeuable(s: &taskito_core::RedisStorage) {
     );
 }
 
-/// #63: completing a job must not clobber a `jobs:unique` pointer a different
-/// live job has reused — the release is a compare-and-delete. Simulated by
-/// repointing the pointer before `complete`.
+/// Completing a job must not clobber a `jobs:unique` pointer a different live job
+/// has reused — the release is a compare-and-delete. Simulated by repointing the
+/// pointer before `complete`.
 #[cfg(feature = "redis")]
 fn redis_complete_preserves_reused_unique_key(s: &taskito_core::RedisStorage) {
     use redis::Commands;
@@ -756,7 +757,7 @@ fn redis_complete_preserves_reused_unique_key(s: &taskito_core::RedisStorage) {
     let _: () = conn.del(&ukey).unwrap();
 }
 
-/// #64: a progress update must never recreate `job:<id>` once the job has been
+/// A progress update must never recreate `job:<id>` once the job has been
 /// archived. The Lua existence gate (and the live-only required lookup) keep a
 /// stale update from leaving an orphan key outside every index.
 #[cfg(feature = "redis")]
@@ -784,6 +785,39 @@ fn redis_update_progress_never_resurrects_archived(s: &taskito_core::RedisStorag
         !exists,
         "archived job key must not be resurrected by a progress update"
     );
+}
+
+/// The DLQ write and the live→archive move commit in one atomic pipeline, so a
+/// dead-lettered job is fully out of every live index and present in the DLQ —
+/// never a half state.
+#[cfg(feature = "redis")]
+fn redis_move_to_dlq_leaves_consistent_state(s: &taskito_core::RedisStorage) {
+    use redis::Commands;
+    let q = "q-redis-dlq-atomic";
+    drain_queue(s, q);
+    let job = s.enqueue(make_job(q, "dlq_atomic")).unwrap();
+    s.dequeue(q, now_millis() + 1000, None).unwrap();
+    let running = s.get_job(&job.id).unwrap().unwrap();
+
+    s.move_to_dlq(&running, "boom", None).unwrap();
+
+    let dead = s.list_dead(10, 0).unwrap();
+    assert!(
+        dead.iter().any(|d| d.original_job_id == job.id),
+        "job must be present in the DLQ"
+    );
+
+    let mut conn = s.conn().unwrap();
+    for set in [
+        rkey(s, &["jobs", "status", "1"]),
+        rkey(s, &["jobs", "by_queue", q]),
+    ] {
+        let member: bool = conn.sismember(&set, &job.id).unwrap();
+        assert!(!member, "dead job must be removed from live index {set}");
+    }
+    let all = rkey(s, &["jobs", "all"]);
+    let score: Option<f64> = conn.zscore(&all, &job.id).unwrap();
+    assert!(score.is_none(), "dead job must be removed from jobs:all");
 }
 
 /// A terminal job has left the live indices, so a mutator that resolves the

--- a/crates/taskito-core/tests/rust/storage_tests.rs
+++ b/crates/taskito-core/tests/rust/storage_tests.rs
@@ -646,9 +646,61 @@ fn redis_storage_tests() {
         }
     };
 
+    // The contract tests use fixed queue names and assert exact counts, so they
+    // need a clean DB. Flush it up front (DB 15 is the designated throwaway test
+    // database per the URL default) so the suite is deterministic across repeated
+    // local runs, not only against a fresh CI container.
+    let mut conn = storage.conn().unwrap();
+    let _: () = redis::cmd("FLUSHDB").query(&mut conn).unwrap();
+    drop(conn);
+
     run_storage_tests(&storage);
     redis_mutators_reject_archived_jobs(&storage);
     redis_purge_preserves_reused_unique_key(&storage);
+    redis_claim_skips_job_dropped_from_pending_set(&storage);
+}
+
+/// Build a raw key under the storage's prefix, matching `RedisStorage::key`.
+#[cfg(feature = "redis")]
+fn rkey(s: &taskito_core::RedisStorage, parts: &[&str]) -> String {
+    format!("{}{}", s.prefix(), parts.join(":"))
+}
+
+/// Drain any pending jobs left in `q` by earlier runs so the test that follows
+/// deterministically dequeues the job it just enqueued (the shared test DB is
+/// not flushed between runs).
+#[cfg(feature = "redis")]
+fn drain_queue(s: &taskito_core::RedisStorage, q: &str) {
+    while s
+        .dequeue(q, now_millis() + 1_000_000, None)
+        .unwrap()
+        .is_some()
+    {}
+}
+
+/// #17: the atomic claim must refuse a candidate that a concurrent cancel/expire
+/// already removed from the pending status set, instead of resurrecting it as a
+/// Running orphan. Simulated deterministically by dropping the job from
+/// `jobs:status:0` while it lingers in the pending zset.
+#[cfg(feature = "redis")]
+fn redis_claim_skips_job_dropped_from_pending_set(s: &taskito_core::RedisStorage) {
+    use redis::Commands;
+    let q = "q-redis-claim-guard";
+    drain_queue(s, q);
+    let job = s.enqueue(make_job(q, "claim_guard")).unwrap();
+
+    let mut conn = s.conn().unwrap();
+    let status_pending = rkey(s, &["jobs", "status", "0"]);
+    let _: () = conn.srem(&status_pending, &job.id).unwrap();
+
+    // No claimable candidate remains, and the job is not flipped to Running.
+    assert!(s.dequeue(q, now_millis() + 1000, None).unwrap().is_none());
+    let fetched = s.get_job(&job.id).unwrap().unwrap();
+    assert_eq!(
+        fetched.status,
+        JobStatus::Pending,
+        "claim guard must not resurrect a job dropped from the pending set"
+    );
 }
 
 /// A terminal job has left the live indices, so a mutator that resolves the

--- a/crates/taskito-core/tests/rust/storage_tests.rs
+++ b/crates/taskito-core/tests/rust/storage_tests.rs
@@ -658,6 +658,7 @@ fn redis_storage_tests() {
     redis_mutators_reject_archived_jobs(&storage);
     redis_purge_preserves_reused_unique_key(&storage);
     redis_claim_skips_job_dropped_from_pending_set(&storage);
+    redis_retry_keeps_job_dequeuable(&storage);
 }
 
 /// Build a raw key under the storage's prefix, matching `RedisStorage::key`.
@@ -700,6 +701,26 @@ fn redis_claim_skips_job_dropped_from_pending_set(s: &taskito_core::RedisStorage
         fetched.status,
         JobStatus::Pending,
         "claim guard must not resurrect a job dropped from the pending set"
+    );
+}
+
+/// #62: retry must leave the job dequeuable — the status-set move and the
+/// pending-zset add now commit together, so the job is never stranded Pending
+/// but absent from the queue.
+#[cfg(feature = "redis")]
+fn redis_retry_keeps_job_dequeuable(s: &taskito_core::RedisStorage) {
+    let q = "q-redis-retry-requeue";
+    drain_queue(s, q);
+    let job = s.enqueue(make_job(q, "retry_requeue")).unwrap();
+    s.dequeue(q, now_millis() + 1000, None).unwrap();
+
+    s.retry(&job.id, now_millis()).unwrap();
+
+    let again = s.dequeue(q, now_millis() + 1000, None).unwrap();
+    assert_eq!(
+        again.map(|j| j.id),
+        Some(job.id.clone()),
+        "retried job must be back in the pending zset and dequeuable"
     );
 }
 

--- a/crates/taskito-core/tests/rust/storage_tests.rs
+++ b/crates/taskito-core/tests/rust/storage_tests.rs
@@ -662,6 +662,7 @@ fn redis_storage_tests() {
     redis_complete_preserves_reused_unique_key(&storage);
     redis_update_progress_never_resurrects_archived(&storage);
     redis_move_to_dlq_leaves_consistent_state(&storage);
+    redis_move_to_dlq_skips_already_archived(&storage);
 }
 
 /// Build a raw key under the storage's prefix, matching `RedisStorage::key`.
@@ -818,6 +819,36 @@ fn redis_move_to_dlq_leaves_consistent_state(s: &taskito_core::RedisStorage) {
     let all = rkey(s, &["jobs", "all"]);
     let score: Option<f64> = conn.zscore(&all, &job.id).unwrap();
     assert!(score.is_none(), "dead job must be removed from jobs:all");
+}
+
+/// A stale caller that lost a race to `complete`/`fail`/the reaper must not
+/// dead-letter a job that was already archived — no duplicate DLQ entry, and the
+/// terminal archive is left intact.
+#[cfg(feature = "redis")]
+fn redis_move_to_dlq_skips_already_archived(s: &taskito_core::RedisStorage) {
+    let q = "q-redis-dlq-guard";
+    drain_queue(s, q);
+    let job = s.enqueue(make_job(q, "dlq_guard")).unwrap();
+    s.dequeue(q, now_millis() + 1000, None).unwrap();
+    let running = s.get_job(&job.id).unwrap().unwrap();
+
+    // A racer archives the job first (Complete).
+    s.complete(&job.id, None).unwrap();
+    let before = s.list_dead(1000, 0).unwrap().len();
+
+    // The stale move_to_dlq must be a no-op.
+    s.move_to_dlq(&running, "boom", None).unwrap();
+
+    assert_eq!(
+        s.list_dead(1000, 0).unwrap().len(),
+        before,
+        "move_to_dlq must not dead-letter an already-archived job"
+    );
+    assert_eq!(
+        s.get_job(&job.id).unwrap().unwrap().status,
+        JobStatus::Complete,
+        "terminal archive must not be overwritten to Dead"
+    );
 }
 
 /// A terminal job has left the live indices, so a mutator that resolves the

--- a/crates/taskito-core/tests/rust/storage_tests.rs
+++ b/crates/taskito-core/tests/rust/storage_tests.rs
@@ -659,6 +659,7 @@ fn redis_storage_tests() {
     redis_purge_preserves_reused_unique_key(&storage);
     redis_claim_skips_job_dropped_from_pending_set(&storage);
     redis_retry_keeps_job_dequeuable(&storage);
+    redis_complete_preserves_reused_unique_key(&storage);
 }
 
 /// Build a raw key under the storage's prefix, matching `RedisStorage::key`.
@@ -722,6 +723,36 @@ fn redis_retry_keeps_job_dequeuable(s: &taskito_core::RedisStorage) {
         Some(job.id.clone()),
         "retried job must be back in the pending zset and dequeuable"
     );
+}
+
+/// #63: completing a job must not clobber a `jobs:unique` pointer a different
+/// live job has reused — the release is a compare-and-delete. Simulated by
+/// repointing the pointer before `complete`.
+#[cfg(feature = "redis")]
+fn redis_complete_preserves_reused_unique_key(s: &taskito_core::RedisStorage) {
+    use redis::Commands;
+    let q = "q-redis-complete-unique";
+    let shared = "redis-complete-reuse";
+    drain_queue(s, q);
+
+    let mut a = make_job(q, "complete_unique_a");
+    a.unique_key = Some(shared.to_string());
+    let a = s.enqueue_unique(a).unwrap();
+    s.dequeue(q, now_millis() + 1000, None).unwrap();
+
+    let mut conn = s.conn().unwrap();
+    let ukey = rkey(s, &["jobs", "unique", shared]);
+    let _: () = conn.set(&ukey, "other-live-job-id").unwrap();
+
+    s.complete(&a.id, None).unwrap();
+
+    let owner: Option<String> = conn.get(&ukey).unwrap();
+    assert_eq!(
+        owner.as_deref(),
+        Some("other-live-job-id"),
+        "complete must not delete a unique key reused by another job"
+    );
+    let _: () = conn.del(&ukey).unwrap();
 }
 
 /// A terminal job has left the live indices, so a mutator that resolves the


### PR DESCRIPTION
Closes a cluster of atomicity races in the Redis storage backend from the 2026-06-10 audit. Root cause is uniform: Redis used unguarded read-then-write (Rust-side status check → plain `SET`, or two separate round trips) where the Diesel backends use a single guarded `UPDATE ... WHERE status = ?` or one transaction. Redis is a supported production backend; the default SQLite/Postgres paths are unaffected.

Key technique: the per-status index sets `jobs:status:<n>` already encode a job's live status, so a `SISMEMBER` gate inside a Lua script is an atomic stand-in for the Diesel `WHERE status = ?` claim — no cjson decode/re-encode of the job JSON. Mirrors existing backend patterns (`RELEASE_LOCK_SCRIPT`, the `enqueue_unique` scripts, `archive_job_immediately`'s `.atomic()` pipe).

## Fixes
- **Atomic dequeue claim** — `dequeue`/`dequeue_batch` claimed with a plain `SET` after checking status in Rust, so a concurrent cancel/expire could archive the job and the `SET` resurrected it as a Running orphan that then executed. Now gated by a Lua CAS on pending-status-set membership.
- **Atomic retry/reschedule requeue** — the status-set move and the pending-zset `ZADD` ran as two round trips; a crash between stranded the job Pending but absent from the queue (never dequeued, never reaped). Folded into one atomic `requeue_pending` pipeline.
- **Compare-and-delete unique key on complete()** — `complete()` unconditionally `DEL`d the unique-key pointer, clobbering a key a concurrent `enqueue_unique` had reused. Now an atomic compare-and-delete that only fires if the pointer still points at this job.
- **Guarded progress/cancel writes** — `update_progress`/`request_cancel` did an unguarded GET-modify-SET of the full job JSON; if the job was archived concurrently the `SET` recreated `job:<id>` as a Running orphan shadowing the terminal record. Both writes now gated by a Lua existence/running check.
- **Atomic DLQ move** — `move_to_dlq` wrote the DLQ entry and archived the job in two round trips; a crash between left the job both DLQ'd and live-Running (re-reaped into a duplicate, or `retry_dead` racing the live copy). Both now commit in one atomic pipeline via a shared `push_archive_ops` helper.

Plus: pin the CI Windows runner from `windows-latest` to `windows-2025` to drop GitHub's deprecation annotation and keep the image deterministic.

## Tests
Five deterministic regression tests in the Redis contract suite (using a raw connection to set up race-window state and assert on internal index keys), and a `FLUSHDB` at suite start so the suite is rerun-safe locally, not only against a fresh CI container. Added `redis` as a dev-dependency for the raw-connection assertions.

## Verification
- Full Redis contract + regression suite green against a local `redis:7-alpine` (DB 15)
- SQLite default suite unaffected
- `cargo clippy --features redis --tests` clean; `cargo check --features postgres` compiles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved atomic consistency of job transitions and DLQ/archive operations to prevent resurrection, duplication, or lost state under concurrent schedulers.
  * Strengthened job claiming, cancellation, retry, and progress updates to avoid race conditions and stale writes.

* **Tests**
  * Added Redis-focused integration tests to validate atomic claim behavior, DLQ/archive consistency, uniqueness preservation, and queue state determinism.

* **Chores**
  * Updated CI publishing/build environments and test dev-dependencies to support the enhanced Redis test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->