### PR TITLE
chore(release): 0.16.2

### DIFF
--- a/crates/taskito-async/Cargo.toml
+++ b/crates/taskito-async/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-async"
-version = "0.16.1"
+version = "0.16.2"
 edition = "2021"
 
 [dependencies]

--- a/crates/taskito-core/Cargo.toml
+++ b/crates/taskito-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-core"
-version = "0.16.1"
+version = "0.16.2"
 edition = "2021"
 
 [features]

--- a/crates/taskito-mesh/Cargo.toml
+++ b/crates/taskito-mesh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-mesh"
-version = "0.16.1"
+version = "0.16.2"
 edition = "2021"
 
 [dependencies]

--- a/crates/taskito-python/Cargo.toml
+++ b/crates/taskito-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-python"
-version = "0.16.1"
+version = "0.16.2"
 edition = "2021"
 
 [features]

--- a/crates/taskito-workflows/Cargo.toml
+++ b/crates/taskito-workflows/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-workflows"
-version = "0.16.1"
+version = "0.16.2"
 edition = "2021"
 
 [features]

--- a/docs/content/docs/more/changelog.mdx
+++ b/docs/content/docs/more/changelog.mdx
@@ -5,6 +5,30 @@ description: "Release history for taskito — every notable change, fix, and fea
 
 All notable changes to taskito are documented here.
 
+## 0.16.2
+
+Reliability patch — correctness fixes across the scheduler, dashboard, and Redis backend. No API changes.
+
+### Fixed
+
+- **Scheduler retry budget.** Soft-gate reschedules (rate limit, circuit breaker,
+  concurrency cap, channel backpressure) no longer consume a job's retry budget; a
+  job that never executed is rescheduled without incrementing `retry_count`, so it
+  is no longer dead-lettered early on its first real failure.
+- **Webhook secrets.** Webhook signing secrets and delivery logs (stored under
+  `webhooks:` keys) are no longer readable through `GET /api/settings`.
+- **Structured notes.** The dashboard job detail page no longer crashes on jobs
+  with notes (the API now emits notes as a canonical JSON string), and non-finite
+  floats (`NaN`/`Infinity`) are rejected at enqueue instead of producing invalid
+  JSON that broke the jobs API.
+- **Redis write-path atomicity.** Closed a cluster of races in the Redis backend:
+  the dequeue claim is now an atomic compare-and-set (a cancelled/expired job can
+  no longer be resurrected and executed); retry/reschedule requeue atomically (no
+  stranded jobs); `complete` and purge release the unique-key pointer with a
+  compare-and-delete (no clobbering a reused key); progress/cancel writes are
+  guarded against resurrecting an archived job; and the dead-letter move commits
+  the DLQ entry and the archive together.
+
 ## 0.16.1
 
 Patch release with no user-facing changes.

--- a/docs/src/lib/release.ts
+++ b/docs/src/lib/release.ts
@@ -1,4 +1,4 @@
-export const RELEASE_VERSION = "0.16.1";
+export const RELEASE_VERSION = "0.16.2";
 export const RELEASE_TAGLINE =
   "mesh scheduling, DLQ policies, dashboard redesign";
 export const RELEASE_BADGE = `v${RELEASE_VERSION.replace(/\.\d+$/, "")} — ${RELEASE_TAGLINE}`;

--- a/py_src/taskito/__init__.py
+++ b/py_src/taskito/__init__.py
@@ -122,4 +122,4 @@ try:
 
     __version__ = _get_version("taskito")
 except PackageNotFoundError:
-    __version__ = "0.16.1"
+    __version__ = "0.16.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "taskito"
-version = "0.16.1"
+version = "0.16.2"
 description = "Rust-powered task queue for Python. No broker required."
 requires-python = ">=3.10"
 license = { file = "LICENSE" }


### PR DESCRIPTION
Version bump to **0.16.2** — a reliability patch rolling up the fixes merged since 0.16.1 (#254 default-config audit tier, #255 Redis write-path atomicity). No API changes.

Bumped all release-version locations: the five crate `Cargo.toml`s, `pyproject.toml`, the `__init__.py` fallback, `docs/src/lib/release.ts`, and a new `0.16.2` changelog section.

After merge, tag `v0.16.2` from master to trigger the publish workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scheduler reschedule retry budget consumption when jobs never executed
  * Enhanced security by restricting webhook signing secrets and delivery logs visibility
  * Fixed dashboard job detail crash when displaying notes
  * Added validation to reject invalid numeric values (NaN/Infinity) at enqueue
  * Resolved multiple Redis backend race conditions and atomicity issues

* **Chores**
  * Version bumped to 0.16.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->