### PR TITLE
chore(release): 0.16.3

### DIFF
--- a/crates/taskito-async/Cargo.toml
+++ b/crates/taskito-async/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-async"
-version = "0.16.2"
+version = "0.16.3"
 edition = "2021"
 
 [dependencies]

--- a/crates/taskito-core/Cargo.toml
+++ b/crates/taskito-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-core"
-version = "0.16.2"
+version = "0.16.3"
 edition = "2021"
 
 [features]

--- a/crates/taskito-mesh/Cargo.toml
+++ b/crates/taskito-mesh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-mesh"
-version = "0.16.2"
+version = "0.16.3"
 edition = "2021"
 
 [dependencies]

--- a/crates/taskito-python/Cargo.toml
+++ b/crates/taskito-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-python"
-version = "0.16.2"
+version = "0.16.3"
 edition = "2021"
 
 [features]

--- a/crates/taskito-workflows/Cargo.toml
+++ b/crates/taskito-workflows/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-workflows"
-version = "0.16.2"
+version = "0.16.3"
 edition = "2021"
 
 [features]

--- a/docs/content/docs/more/changelog.mdx
+++ b/docs/content/docs/more/changelog.mdx
@@ -5,6 +5,35 @@ description: "Release history for taskito — every notable change, fix, and fea
 
 All notable changes to taskito are documented here.
 
+## 0.16.3
+
+Reliability patch — correctness fixes across the scheduler and storage layer, plus the missing Django admin templates. No API changes.
+
+### Fixed
+
+- **Django admin templates.** The `taskito.contrib.django` admin views shipped
+  without their templates, so every admin page raised `TemplateDoesNotExist`. The
+  templates are now authored and packaged, and the integration guide documents the
+  required `taskito.contrib.django` entry in `INSTALLED_APPS`.
+- **At-most-once retries.** An explicit per-call `max_retries=0` is no longer
+  overridden by the task-policy default, so a no-retry job is no longer
+  re-executed up to the policy limit.
+- **Unique enqueue.** `enqueue_unique` now validates dependencies inside the
+  transaction — a missing dependency no longer runs the job and a dead/cancelled
+  dependency no longer strands it `Pending` — and never returns a phantom
+  (rolled-back) job under unique-key contention.
+- **Dead-letter policy.** DLQ auto-retry is scoped to the worker's namespace and
+  served queues (no longer resurrecting other workers' entries); per-entry and
+  per-job result TTLs are purged even without a global `result_ttl`; and job
+  metadata survives the dead-letter round trip.
+- **SQLite transaction safety.** Read-then-write operations (dequeue, enqueue,
+  rate-limit) use immediate write-priority transactions, avoiding `SQLITE_BUSY`
+  deadlocks; migration `ALTER TABLE` failures now propagate instead of being
+  downgraded to warnings.
+- **Postgres rate limiting.** The rate-limit row is seeded and locked
+  `FOR UPDATE`, preventing concurrent workers from over-admitting beyond the
+  configured limit.
+
 ## 0.16.2
 
 Reliability patch — correctness fixes across the scheduler, dashboard, and Redis backend. No API changes.

--- a/py_src/taskito/__init__.py
+++ b/py_src/taskito/__init__.py
@@ -122,4 +122,4 @@ try:
 
     __version__ = _get_version("taskito")
 except PackageNotFoundError:
-    __version__ = "0.16.2"
+    __version__ = "0.16.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "taskito"
-version = "0.16.2"
+version = "0.16.3"
 description = "Rust-powered task queue for Python. No broker required."
 requires-python = ">=3.10"
 license = { file = "LICENSE" }


### PR DESCRIPTION
Release 0.16.3 — reliability patch.

Bumps version across `pyproject.toml`, the five crate manifests, and the `__init__.py` fallback, and adds the changelog section.

### Included since 0.16.2

- Ship missing Django admin templates — fixes `TemplateDoesNotExist` on every admin page (#261, #262)
- At-most-once retries honored; unique-enqueue dependency validation; no phantom jobs (#257)
- Dead-letter policy: namespace/queue-scoped auto-retry, per-entry TTL purge, metadata preserved (#258)
- SQLite immediate transactions + migration error propagation; Postgres rate-limit over-admit fix (#259)

Tag `0.16.3` from master after merge to publish.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed missing Django admin templates packaging.
  * Fixed retry behavior when explicitly disabled.
  * Improved dependency validation for unique job enqueuing.
  * Enhanced dead-letter queue handling and metadata preservation.
  * Improved SQLite transaction safety to prevent deadlocks.
  * Improved PostgreSQL rate limiting under concurrent load.

* **Chores**
  * Version bumped to 0.16.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->