### PR TITLE
fix: ship missing Django admin templates (#261)

### DIFF
--- a/docs/content/docs/guides/integrations/django.mdx
+++ b/docs/content/docs/guides/integrations/django.mdx
@@ -16,6 +16,24 @@ pip install taskito[django]
 
 ## Setup
 
+Add the integration to `INSTALLED_APPS`. This is required for the admin
+templates to load — Django's app-directories template loader only scans
+installed apps — and for task autodiscovery:
+
+```python
+# settings.py
+INSTALLED_APPS = [
+    # ...
+    "django.contrib.admin",
+    "taskito.contrib.django",
+]
+```
+
+<Callout type="info" title="Template loading">
+  Keep the default `APP_DIRS = True` in your `TEMPLATES` setting (Django's
+  default) so the bundled admin templates are discovered.
+</Callout>
+
 ### Option 1: register on the default admin site
 
 In your project's `admin.py` or `urls.py`:

--- a/py_src/taskito/contrib/django/admin.py
+++ b/py_src/taskito/contrib/django/admin.py
@@ -12,19 +12,41 @@ try:
     from django.contrib import admin
     from django.http import HttpRequest, HttpResponse
     from django.template.response import TemplateResponse
-    from django.urls import path
+    from django.urls import path, reverse
 except ImportError as e:
     raise ImportError(
         "Django integration requires 'django'. Install with: pip install taskito[django]"
     ) from e
 
 
+def _base_context(request: HttpRequest, site: Any, **extra: Any) -> dict[str, Any]:
+    """Build the shared template context for every taskito admin view.
+
+    Resolves the nav URLs against the *current* admin site's namespace
+    (``site.name``) so the templates work on both the default admin site and a
+    custom :class:`TaskitoAdminSite`. ``job_detail_name`` is passed as a view
+    name (not a resolved URL) so templates can reverse it per-row with the job
+    id via ``{% url %}``.
+    """
+    namespace = site.name
+    context: dict[str, Any] = {
+        **site.each_context(request),
+        "taskito_urls": {
+            "dashboard": reverse(f"{namespace}:taskito_dashboard"),
+            "jobs": reverse(f"{namespace}:taskito_jobs"),
+            "dead_letters": reverse(f"{namespace}:taskito_dead_letters"),
+            "job_detail_name": f"{namespace}:taskito_job_detail",
+        },
+    }
+    context.update(extra)
+    return context
+
+
 def _dashboard_view(request: HttpRequest, site: Any) -> HttpResponse:
     from taskito.contrib.django.settings import get_queue
 
     queue = get_queue()
-    stats = queue.stats()
-    context = {**site.each_context(request), "stats": stats, "title": "Taskito Dashboard"}
+    context = _base_context(request, site, stats=queue.stats(), title="Taskito Dashboard")
     return TemplateResponse(request, "taskito/admin/dashboard.html", context)
 
 
@@ -57,13 +79,15 @@ def _jobs_view(request: HttpRequest, site: Any) -> HttpResponse:
 
         logging.getLogger(__name__).exception("Failed to list jobs")
         jobs = []
-    context = {
-        **site.each_context(request),
-        "jobs": [j.to_dict() for j in jobs],
-        "filters": {"status": status, "queue": queue_name, "task_name": task_name},
-        "page": page,
-        "title": "Taskito Jobs",
-    }
+    context = _base_context(
+        request,
+        site,
+        jobs=[j.to_dict() for j in jobs],
+        filters={"status": status, "queue": queue_name, "task_name": task_name},
+        page=page,
+        has_next=len(jobs) == per_page,
+        title="Taskito Jobs",
+    )
     return TemplateResponse(request, "taskito/admin/jobs.html", context)
 
 
@@ -73,12 +97,13 @@ def _job_detail_view(request: HttpRequest, site: Any, job_id: str) -> HttpRespon
     queue = get_queue()
     job = queue.get_job(job_id)
     errors = queue.job_errors(job_id) if job else []
-    context = {
-        **site.each_context(request),
-        "job": job.to_dict() if job else None,
-        "errors": errors,
-        "title": f"Job {job_id}",
-    }
+    context = _base_context(
+        request,
+        site,
+        job=job.to_dict() if job else None,
+        errors=errors,
+        title=f"Job {job_id}",
+    )
     return TemplateResponse(request, "taskito/admin/job_detail.html", context)
 
 
@@ -102,12 +127,14 @@ def _dead_letters_view(request: HttpRequest, site: Any) -> HttpResponse:
 
     per_page = getattr(django_settings, "TASKITO_ADMIN_PER_PAGE", 50)
     dead = queue.dead_letters(limit=per_page, offset=(page - 1) * per_page)
-    context = {
-        **site.each_context(request),
-        "dead_letters": dead,
-        "page": page,
-        "title": "Taskito Dead Letters",
-    }
+    context = _base_context(
+        request,
+        site,
+        dead_letters=dead,
+        page=page,
+        has_next=len(dead) == per_page,
+        title="Taskito Dead Letters",
+    )
     return TemplateResponse(request, "taskito/admin/dead_letters.html", context)
 
 
@@ -179,6 +206,12 @@ def register_taskito_admin(site: Any = None) -> None:
     def jobs_view(request: HttpRequest) -> HttpResponse:
         return _jobs_view(request, target)
 
+    def job_detail_view(request: HttpRequest, job_id: str) -> HttpResponse:
+        return _job_detail_view(request, target, job_id)
+
+    def dead_letters_view(request: HttpRequest) -> HttpResponse:
+        return _dead_letters_view(request, target)
+
     original_get_urls = target.get_urls
 
     def patched_get_urls() -> list:
@@ -186,6 +219,16 @@ def register_taskito_admin(site: Any = None) -> None:
         custom = [
             path("taskito/", target.admin_view(dashboard_view), name="taskito_dashboard"),
             path("taskito/jobs/", target.admin_view(jobs_view), name="taskito_jobs"),
+            path(
+                "taskito/jobs/<str:job_id>/",
+                target.admin_view(job_detail_view),
+                name="taskito_job_detail",
+            ),
+            path(
+                "taskito/dead-letters/",
+                target.admin_view(dead_letters_view),
+                name="taskito_dead_letters",
+            ),
         ]
         return custom + urls  # type: ignore[no-any-return]
 

--- a/py_src/taskito/contrib/django/templates/taskito/admin/base.html
+++ b/py_src/taskito/contrib/django/templates/taskito/admin/base.html
@@ -1,0 +1,10 @@
+{% extends "admin/base_site.html" %}
+
+{% block content %}
+<ul class="object-tools">
+  <li><a href="{{ taskito_urls.dashboard }}">Dashboard</a></li>
+  <li><a href="{{ taskito_urls.jobs }}">Jobs</a></li>
+  <li><a href="{{ taskito_urls.dead_letters }}">Dead Letters</a></li>
+</ul>
+{% block taskito_content %}{% endblock %}
+{% endblock %}

--- a/py_src/taskito/contrib/django/templates/taskito/admin/dashboard.html
+++ b/py_src/taskito/contrib/django/templates/taskito/admin/dashboard.html
@@ -1,0 +1,25 @@
+{% extends "taskito/admin/base.html" %}
+
+{% block taskito_content %}
+<h1>Taskito Dashboard</h1>
+
+{% if stats %}
+<div class="module">
+  <table>
+    <thead>
+      <tr><th>Status</th><th>Count</th></tr>
+    </thead>
+    <tbody>
+      {% for name, count in stats.items %}
+      <tr>
+        <td>{{ name }}</td>
+        <td>{{ count }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% else %}
+<p>No queue statistics available.</p>
+{% endif %}
+{% endblock %}

--- a/py_src/taskito/contrib/django/templates/taskito/admin/dead_letters.html
+++ b/py_src/taskito/contrib/django/templates/taskito/admin/dead_letters.html
@@ -1,0 +1,52 @@
+{% extends "taskito/admin/base.html" %}
+{% load taskito_admin %}
+
+{% block taskito_content %}
+<h1>Dead Letters</h1>
+
+{% if dead_letters %}
+<div class="module">
+  <table>
+    <thead>
+      <tr>
+        <th>ID</th>
+        <th>Task</th>
+        <th>Queue</th>
+        <th>Retries</th>
+        <th>Failed</th>
+        <th>Error</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for dead in dead_letters %}
+      <tr>
+        <td>{{ dead.id }}</td>
+        <td>{{ dead.task_name }}</td>
+        <td>{{ dead.queue }}</td>
+        <td>{{ dead.retry_count }}</td>
+        <td>{{ dead.failed_at|ms_datetime }}</td>
+        <td><pre>{{ dead.error }}</pre></td>
+        <td>
+          <form method="post">
+            {% csrf_token %}
+            <input type="hidden" name="action" value="retry">
+            <input type="hidden" name="dead_id" value="{{ dead.id }}">
+            <input type="submit" value="Retry">
+          </form>
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+
+<p class="paginator">
+  {% if page > 1 %}<a href="?page={{ page|add:'-1' }}">Previous</a>{% endif %}
+  Page {{ page }}
+  {% if has_next %}<a href="?page={{ page|add:'1' }}">Next</a>{% endif %}
+</p>
+{% else %}
+<p>No dead letters.</p>
+{% endif %}
+{% endblock %}

--- a/py_src/taskito/contrib/django/templates/taskito/admin/job_detail.html
+++ b/py_src/taskito/contrib/django/templates/taskito/admin/job_detail.html
@@ -1,0 +1,50 @@
+{% extends "taskito/admin/base.html" %}
+{% load taskito_admin %}
+
+{% block taskito_content %}
+<p><a href="{{ taskito_urls.jobs }}">&larr; Back to jobs</a></p>
+
+{% if job %}
+<h1>Job {{ job.id }}</h1>
+
+<div class="module">
+  <table>
+    <tbody>
+      <tr><th>Status</th><td>{{ job.status }}</td></tr>
+      <tr><th>Task</th><td>{{ job.task_name }}</td></tr>
+      <tr><th>Queue</th><td>{{ job.queue }}</td></tr>
+      <tr><th>Priority</th><td>{{ job.priority }}</td></tr>
+      <tr><th>Progress</th><td>{{ job.progress }}</td></tr>
+      <tr><th>Retries</th><td>{{ job.retry_count }}/{{ job.max_retries }}</td></tr>
+      <tr><th>Created</th><td>{{ job.created_at|ms_datetime }}</td></tr>
+      <tr><th>Scheduled</th><td>{{ job.scheduled_at|ms_datetime }}</td></tr>
+      <tr><th>Started</th><td>{{ job.started_at|ms_datetime }}</td></tr>
+      <tr><th>Completed</th><td>{{ job.completed_at|ms_datetime }}</td></tr>
+      {% if job.error %}<tr><th>Error</th><td><pre>{{ job.error }}</pre></td></tr>{% endif %}
+    </tbody>
+  </table>
+</div>
+
+{% if errors %}
+<h2>Error history</h2>
+<div class="module">
+  <table>
+    <thead>
+      <tr><th>Attempt</th><th>When</th><th>Error</th></tr>
+    </thead>
+    <tbody>
+      {% for err in errors %}
+      <tr>
+        <td>{{ err.attempt }}</td>
+        <td>{{ err.failed_at|ms_datetime }}</td>
+        <td><pre>{{ err.error }}</pre></td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endif %}
+{% else %}
+<p>Job not found.</p>
+{% endif %}
+{% endblock %}

--- a/py_src/taskito/contrib/django/templates/taskito/admin/jobs.html
+++ b/py_src/taskito/contrib/django/templates/taskito/admin/jobs.html
@@ -1,0 +1,54 @@
+{% extends "taskito/admin/base.html" %}
+{% load taskito_admin %}
+
+{% block taskito_content %}
+<h1>Jobs</h1>
+
+<form method="get" id="changelist-search">
+  <input type="text" name="status" value="{{ filters.status|default:'' }}" placeholder="status">
+  <input type="text" name="queue" value="{{ filters.queue|default:'' }}" placeholder="queue">
+  <input type="text" name="task_name" value="{{ filters.task_name|default:'' }}" placeholder="task name">
+  <input type="submit" value="Filter">
+</form>
+
+{% if jobs %}
+<div class="module">
+  <table>
+    <thead>
+      <tr>
+        <th>ID</th>
+        <th>Task</th>
+        <th>Queue</th>
+        <th>Status</th>
+        <th>Retries</th>
+        <th>Created</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for job in jobs %}
+      <tr>
+        <td><a href="{% url taskito_urls.job_detail_name job.id %}">{{ job.id }}</a></td>
+        <td>{{ job.task_name }}</td>
+        <td>{{ job.queue }}</td>
+        <td>{{ job.status }}</td>
+        <td>{{ job.retry_count }}/{{ job.max_retries }}</td>
+        <td>{{ job.created_at|ms_datetime }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+
+<p class="paginator">
+  {% if page > 1 %}
+  <a href="?{% if filters.status %}status={{ filters.status }}&amp;{% endif %}{% if filters.queue %}queue={{ filters.queue }}&amp;{% endif %}{% if filters.task_name %}task_name={{ filters.task_name }}&amp;{% endif %}page={{ page|add:'-1' }}">Previous</a>
+  {% endif %}
+  Page {{ page }}
+  {% if has_next %}
+  <a href="?{% if filters.status %}status={{ filters.status }}&amp;{% endif %}{% if filters.queue %}queue={{ filters.queue }}&amp;{% endif %}{% if filters.task_name %}task_name={{ filters.task_name }}&amp;{% endif %}page={{ page|add:'1' }}">Next</a>
+  {% endif %}
+</p>
+{% else %}
+<p>No jobs found.</p>
+{% endif %}
+{% endblock %}

--- a/py_src/taskito/contrib/django/templatetags/taskito_admin.py
+++ b/py_src/taskito/contrib/django/templatetags/taskito_admin.py
@@ -1,0 +1,36 @@
+"""Template filters for the taskito Django admin views.
+
+Taskito stores every timestamp as Unix **milliseconds** (the dashboard API
+contract), so the stock Django ``|date`` filter — which expects seconds or a
+``datetime`` — cannot format them directly. ``ms_datetime`` bridges that gap.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+try:
+    from django import template
+except ImportError as e:  # pragma: no cover - import guard mirrors sibling modules
+    raise ImportError(
+        "Django integration requires 'django'. Install with: pip install taskito[django]"
+    ) from e
+
+register = template.Library()
+
+
+@register.filter
+def ms_datetime(value: object) -> str:
+    """Render a Unix-millisecond timestamp as a human-readable UTC string.
+
+    Returns an em dash for ``None`` or values that aren't a finite number, so
+    templates never show ``None`` or raise on malformed data.
+    """
+    if value is None:
+        return "—"
+    try:
+        seconds = float(value) / 1000.0  # type: ignore[arg-type]
+        moment = datetime.fromtimestamp(seconds, tz=timezone.utc)
+    except (TypeError, ValueError, OverflowError, OSError):
+        return "—"
+    return moment.strftime("%Y-%m-%d %H:%M:%S UTC")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,11 +56,9 @@ manifest-path = "crates/taskito-python/Cargo.toml"
 python-source = "py_src"
 module-name = "taskito._taskito"
 features = ["extension-module", "postgres", "redis", "workflows"]
-# Maturin's `python-source` only auto-packages Python sources (`.py`, `.pyi`,
-# `py.typed`). The compiled dashboard SPA must be opted in explicitly so it
-# ships in both the wheel and the sdist.
 include = [
     { path = "py_src/taskito/static/dashboard/**/*", format = ["wheel", "sdist"] },
+    { path = "py_src/taskito/contrib/django/templates/**/*", format = ["wheel", "sdist"] },
 ]
 
 [project.scripts]

--- a/tests/integrations/test_django_admin.py
+++ b/tests/integrations/test_django_admin.py
@@ -1,0 +1,149 @@
+"""Tests for the Django admin integration (issue #261).
+
+Regression coverage: the admin views render four templates via
+``TemplateResponse``; before this fix those templates were never shipped, so
+every admin page raised ``TemplateDoesNotExist``. These tests render each view
+end-to-end and assert a 200 with real content, which fails loudly if a template
+(or its packaging) goes missing again.
+
+Views are exercised directly (not through ``admin_view``) so no auth database or
+migrations are needed — ``each_context`` short-circuits for an anonymous user.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# Skip the whole module when Django isn't installed (it's an optional extra).
+pytest.importorskip("django")
+
+from django.conf import settings
+
+if not settings.configured:
+    settings.configure(
+        DEBUG=True,
+        DATABASES={"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}},
+        INSTALLED_APPS=[
+            "django.contrib.contenttypes",
+            "django.contrib.auth",
+            "django.contrib.messages",
+            "django.contrib.sessions",
+            "django.contrib.admin",
+            "taskito.contrib.django",
+        ],
+        TEMPLATES=[
+            {
+                "BACKEND": "django.template.backends.django.DjangoTemplates",
+                "APP_DIRS": True,
+                "OPTIONS": {
+                    "context_processors": [
+                        "django.template.context_processors.request",
+                        "django.contrib.auth.context_processors.auth",
+                        "django.contrib.messages.context_processors.messages",
+                    ],
+                },
+            }
+        ],
+        ROOT_URLCONF=__name__,
+        MIDDLEWARE=[],
+        SECRET_KEY="test-only",
+        USE_TZ=True,
+    )
+    import django
+
+    django.setup()
+
+from collections.abc import Callable
+
+from django.contrib import admin
+from django.contrib.auth.models import AnonymousUser
+from django.test import RequestFactory
+from django.urls import path, reverse
+
+import taskito.contrib.django.settings as tk_settings
+from taskito import Queue
+from taskito.contrib.django import admin as tk_admin
+
+# Wire the four taskito routes onto the default admin site so reverse() resolves
+# them, then expose that site as this module's URLconf (ROOT_URLCONF above).
+tk_admin.register_taskito_admin()
+urlpatterns = [path("admin/", admin.site.urls)]
+
+
+@pytest.fixture
+def rf() -> RequestFactory:
+    return RequestFactory()
+
+
+@pytest.fixture
+def patched_queue(queue: Queue, monkeypatch: pytest.MonkeyPatch) -> Queue:
+    """Point the Django integration's singleton accessor at the temp queue."""
+    monkeypatch.setattr(tk_settings, "get_queue", lambda: queue)
+    return queue
+
+
+def _render(view: Callable[..., object], request: object, *args: object) -> object:
+    request.user = AnonymousUser()  # type: ignore[attr-defined]
+    response = view(request, admin.site, *args)
+    response.render()  # type: ignore[attr-defined]
+    return response
+
+
+def test_dashboard_renders(rf: RequestFactory, patched_queue: Queue) -> None:
+    response = _render(tk_admin._dashboard_view, rf.get("/admin/taskito/"))
+    assert response.status_code == 200  # type: ignore[attr-defined]
+    assert b"Taskito Dashboard" in response.content  # type: ignore[attr-defined]
+
+
+def test_jobs_view_lists_enqueued_job(rf: RequestFactory, patched_queue: Queue) -> None:
+    @patched_queue.task()
+    def add(x: int, y: int) -> int:
+        return x + y
+
+    job_id = add.delay(1, 2).id
+
+    response = _render(tk_admin._jobs_view, rf.get("/admin/taskito/jobs/"))
+    assert response.status_code == 200  # type: ignore[attr-defined]
+    assert job_id.encode() in response.content  # type: ignore[attr-defined]
+
+
+def test_job_detail_renders(rf: RequestFactory, patched_queue: Queue) -> None:
+    @patched_queue.task()
+    def noop() -> None:
+        return None
+
+    job_id = noop.delay().id
+
+    response = _render(tk_admin._job_detail_view, rf.get(f"/admin/taskito/jobs/{job_id}/"), job_id)
+    assert response.status_code == 200  # type: ignore[attr-defined]
+    assert job_id.encode() in response.content  # type: ignore[attr-defined]
+
+
+def test_dead_letters_empty_renders(rf: RequestFactory, patched_queue: Queue) -> None:
+    response = _render(tk_admin._dead_letters_view, rf.get("/admin/taskito/dead-letters/"))
+    assert response.status_code == 200  # type: ignore[attr-defined]
+    assert b"No dead letters" in response.content  # type: ignore[attr-defined]
+
+
+def test_dead_letters_retry_posts_to_queue(
+    rf: RequestFactory, patched_queue: Queue, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    retried: list[str] = []
+
+    def record_retry(dead_id: str) -> str:
+        retried.append(dead_id)
+        return "new"
+
+    monkeypatch.setattr(patched_queue, "retry_dead", record_retry)
+
+    request = rf.post("/admin/taskito/dead-letters/", {"action": "retry", "dead_id": "abc123"})
+    _render(tk_admin._dead_letters_view, request)
+    assert retried == ["abc123"]
+
+
+def test_register_taskito_admin_wires_all_routes() -> None:
+    # Parity with TaskitoAdminSite — all four named routes must resolve.
+    assert reverse("admin:taskito_dashboard")
+    assert reverse("admin:taskito_jobs")
+    assert reverse("admin:taskito_dead_letters")
+    assert reverse("admin:taskito_job_detail", args=["xyz"])


### PR DESCRIPTION
## Summary

The Django admin integration (`taskito.contrib.django`) renders four views via `TemplateResponse`, but the templates they reference were never authored or packaged. Every admin page therefore raised `TemplateDoesNotExist` (reported in #261).

This adds the templates, ships them in the build, fixes a route-registration gap, and documents the `INSTALLED_APPS` requirement.

## Changes

- **Templates** — `dashboard`, `jobs`, `job_detail`, `dead_letters` under `contrib/django/templates/taskito/admin/`, extending `admin/base_site.html` with admin-native styling (no custom CSS). Adds a `ms_datetime` template filter (taskito timestamps are Unix ms).
- **admin.py** — shared `_base_context()` helper resolving nav URLs against the current admin site's namespace; `register_taskito_admin()` now wires all four routes (parity with `TaskitoAdminSite`, which previously had `job_detail` + `dead_letters` while the lightweight path did not).
- **Packaging** — maturin auto-packages only Python sources, so the `.html` templates are added to the `[tool.maturin] include` list (wheel + sdist).
- **Docs** — `INSTALLED_APPS` must contain `taskito.contrib.django` for Django's app-directories loader to find the templates; without it the error persists. Added to the Django integration guide.
- **Tests** — `tests/integrations/test_django_admin.py` renders each view end-to-end (regression against `TemplateDoesNotExist`), asserts seeded data appears, the dead-letter retry POST reaches the queue, and all four routes resolve.

## Verification

- 6/6 new tests pass; `ruff` and `mypy` clean
- wheel + sdist confirmed to ship all five templates

Fixes #261

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Django admin integration with a dashboard displaying task statistics.
  * Added Jobs list page with filtering by status, queue, and task name, plus pagination support.
  * Added Job detail page showing task status, progress, retry counts, and error history.
  * Added Dead Letters page for managing failed tasks with retry functionality.

* **Documentation**
  * Added Django integration setup guide with configuration instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->