### PR TITLE
fix: dead-letter policy correctness

### DIFF
--- a/crates/taskito-core/src/scheduler/maintenance.rs
+++ b/crates/taskito-core/src/scheduler/maintenance.rs
@@ -141,7 +141,16 @@ impl Scheduler {
         let cutoff = now.saturating_sub(delay);
         let max_retries = self.config.dlq_auto_retry_max;
 
-        let candidates = self.storage.list_dead_for_retry(cutoff, max_retries, 50)?;
+        // Only retry entries this worker actually serves (its namespace + active,
+        // non-paused queues), mirroring the poller's dequeue scoping.
+        let active_queues = self.active_queues();
+        let candidates = self.storage.list_dead_for_retry(
+            cutoff,
+            max_retries,
+            self.namespace.as_deref(),
+            &active_queues,
+            50,
+        )?;
 
         if candidates.is_empty() {
             return Ok(());

--- a/crates/taskito-core/src/scheduler/maintenance.rs
+++ b/crates/taskito-core/src/scheduler/maintenance.rs
@@ -48,26 +48,36 @@ impl Scheduler {
         Ok(())
     }
 
-    /// Purge old completed/dead jobs and their errors if result_ttl_ms is set.
+    /// Purge expired completed/dead jobs and their side data. The per-entry TTL
+    /// purges run every tick — a job or DLQ entry can carry its own `result_ttl`
+    /// even when no queue-wide `result_ttl` is configured. The global-cutoff
+    /// deletes (and the side tables, which have no per-entry TTL) only run when a
+    /// global `result_ttl` is set.
     pub(super) fn auto_cleanup(&self) -> Result<()> {
-        let ttl = match self.config.result_ttl_ms {
-            Some(t) => t,
-            None => return Ok(()),
+        let now = now_millis();
+        let global_cutoff = self.config.result_ttl_ms.map(|ttl| now.saturating_sub(ttl));
+        // `i64::MIN` disables the methods' global-cutoff branch (`failed_at < MIN`
+        // never matches), leaving only the per-entry TTL deletes.
+        let ttl_cutoff = global_cutoff.unwrap_or(i64::MIN);
+
+        let completed = self.storage.purge_completed_with_ttl(ttl_cutoff)?;
+        let dead = self.storage.purge_dead_with_ttl(ttl_cutoff)?;
+
+        let (errors, metrics, logs) = match global_cutoff {
+            Some(cutoff) => {
+                let errors = self.storage.purge_job_errors(cutoff)?;
+                let metrics = self.storage.purge_metrics(cutoff).unwrap_or_else(|e| {
+                    warn!("purge_metrics failed: {e}");
+                    0
+                });
+                let logs = self.storage.purge_task_logs(cutoff).unwrap_or_else(|e| {
+                    warn!("purge_task_logs failed: {e}");
+                    0
+                });
+                (errors, metrics, logs)
+            }
+            None => (0, 0, 0),
         };
-
-        let cutoff = now_millis().saturating_sub(ttl);
-
-        let completed = self.storage.purge_completed_with_ttl(cutoff)?;
-        let dead = self.storage.purge_dead_with_ttl(cutoff)?;
-        let errors = self.storage.purge_job_errors(cutoff)?;
-        let metrics = self.storage.purge_metrics(cutoff).unwrap_or_else(|e| {
-            warn!("purge_metrics failed: {e}");
-            0
-        });
-        let logs = self.storage.purge_task_logs(cutoff).unwrap_or_else(|e| {
-            warn!("purge_task_logs failed: {e}");
-            0
-        });
 
         if completed + dead + errors + metrics + logs > 0 {
             info!(

--- a/crates/taskito-core/src/scheduler/mod.rs
+++ b/crates/taskito-core/src/scheduler/mod.rs
@@ -1048,6 +1048,36 @@ mod tests {
     }
 
     #[test]
+    fn test_auto_cleanup_per_entry_ttl_without_global() {
+        // With no queue-wide result_ttl, a per-job result_ttl must still be
+        // honored (the per-entry purge runs every tick).
+        let storage =
+            StorageBackend::Sqlite(crate::storage::sqlite::SqliteStorage::in_memory().unwrap());
+        let config = SchedulerConfig {
+            result_ttl_ms: None,
+            ..SchedulerConfig::default()
+        };
+        let scheduler = Scheduler::new(storage, vec!["default".to_string()], config, None);
+
+        let mut nj = make_job("per_entry_ttl");
+        nj.result_ttl_ms = Some(1); // 1ms per-job TTL
+        let job = scheduler.storage.enqueue(nj).unwrap();
+        scheduler
+            .storage
+            .dequeue("default", now_millis() + 1000, None)
+            .unwrap();
+        scheduler.storage.complete(&job.id, Some(vec![1])).unwrap();
+
+        std::thread::sleep(Duration::from_millis(10));
+        scheduler.auto_cleanup().unwrap();
+
+        assert!(
+            scheduler.storage.get_job(&job.id).unwrap().is_none(),
+            "per-job result_ttl must be purged even without a global result_ttl"
+        );
+    }
+
+    #[test]
     fn test_tick_dispatches_and_maintains() {
         let storage =
             StorageBackend::Sqlite(crate::storage::sqlite::SqliteStorage::in_memory().unwrap());

--- a/crates/taskito-core/src/scheduler/poller.rs
+++ b/crates/taskito-core/src/scheduler/poller.rs
@@ -163,7 +163,7 @@ impl Scheduler {
     /// list is cached for 1s to avoid hammering storage on every tick. Borrows
     /// the queue list directly in the common case (nothing paused), allocating
     /// only when a filtered copy is actually needed.
-    fn active_queues(&self) -> std::borrow::Cow<'_, [String]> {
+    pub(super) fn active_queues(&self) -> std::borrow::Cow<'_, [String]> {
         let mut cache = self.paused_cache.lock().unwrap_or_else(|poisoned| {
             warn!("paused_cache mutex was poisoned, recovering");
             poisoned.into_inner()

--- a/crates/taskito-core/src/storage/diesel_common/dead_letter.rs
+++ b/crates/taskito-core/src/storage/diesel_common/dead_letter.rs
@@ -258,13 +258,26 @@ macro_rules! impl_diesel_dead_letter_ops {
                 &self,
                 cutoff_ms: i64,
                 max_retries: i32,
+                namespace: Option<&str>,
+                queues: &[String],
                 limit: i64,
             ) -> Result<Vec<DeadJob>> {
                 let mut conn = self.conn()?;
 
-                let rows: Vec<DeadLetterRow> = dead_letter::table
+                // Scope to the worker's own namespace + served queues, mirroring
+                // the poller's dequeue scoping, so auto-retry never resurrects
+                // entries belonging to other namespaces/queues.
+                let mut query = dead_letter::table
                     .filter(dead_letter::failed_at.le(cutoff_ms))
                     .filter(dead_letter::dlq_retry_count.lt(max_retries))
+                    .filter(dead_letter::queue.eq_any(queues))
+                    .into_boxed();
+                match namespace {
+                    Some(ns) => query = query.filter(dead_letter::namespace.eq(ns)),
+                    None => query = query.filter(dead_letter::namespace.is_null()),
+                }
+
+                let rows: Vec<DeadLetterRow> = query
                     .order(dead_letter::failed_at.asc())
                     .limit(limit)
                     .select(DeadLetterRow::as_select())

--- a/crates/taskito-core/src/storage/diesel_common/dead_letter.rs
+++ b/crates/taskito-core/src/storage/diesel_common/dead_letter.rs
@@ -36,7 +36,9 @@ macro_rules! impl_diesel_dead_letter_ops {
                         error: Some(error),
                         retry_count: job.retry_count,
                         failed_at: now,
-                        metadata,
+                        // Preserve the job's own metadata so it survives the
+                        // round trip; an explicit `metadata` arg overrides it.
+                        metadata: metadata.or(job.metadata.as_deref()),
                         notes: job.notes.as_deref(),
                         priority: job.priority,
                         max_retries: job.max_retries,

--- a/crates/taskito-core/src/storage/mod.rs
+++ b/crates/taskito-core/src/storage/mod.rs
@@ -260,9 +260,11 @@ macro_rules! impl_storage {
                 &self,
                 cutoff_ms: i64,
                 max_retries: i32,
+                namespace: Option<&str>,
+                queues: &[String],
                 limit: i64,
             ) -> $crate::error::Result<Vec<$crate::storage::DeadJob>> {
-                self.list_dead_for_retry(cutoff_ms, max_retries, limit)
+                self.list_dead_for_retry(cutoff_ms, max_retries, namespace, queues, limit)
             }
             fn get_rate_limit(
                 &self,
@@ -766,9 +768,19 @@ impl Storage for StorageBackend {
         &self,
         cutoff_ms: i64,
         max_retries: i32,
+        namespace: Option<&str>,
+        queues: &[String],
         limit: i64,
     ) -> Result<Vec<DeadJob>> {
-        delegate!(self, list_dead_for_retry, cutoff_ms, max_retries, limit)
+        delegate!(
+            self,
+            list_dead_for_retry,
+            cutoff_ms,
+            max_retries,
+            namespace,
+            queues,
+            limit
+        )
     }
     fn get_rate_limit(&self, key: &str) -> Result<Option<models::RateLimitRow>> {
         delegate!(self, get_rate_limit, key)

--- a/crates/taskito-core/src/storage/redis_backend/dead_letter.rs
+++ b/crates/taskito-core/src/storage/redis_backend/dead_letter.rs
@@ -296,6 +296,8 @@ impl RedisStorage {
         &self,
         cutoff_ms: i64,
         max_retries: i32,
+        namespace: Option<&str>,
+        queues: &[String],
         limit: i64,
     ) -> Result<Vec<DeadJob>> {
         let mut conn = self.conn()?;
@@ -314,7 +316,12 @@ impl RedisStorage {
             let data: Option<String> = conn.get(&dlq_key).map_err(map_err)?;
             if let Some(d) = data {
                 if let Ok(entry) = serde_json::from_str::<DeadJobEntry>(&d) {
-                    if entry.dlq_retry_count < max_retries {
+                    // Scope to the worker's own namespace + served queues, matching
+                    // the Diesel backend (the poller's dequeue scoping).
+                    if entry.dlq_retry_count < max_retries
+                        && entry.namespace.as_deref() == namespace
+                        && queues.iter().any(|q| q == &entry.queue)
+                    {
                         results.push(DeadJob::from(entry));
                     }
                 }

--- a/crates/taskito-core/src/storage/redis_backend/dead_letter.rs
+++ b/crates/taskito-core/src/storage/redis_backend/dead_letter.rs
@@ -74,7 +74,11 @@ impl RedisStorage {
             error: Some(error.to_string()),
             retry_count: job.retry_count,
             failed_at: now,
-            metadata: metadata.map(|s| s.to_string()),
+            // Preserve the job's own metadata so it survives the round trip;
+            // an explicit `metadata` arg overrides it.
+            metadata: metadata
+                .map(|s| s.to_string())
+                .or_else(|| job.metadata.clone()),
             notes: job.notes.clone(),
             priority: job.priority,
             max_retries: job.max_retries,

--- a/crates/taskito-core/src/storage/sqlite/tests.rs
+++ b/crates/taskito-core/src/storage/sqlite/tests.rs
@@ -81,6 +81,40 @@ fn test_notes_survive_dlq_round_trip() {
 }
 
 #[test]
+fn test_metadata_survives_dlq_round_trip() {
+    // User metadata attached at enqueue must survive job → DLQ → retry_dead, with
+    // __dlq_retry_count merged in (it was previously dropped to NULL).
+    let storage = test_storage();
+    let mut new_job = make_job("dlq_meta_task");
+    new_job.metadata = Some(r#"{"user_id":"u1"}"#.to_string());
+    let job = storage.enqueue(new_job).unwrap();
+
+    storage
+        .move_to_dlq(&job, "boom", None)
+        .expect("move_to_dlq");
+
+    let dead = storage.list_dead(10, 0).unwrap();
+    let entry = dead
+        .iter()
+        .find(|d| d.original_job_id == job.id)
+        .expect("dead entry");
+    assert_eq!(entry.metadata.as_deref(), Some(r#"{"user_id":"u1"}"#));
+
+    let new_id = storage.retry_dead(&entry.id).expect("retry_dead");
+    let retried = storage.get_job(&new_id).unwrap().unwrap();
+    let meta: serde_json::Value =
+        serde_json::from_str(retried.metadata.as_deref().expect("metadata")).unwrap();
+    assert_eq!(
+        meta["user_id"], "u1",
+        "user metadata must survive the round trip"
+    );
+    assert_eq!(
+        meta["__dlq_retry_count"], 1,
+        "retry count must be merged in"
+    );
+}
+
+#[test]
 fn test_dequeue() {
     let storage = test_storage();
     let job = storage.enqueue(make_job("dequeue_task")).unwrap();

--- a/crates/taskito-core/src/storage/sqlite/tests.rs
+++ b/crates/taskito-core/src/storage/sqlite/tests.rs
@@ -1165,17 +1165,23 @@ fn test_list_dead_for_retry() {
     let running = storage.get_job(&job.id).unwrap().unwrap();
     storage.move_to_dlq(&running, "err", None).unwrap();
 
+    let qs = [String::from("default")];
+
     // Cutoff in the future, max_retries=3 — should find it
-    let cands = storage.list_dead_for_retry(now + 5000, 3, 10).unwrap();
+    let cands = storage
+        .list_dead_for_retry(now + 5000, 3, None, &qs, 10)
+        .unwrap();
     assert_eq!(cands.len(), 1);
     assert_eq!(cands[0].dlq_retry_count, 0);
 
     // max_retries=0 — should find nothing
-    let cands = storage.list_dead_for_retry(now + 5000, 0, 10).unwrap();
+    let cands = storage
+        .list_dead_for_retry(now + 5000, 0, None, &qs, 10)
+        .unwrap();
     assert!(cands.is_empty());
 
     // Cutoff in the past — should find nothing
-    let cands = storage.list_dead_for_retry(0, 3, 10).unwrap();
+    let cands = storage.list_dead_for_retry(0, 3, None, &qs, 10).unwrap();
     assert!(cands.is_empty());
 }
 

--- a/crates/taskito-core/src/storage/traits.rs
+++ b/crates/taskito-core/src/storage/traits.rs
@@ -86,6 +86,8 @@ pub trait Storage: Send + Sync + Clone {
         &self,
         cutoff_ms: i64,
         max_retries: i32,
+        namespace: Option<&str>,
+        queues: &[String],
         limit: i64,
     ) -> Result<Vec<DeadJob>>;
 

--- a/crates/taskito-core/tests/rust/storage_tests.rs
+++ b/crates/taskito-core/tests/rust/storage_tests.rs
@@ -277,7 +277,10 @@ fn test_list_dead_for_retry(s: &impl Storage) {
     s.move_to_dlq(&running, "err", None).unwrap();
 
     let now = now_millis();
-    let cands = s.list_dead_for_retry(now + 5000, 3, 100).unwrap();
+    let qs = [q.to_string()];
+    let cands = s
+        .list_dead_for_retry(now + 5000, 3, None, &qs, 100)
+        .unwrap();
     let ours = cands
         .iter()
         .find(|d| d.original_job_id == job.id)
@@ -285,10 +288,30 @@ fn test_list_dead_for_retry(s: &impl Storage) {
     assert_eq!(ours.dlq_retry_count, 0);
 
     // max_retries=0 should exclude everything
-    let empty = s.list_dead_for_retry(now + 5000, 0, 100).unwrap();
+    let empty = s
+        .list_dead_for_retry(now + 5000, 0, None, &qs, 100)
+        .unwrap();
     assert!(
         empty.iter().all(|d| d.original_job_id != job.id),
         "max_retries=0 should exclude our entry"
+    );
+
+    // Scoping: a different namespace or a queue we don't serve must exclude it
+    // (our entry has no namespace and lives in queue `q`).
+    let other_ns = s
+        .list_dead_for_retry(now + 5000, 3, Some("other-ns"), &qs, 100)
+        .unwrap();
+    assert!(
+        other_ns.iter().all(|d| d.original_job_id != job.id),
+        "a different namespace must exclude our entry"
+    );
+    let other_q = [String::from("q-not-served")];
+    let other_queue = s
+        .list_dead_for_retry(now + 5000, 3, None, &other_q, 100)
+        .unwrap();
+    assert!(
+        other_queue.iter().all(|d| d.original_job_id != job.id),
+        "an unserved queue must exclude our entry"
     );
 }
 


### PR DESCRIPTION
Three correctness bugs in the DLQ policies (auto-retry, per-entry TTL, metadata) shipped in PR #236, from the 2026-06-10 audit. All Rust-internal scheduler-maintenance + storage paths — no PyO3/Python API changes.

## fix(scheduler): scope DLQ auto-retry to namespace and queues
`list_dead_for_retry` filtered only on `failed_at` + `dlq_retry_count`, so `auto_retry_dlq` resurrected dead entries belonging to other namespaces and queues this worker doesn't serve. Added `namespace` + `queues` parameters and filtering (the `dead_letter` columns already exist), and pass the scheduler's namespace + active (non-paused) queues — mirroring the poller's `dequeue` scoping. Diesel filters in SQL; Redis filters the decoded entries in memory.

## fix(scheduler): purge per-entry TTL without a global result_ttl
`auto_cleanup` early-returned when no queue-wide `result_ttl` was configured, and it's the sole caller of the per-entry TTL purges — so a per-job `result_ttl` (`apply_async(result_ttl=...)`) or per-entry DLQ TTL was silently inert. Now the per-entry purges run every tick (`i64::MIN` disables the methods' global-cutoff branch); the global-only side-table purges (errors/metrics/logs) stay gated on `result_ttl_ms`.

## fix(storage): preserve job metadata across the dead-letter round trip
`move_to_dlq` was always called with `metadata=None`, so the `dead_letter` row's metadata was NULL and user metadata was lost — `retry_dead` rebuilt it as just `{"__dlq_retry_count": n}`. Made the `metadata` arg a real override that falls back to the job's own metadata; `retry_dead` already merges `__dlq_retry_count` into the preserved metadata, so user fields now survive.

The storage fixes live in the shared `impl_diesel_job_ops!`/dead-letter macro (SQLite + Postgres) with matching Redis changes.

## Tests
- `test_auto_cleanup_per_entry_ttl_without_global` (scheduler), `test_metadata_survives_dlq_round_trip` (SQLite), and namespace/queue scoping assertions added to the `test_list_dead_for_retry` contract test (run against SQLite + Postgres + Redis).

## Verification
- `cargo test --workspace`, clippy clean, `--features postgres` compiles, Redis contract+parity green against a local `redis:7-alpine`
- `pytest tests/core/test_dlq.py` — no regression (DLQ policies are Rust-internal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed metadata loss during dead-letter queue retry operations; original job metadata now persists across retries.
  * Corrected result cleanup behavior to honor per-entry TTL settings even when global TTL is not configured.

* **New Features**
  * Enhanced dead-letter queue retry logic to respect worker queue assignments, preventing unnecessary retry attempts across unrelated queues.
  * Added namespace support for improved dead-letter queue filtering and scoping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->