### PR TITLE
fix(docs): link shared architecture/resources at root, not /python

### DIFF
--- a/docs/app/components/landing/footer.tsx
+++ b/docs/app/components/landing/footer.tsx
@@ -9,7 +9,7 @@ const COLS = [
         href: "/python/getting-started/installation",
       },
       { label: "Guides", href: "/python/guides" },
-      { label: "Architecture", href: "/python/architecture" },
+      { label: "Architecture", href: "/architecture" },
       { label: "API Reference", href: "/python/api-reference" },
     ],
   },
@@ -17,9 +17,9 @@ const COLS = [
     title: "More",
     links: [
       { label: "Examples", href: "/python/more/examples" },
-      { label: "Celery comparison", href: "/python/more/comparison" },
-      { label: "FAQ", href: "/python/more/faq" },
-      { label: "Changelog", href: "/python/more/changelog" },
+      { label: "Celery comparison", href: "/resources/comparison" },
+      { label: "FAQ", href: "/resources/faq" },
+      { label: "Changelog", href: "/resources/changelog" },
     ],
   },
   {

--- a/docs/app/components/landing/sections.tsx
+++ b/docs/app/components/landing/sections.tsx
@@ -400,7 +400,7 @@ export function CTA() {
           <Link className="btn pri" to="/python/getting-started/quickstart">
             Start the quickstart →
           </Link>
-          <Link className="btn sec" to="/python/more/comparison">
+          <Link className="btn sec" to="/resources/comparison">
             See the full comparison
           </Link>
         </div>

--- a/docs/app/components/ui/site-nav.tsx
+++ b/docs/app/components/ui/site-nav.tsx
@@ -20,9 +20,9 @@ function GithubMark() {
 const LINKS = [
   { label: "Getting Started", href: "/python/getting-started/installation" },
   { label: "Guides", href: "/python/guides" },
-  { label: "Architecture", href: "/python/architecture" },
+  { label: "Architecture", href: "/architecture" },
   { label: "API", href: "/python/api-reference" },
-  { label: "Changelog", href: "/python/more/changelog" },
+  { label: "Changelog", href: "/resources/changelog" },
 ];
 
 /** Sticky top navigation, shared by the landing and docs shells. */


### PR DESCRIPTION
## Problem

Nav, footer, and the landing "comparison" CTA linked architecture/changelog/FAQ/comparison under `/python/*`. Those `/python/*` paths only exist as **redirect stubs** (real content lives at the shared root `/architecture`, `/resources/*`), so every click **bounced** through a redirect to a bare-root URL — reported as architecture → `/architecture`, changelog → `/resources/changelog`.

## Why root is correct

Architecture and resources (changelog/FAQ/comparison) are **SDK-agnostic** — they apply to both the Python and Node SDKs, so they live at shared root paths, not under `/python/`. This matches how multi-SDK docs (e.g. Temporal) separate language-independent concepts from per-language guides.

## Fix

Point the nav/footer/CTA links directly at the canonical shared root URLs — no redirect hop. `app/lib/redirects.ts` keeps mapping old `/python/*` deep links to root for external bookmarks.

- `site-nav.tsx`: Architecture → `/architecture`, Changelog → `/resources/changelog`
- `footer.tsx`: Architecture → `/architecture`; comparison/FAQ/changelog → `/resources/*`
- `sections.tsx`: comparison CTA → `/resources/comparison`

Per-SDK links (getting-started, guides, API, examples) stay `/python/*` unchanged.

## Verify
- `pnpm typecheck` + `pnpm build` + `pnpm lint` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized navigation links across the site. Updated paths for comparison, FAQ, changelog, and architecture documentation resources to streamline navigation structure and improve overall site information accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->