### PR TITLE
docs: landing polish + Node section alignment

### DIFF
--- a/docs/app/components/demos/recovery-demo.tsx
+++ b/docs/app/components/demos/recovery-demo.tsx
@@ -194,6 +194,12 @@ export default function RecoveryDemo(_props: DemoProps) {
     setPlaying(true);
   }, [reduced, DUR]);
 
+  // Auto-play on open; startPlay() shows the finished frame under reduced motion.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: run once on mount.
+  useEffect(() => {
+    startPlay();
+  }, []);
+
   const setFromX = useCallback(
     (clientX: number) => {
       const track = trackRef.current;

--- a/docs/app/components/landing/footer.tsx
+++ b/docs/app/components/landing/footer.tsx
@@ -1,22 +1,32 @@
 import { Link } from "react-router";
+import { useActiveSdk } from "@/hooks";
 
-const COLS = [
+type FootLink = {
+  label: string;
+  /** When `sdk` is set, this is an SDK-relative path (prefixed with /python|/node). */
+  href: string;
+  external?: boolean;
+  sdk?: boolean;
+};
+
+const COLS: { title: string; links: FootLink[] }[] = [
   {
     title: "Docs",
     links: [
       {
         label: "Getting Started",
-        href: "/python/getting-started/installation",
+        href: "getting-started/installation",
+        sdk: true,
       },
-      { label: "Guides", href: "/python/guides" },
+      { label: "Guides", href: "guides", sdk: true },
       { label: "Architecture", href: "/architecture" },
-      { label: "API Reference", href: "/python/api-reference" },
+      { label: "API Reference", href: "api-reference", sdk: true },
     ],
   },
   {
     title: "More",
     links: [
-      { label: "Examples", href: "/python/more/examples" },
+      { label: "Examples", href: "more/examples", sdk: true },
       { label: "Celery comparison", href: "/resources/comparison" },
       { label: "FAQ", href: "/resources/faq" },
       { label: "Changelog", href: "/resources/changelog" },
@@ -50,6 +60,7 @@ const COLS = [
 ];
 
 export function Footer() {
+  const sdk = useActiveSdk();
   return (
     <footer className="foot">
       <div className="foot-grid">
@@ -69,12 +80,12 @@ export function Footer() {
           <div key={col.title} className="foot-col">
             <h4>{col.title}</h4>
             {col.links.map((l) =>
-              "external" in l && l.external ? (
+              l.external ? (
                 <a key={l.label} href={l.href} target="_blank" rel="noreferrer">
                   {l.label}
                 </a>
               ) : (
-                <Link key={l.label} to={l.href}>
+                <Link key={l.label} to={l.sdk ? `/${sdk}/${l.href}` : l.href}>
                   {l.label}
                 </Link>
               ),

--- a/docs/app/components/landing/hero.tsx
+++ b/docs/app/components/landing/hero.tsx
@@ -3,9 +3,9 @@ import { Link } from "react-router";
 import { RawHtml } from "@/components/ui";
 import { useSdk } from "@/hooks";
 import { highlightPython, highlightTs } from "@/lib/highlight-lite";
-import { HERO_PANES, SOON_PANES, type SoonLang } from "@/lib/landing-content";
+import { HERO_PANES } from "@/lib/landing-content";
 
-type Lang = "py" | "ts" | "go" | "java";
+type Lang = "py" | "ts";
 
 function CopyButton({ text }: { text: string }) {
   const [copied, setCopied] = useState(false);
@@ -24,31 +24,14 @@ function CopyButton({ text }: { text: string }) {
   );
 }
 
-function SoonBox({ pane }: { pane: SoonLang }) {
-  return (
-    <div className="soonbox">
-      <div className="ring" />
-      <h4>{pane.heading}</h4>
-      <p>{pane.body}</p>
-      <span className="gh">github.com/ByteVeda/taskito</span>
-    </div>
-  );
-}
-
 export function Hero() {
   const { sdk, setSdk } = useSdk();
-  // Roadmap langs (go/java) have no SDK — selected locally; py/ts mirror the
-  // global SDK so the hero tab and the docs sidebar switch stay in sync.
-  const [soon, setSoon] = useState<SoonLang["id"] | null>(null);
-  const lang: Lang = soon ?? (sdk === "node" ? "ts" : "py");
+  // py/ts mirror the global SDK so the hero tab and the docs sidebar switch stay in sync.
   const isNode = sdk === "node";
-  const pane = HERO_PANES.find((p) => p.id === lang);
-  const codeHtml = pane
-    ? lang === "ts"
-      ? highlightTs(pane.code)
-      : highlightPython(pane.code)
-    : "";
-  const active = pane ?? HERO_PANES[0];
+  const lang: Lang = isNode ? "ts" : "py";
+  const active = HERO_PANES.find((p) => p.id === lang) ?? HERO_PANES[0];
+  const codeHtml =
+    lang === "ts" ? highlightTs(active.code) : highlightPython(active.code);
 
   return (
     <section className="hero">
@@ -106,53 +89,31 @@ export function Hero() {
                 key={p.id}
                 type="button"
                 className={`langtab ${p.id === lang ? "active" : ""}`.trim()}
-                onClick={() => {
-                  setSoon(null);
-                  setSdk(p.id === "ts" ? "node" : "python");
-                }}
+                onClick={() => setSdk(p.id === "ts" ? "node" : "python")}
               >
                 {p.label}
+                {p.id === "ts" ? <span className="tag beta">Beta</span> : null}
               </button>
             ))}
-            {SOON_PANES.map((p) => (
-              <button
-                key={p.id}
-                type="button"
-                className={`langtab dis ${p.id === lang ? "active" : ""}`.trim()}
-                onClick={() => setSoon(p.id)}
-              >
-                {p.label} <span className="tag soon">soon</span>
-              </button>
-            ))}
-            {pane ? <CopyButton text={pane.code} /> : null}
+            <CopyButton text={active.code} />
           </div>
           <div id="hero-panes">
-            {pane ? (
-              <RawHtml as="pre" className="code" html={codeHtml} />
-            ) : (
-              <SoonBox
-                pane={SOON_PANES.find((p) => p.id === lang) ?? SOON_PANES[0]}
-              />
-            )}
+            <RawHtml as="pre" className="code" html={codeHtml} />
           </div>
         </div>
 
-        {pane ? (
-          <div className="out">
-            <div className="outset">
-              {pane.output.map((line) => (
-                <div className="oline show" key={line.text}>
-                  <span className={line.glyphKind}>{line.glyph}</span>
-                  <span className="var">{line.text}</span>
-                  {line.value ? <span className="v">{line.value}</span> : null}
-                  {line.timing ? (
-                    <span className="t">{line.timing}</span>
-                  ) : null}
-                </div>
-              ))}
-            </div>
+        <div className="out">
+          <div className="outset">
+            {active.output.map((line) => (
+              <div className="oline show" key={line.text}>
+                <span className={line.glyphKind}>{line.glyph}</span>
+                <span className="var">{line.text}</span>
+                {line.value ? <span className="v">{line.value}</span> : null}
+                {line.timing ? <span className="t">{line.timing}</span> : null}
+              </div>
+            ))}
           </div>
-        ) : null}
+        </div>
 
         <div className="hero-doclinks">
           <Link
@@ -162,7 +123,7 @@ export function Hero() {
             Read the Python quickstart →
           </Link>
           <Link className="hero-doclink" to="/node/getting-started/quickstart">
-            Read the TypeScript quickstart →
+            Read the Node.js quickstart →
           </Link>
         </div>
       </div>

--- a/docs/app/components/landing/scenario-finder.tsx
+++ b/docs/app/components/landing/scenario-finder.tsx
@@ -1,7 +1,21 @@
 import { type KeyboardEvent, useEffect, useRef, useState } from "react";
 import { Link } from "react-router";
 import { RawHtml } from "@/components/ui";
+import { type Sdk, useActiveSdk } from "@/hooks";
 import { DemoModal, type DemoTarget } from "./demo-modal";
+
+// Scenario guides are authored as Python paths; most map to Node by swapping the
+// SDK segment, but a few pages live under a different slug in the Node tree.
+const NODE_GUIDE_OVERRIDES: Record<string, string> = {
+  "/python/guides/advanced-execution/streaming": "/node/guides/core/streaming",
+  "/python/guides/workflows/sagas": "/node/guides/workflows/saga",
+};
+
+/** Resolve a scenario's Python guide path to the active SDK's docs. */
+function guideHref(pyPath: string, sdk: Sdk): string {
+  if (sdk !== "node") return pyPath;
+  return NODE_GUIDE_OVERRIDES[pyPath] ?? pyPath.replace("/python/", "/node/");
+}
 
 interface Bullet {
   /** Short mono label in the left rail. */
@@ -407,6 +421,7 @@ function motionDisabled(): boolean {
  * in {@link DemoModal}, the secondary links the guide that goes deeper.
  */
 export function ScenarioFinder() {
+  const sdk = useActiveSdk();
   const [selected, setSelected] = useState(0);
   // Drives the card's enter animation; re-triggered on every selection change.
   const [entered, setEntered] = useState(true);
@@ -570,7 +585,7 @@ export function ScenarioFinder() {
                   {active.demo.label}
                   {CTA_ARROW}
                 </button>
-                <Link className="btn sec" to={active.guide.to}>
+                <Link className="btn sec" to={guideHref(active.guide.to, sdk)}>
                   {active.guide.label}
                 </Link>
               </div>

--- a/docs/app/components/landing/sections.tsx
+++ b/docs/app/components/landing/sections.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Link } from "react-router";
 import { RawHtml } from "@/components/ui";
+import { useActiveSdk } from "@/hooks";
 import { highlightPython } from "@/lib/highlight-lite";
 import {
   CODE_CELERY,
@@ -233,6 +234,7 @@ export function Features() {
 }
 
 export function UseCases() {
+  const sdk = useActiveSdk();
   return (
     <section
       className="section"
@@ -249,7 +251,11 @@ export function UseCases() {
         />
         <div className="uc-grid">
           {USE_CASES.map((c) => (
-            <div key={c.title} className="uc reveal">
+            <Link
+              key={c.title}
+              to={c.href ? `/${sdk}/${c.href}` : "#"}
+              className="uc reveal"
+            >
               <div className="ic">
                 <Icon d={c.icon} rect={c.rect} />
               </div>
@@ -259,7 +265,7 @@ export function UseCases() {
                 </h3>
                 <RawHtml as="p" html={c.body} />
               </div>
-            </div>
+            </Link>
           ))}
         </div>
       </div>

--- a/docs/app/components/landing/sections.tsx
+++ b/docs/app/components/landing/sections.tsx
@@ -250,23 +250,34 @@ export function UseCases() {
           lead="Pick the workload — taskito ships the primitives."
         />
         <div className="uc-grid">
-          {USE_CASES.map((c) => (
-            <Link
-              key={c.title}
-              to={c.href ? `/${sdk}/${c.href}` : "#"}
-              className="uc reveal"
-            >
-              <div className="ic">
-                <Icon d={c.icon} rect={c.rect} />
+          {USE_CASES.map((c) => {
+            const inner = (
+              <>
+                <div className="ic">
+                  <Icon d={c.icon} rect={c.rect} />
+                </div>
+                <div>
+                  <h3>
+                    {c.title} <span className="arr">→</span>
+                  </h3>
+                  <RawHtml as="p" html={c.body} />
+                </div>
+              </>
+            );
+            return c.href ? (
+              <Link
+                key={c.title}
+                to={`/${sdk}/${c.href}`}
+                className="uc reveal"
+              >
+                {inner}
+              </Link>
+            ) : (
+              <div key={c.title} className="uc reveal">
+                {inner}
               </div>
-              <div>
-                <h3>
-                  {c.title} <span className="arr">→</span>
-                </h3>
-                <RawHtml as="p" html={c.body} />
-              </div>
-            </Link>
-          ))}
+            );
+          })}
         </div>
       </div>
     </section>

--- a/docs/app/hooks/index.ts
+++ b/docs/app/hooks/index.ts
@@ -1,1 +1,2 @@
+export { usePrefetchDocs } from "./use-prefetch-docs";
 export { type Sdk, useActiveSdk, useSdk } from "./use-sdk";

--- a/docs/app/hooks/use-prefetch-docs.ts
+++ b/docs/app/hooks/use-prefetch-docs.ts
@@ -1,0 +1,15 @@
+import { useEffect } from "react";
+import { prefetchSdkDocs } from "@/lib/prefetch";
+import { useActiveSdk } from "./use-sdk";
+
+/**
+ * Warm the active SDK's docs in the background. Runs on mount and whenever the
+ * selected language changes (hero tab, sidebar switcher, or a `/node|/python`
+ * URL), so the first navigation into that SDK's docs is instant.
+ */
+export function usePrefetchDocs(): void {
+  const sdk = useActiveSdk();
+  useEffect(() => {
+    prefetchSdkDocs(sdk);
+  }, [sdk]);
+}

--- a/docs/app/lib/landing-content.ts
+++ b/docs/app/lib/landing-content.ts
@@ -56,7 +56,7 @@ print(job.result())   # → 5`,
   },
   {
     id: "ts",
-    label: "TypeScript",
+    label: "Node.js",
     filename: "tasks.ts",
     install: "pnpm add taskito",
     code: `import { Queue } from "taskito";
@@ -83,30 +83,7 @@ console.log(await queue.result(id)); // → 5`,
       },
     ],
     docHref: "/node/getting-started/quickstart",
-    docLabel: "Read the TypeScript quickstart",
-  },
-];
-
-/** Roadmap languages: disabled tab + "coming soon" panel (no fabricated SDK). */
-export interface SoonLang {
-  id: "go" | "java";
-  label: string;
-  heading: string;
-  body: string;
-}
-
-export const SOON_PANES: SoonLang[] = [
-  {
-    id: "go",
-    label: "Go",
-    heading: "Go client — coming soon",
-    body: "A native Go client for enqueuing and inspecting taskito jobs is on the roadmap.",
-  },
-  {
-    id: "java",
-    label: "Java",
-    heading: "Java client — coming soon",
-    body: "A JVM client for enqueuing taskito jobs from Java & Kotlin is planned.",
+    docLabel: "Read the Node.js quickstart",
   },
 ];
 

--- a/docs/app/lib/landing-content.ts
+++ b/docs/app/lib/landing-content.ts
@@ -92,6 +92,8 @@ export interface IconCard {
   rect?: boolean;
   title: string;
   body: string;
+  /** SDK-relative doc path (no leading slash, no `/python|/node` prefix). */
+  href?: string;
 }
 
 export const FEATURES: IconCard[] = [
@@ -133,22 +135,26 @@ export const USE_CASES: IconCard[] = [
     icon: "M12 2C6.48 2 2 4.02 2 6.5v11C2 19.98 6.48 22 12 22s10-2.02 10-4.5v-11C22 4.02 17.52 2 12 2zM2 6.5C2 8.43 6.48 10 12 10s10-1.57 10-3.5M2 12c0 1.93 4.48 3.5 10 3.5s10-1.57 10-3.5",
     title: "ETL pipelines",
     body: "Chain extract → transform → load as a DAG. Fan out across workers, fan in to aggregate, restart from any node on failure.",
+    href: "more/examples/data-pipeline",
   },
   {
     icon: "M4 4h16a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2zM22 6l-10 7L2 6",
     title: "Email & notifications",
     body: "Bursty SMTP, push, or webhook delivery. Per-task rate limits keep providers happy; retries with backoff handle transient failures.",
+    href: "more/examples/notifications",
   },
   {
     icon: "M9 2v3M15 2v3M9 19v3M15 19v3M2 9h3M2 15h3M19 9h3M19 15h3",
     rect: true,
     title: "ML inference & batch",
     body: "Long-running model jobs with progress tracking, soft timeouts, and prefork pools for true CPU parallelism without GIL contention.",
+    href: "more/examples/benchmark",
   },
   {
     icon: "M12 6v6l4 2M12 22a10 10 0 1 1 0-20 10 10 0 0 1 0 20z",
     title: "Scheduled jobs",
     body: "Six-field cron syntax down to the second. Periodic tasks live in the scheduler — no separate beat daemon to babysit.",
+    href: "guides/core/scheduling",
   },
 ];
 

--- a/docs/app/lib/prefetch.ts
+++ b/docs/app/lib/prefetch.ts
@@ -1,0 +1,71 @@
+import { allDocSlugs, getDocLoader } from "./content";
+import type { Sdk } from "./sdk-store";
+
+/** SDKs already warmed this session — a toggle back to one is a no-op. */
+const prefetched = new Set<Sdk>();
+
+/** Max chunks fetched at once, so a 80-page SDK doesn't saturate the network. */
+const CONCURRENCY = 3;
+
+/** Run `cb` when the browser is idle; fall back to a microtask-ish delay. */
+function onIdle(cb: () => void): void {
+  if (typeof window !== "undefined" && "requestIdleCallback" in window) {
+    window.requestIdleCallback(cb, { timeout: 2000 });
+  } else {
+    setTimeout(cb, 1);
+  }
+}
+
+interface NetworkInformation {
+  saveData?: boolean;
+  effectiveType?: string;
+}
+
+/** Honor the user's data-saver preference and skip slow (2G) connections. */
+function prefetchAllowed(): boolean {
+  const conn = (navigator as unknown as { connection?: NetworkInformation })
+    .connection;
+  if (!conn) {
+    return true;
+  }
+  if (conn.saveData) {
+    return false;
+  }
+  return conn.effectiveType !== "slow-2g" && conn.effectiveType !== "2g";
+}
+
+/**
+ * Warm every doc chunk for `sdk` in the background. Idempotent per SDK; chunked
+ * across idle callbacks with a small concurrency cap. A no-op during SSR/prerender
+ * and under Save-Data / 2G. Failed prefetches are ignored — the page still loads
+ * on demand when actually visited.
+ */
+export function prefetchSdkDocs(sdk: Sdk): void {
+  if (typeof window === "undefined" || prefetched.has(sdk)) {
+    return;
+  }
+  if (!prefetchAllowed()) {
+    return; // not marked prefetched, so a later call can retry if conditions improve
+  }
+  prefetched.add(sdk);
+
+  const prefix = `/${sdk}`;
+  const loaders = allDocSlugs()
+    .filter((slug) => slug === prefix || slug.startsWith(`${prefix}/`))
+    .map(getDocLoader)
+    .filter((loader): loader is NonNullable<typeof loader> => Boolean(loader));
+
+  let next = 0;
+  const pump = (): void => {
+    if (next >= loaders.length) {
+      return;
+    }
+    const loader = loaders[next++];
+    loader()
+      .catch(() => {})
+      .finally(() => onIdle(pump));
+  };
+  for (let lane = 0; lane < CONCURRENCY; lane++) {
+    onIdle(pump);
+  }
+}

--- a/docs/app/root.tsx
+++ b/docs/app/root.tsx
@@ -6,6 +6,7 @@ import {
   Scripts,
   ScrollRestoration,
 } from "react-router";
+import { usePrefetchDocs } from "@/hooks";
 import type { Route } from "./+types/root";
 import "./app.css";
 
@@ -57,6 +58,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
 }
 
 export default function App() {
+  usePrefetchDocs();
   return <Outlet />;
 }
 

--- a/docs/app/styles/landing.css
+++ b/docs/app/styles/landing.css
@@ -794,6 +794,8 @@ main {
   border: 1px solid var(--line2);
   border-radius: 16px;
   background: var(--panel);
+  color: inherit;
+  text-decoration: none;
   transition:
     border-color 0.2s,
     transform 0.2s;

--- a/docs/content/docs/node/getting-started/capabilities.mdx
+++ b/docs/content/docs/node/getting-started/capabilities.mdx
@@ -1,5 +1,5 @@
 ---
-title: Capabilities
+title: Capabilities at a glance
 description: "Everything the Node SDK can do, with a link to each guide."
 ---
 

--- a/docs/content/docs/node/guides/core/execution-model.mdx
+++ b/docs/content/docs/node/guides/core/execution-model.mdx
@@ -1,5 +1,5 @@
 ---
-title: Execution model
+title: Execution Models
 description: "How the Node worker runs jobs — the event loop, concurrency, and CPU-bound work."
 ---
 

--- a/docs/content/docs/node/guides/core/predicates.mdx
+++ b/docs/content/docs/node/guides/core/predicates.mdx
@@ -1,5 +1,5 @@
 ---
-title: Predicate gates
+title: Predicates
 description: "Gate enqueues with composable predicates evaluated at submit time."
 ---
 

--- a/docs/content/docs/node/guides/core/queues.mdx
+++ b/docs/content/docs/node/guides/core/queues.mdx
@@ -1,5 +1,5 @@
 ---
-title: Queues
+title: Queues & Priority
 description: "Route jobs to named queues, set priority, and pause/resume."
 ---
 

--- a/docs/content/docs/node/guides/core/scheduling.mdx
+++ b/docs/content/docs/node/guides/core/scheduling.mdx
@@ -1,5 +1,5 @@
 ---
-title: Scheduling (cron)
+title: Scheduling
 description: "Register periodic tasks on a cron expression; a worker fires them when due."
 ---
 

--- a/docs/content/docs/node/guides/extensibility/middleware.mdx
+++ b/docs/content/docs/node/guides/extensibility/middleware.mdx
@@ -1,5 +1,5 @@
 ---
-title: Middleware
+title: Per-Task Middleware
 description: "Wrap task execution with before/after/error and outcome hooks."
 ---
 

--- a/docs/content/docs/node/guides/extensibility/serializers.mdx
+++ b/docs/content/docs/node/guides/extensibility/serializers.mdx
@@ -1,5 +1,5 @@
 ---
-title: Serializers
+title: Pluggable Serializers
 description: "Pluggable arg/result serialization — JSON or msgpack."
 ---
 

--- a/docs/content/docs/node/guides/integrations/express.mdx
+++ b/docs/content/docs/node/guides/integrations/express.mdx
@@ -1,5 +1,5 @@
 ---
-title: Express
+title: Express Integration
 description: "Mount a REST API and the dashboard into an Express app."
 ---
 

--- a/docs/content/docs/node/guides/integrations/fastify.mdx
+++ b/docs/content/docs/node/guides/integrations/fastify.mdx
@@ -1,5 +1,5 @@
 ---
-title: Fastify
+title: Fastify Integration
 description: "Register the REST API and dashboard as Fastify plugins."
 ---
 

--- a/docs/content/docs/node/guides/integrations/nest.mdx
+++ b/docs/content/docs/node/guides/integrations/nest.mdx
@@ -1,5 +1,5 @@
 ---
-title: NestJS
+title: NestJS Integration
 description: "Inject a TaskitoService into your Nest providers."
 ---
 

--- a/docs/content/docs/node/guides/integrations/otel.mdx
+++ b/docs/content/docs/node/guides/integrations/otel.mdx
@@ -1,5 +1,5 @@
 ---
-title: OpenTelemetry
+title: OpenTelemetry Integration
 description: "Distributed tracing for Node.js task execution — one span per attempt."
 ---
 

--- a/docs/content/docs/node/guides/integrations/prometheus.mdx
+++ b/docs/content/docs/node/guides/integrations/prometheus.mdx
@@ -1,5 +1,5 @@
 ---
-title: Prometheus
+title: Prometheus Metrics
 description: "Execution metrics and polled queue/DLQ depth gauges for Node.js workers."
 ---
 

--- a/docs/content/docs/node/guides/integrations/sentry.mdx
+++ b/docs/content/docs/node/guides/integrations/sentry.mdx
@@ -1,5 +1,5 @@
 ---
-title: Sentry
+title: Sentry Integration
 description: "Capture the original exception when a Node.js job dead-letters."
 ---
 

--- a/docs/content/docs/node/guides/observability/logging.mdx
+++ b/docs/content/docs/node/guides/observability/logging.mdx
@@ -1,5 +1,5 @@
 ---
-title: Logging
+title: Structured Task Logging
 description: "The built-in leveled logger — levels, namespaces, and a pluggable sink."
 ---
 

--- a/docs/content/docs/node/guides/observability/monitoring.mdx
+++ b/docs/content/docs/node/guides/observability/monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-title: Monitoring
+title: Monitoring & Hooks
 description: "Queue stats, per-task metrics, job progress, and worker heartbeats."
 ---
 

--- a/docs/content/docs/node/guides/operations/inspection.mdx
+++ b/docs/content/docs/node/guides/operations/inspection.mdx
@@ -1,5 +1,5 @@
 ---
-title: Job management
+title: Job Management
 description: "List and inspect jobs, manage the dead-letter queue, and pause queues."
 ---
 

--- a/docs/content/docs/node/guides/operations/keda.mdx
+++ b/docs/content/docs/node/guides/operations/keda.mdx
@@ -1,5 +1,5 @@
 ---
-title: KEDA autoscaling
+title: KEDA Autoscaling
 description: "Scale Node workers on Kubernetes by queue depth via the bundled scaler server."
 ---
 

--- a/docs/content/docs/node/guides/operations/mesh.mdx
+++ b/docs/content/docs/node/guides/operations/mesh.mdx
@@ -1,5 +1,5 @@
 ---
-title: Mesh
+title: Mesh Scheduling
 description: "Form a work-stealing overlay so idle workers pull from busy peers."
 ---
 

--- a/docs/content/docs/node/guides/reliability/circuit-breakers.mdx
+++ b/docs/content/docs/node/guides/reliability/circuit-breakers.mdx
@@ -1,5 +1,5 @@
 ---
-title: Circuit breakers
+title: Circuit Breakers
 description: "Trip a task after repeated failures to shed load on a failing dependency."
 ---
 

--- a/docs/content/docs/node/guides/reliability/error-handling.mdx
+++ b/docs/content/docs/node/guides/reliability/error-handling.mdx
@@ -1,5 +1,5 @@
 ---
-title: Error handling
+title: Error Handling
 description: "What happens when a task throws — retries, timeouts, and the dead-letter queue."
 ---
 

--- a/docs/content/docs/node/guides/reliability/guarantees.mdx
+++ b/docs/content/docs/node/guides/reliability/guarantees.mdx
@@ -1,5 +1,5 @@
 ---
-title: Delivery guarantees
+title: Delivery Guarantees
 description: "At-least-once execution, job claiming, and staying correct under retries."
 ---
 

--- a/docs/content/docs/node/guides/reliability/locks.mdx
+++ b/docs/content/docs/node/guides/reliability/locks.mdx
@@ -1,5 +1,5 @@
 ---
-title: Distributed locks
+title: Distributed Locking
 description: "TTL-bounded, owner-scoped locks backed by the queue's storage."
 ---
 

--- a/docs/content/docs/node/guides/reliability/rate-limiting.mdx
+++ b/docs/content/docs/node/guides/reliability/rate-limiting.mdx
@@ -1,5 +1,5 @@
 ---
-title: Rate limiting
+title: Rate Limiting
 description: "Token-bucket limits per task or per queue."
 ---
 

--- a/docs/content/docs/node/guides/resources/dependency-injection.mdx
+++ b/docs/content/docs/node/guides/resources/dependency-injection.mdx
@@ -1,5 +1,5 @@
 ---
-title: Dependency injection
+title: Dependency Injection
 description: "Register external dependencies once and inject them into tasks by scope."
 ---
 

--- a/docs/content/docs/node/guides/resources/index.mdx
+++ b/docs/content/docs/node/guides/resources/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Resources
+title: Resource System
 description: "Inject external dependencies into tasks and intercept jobs before they enqueue."
 ---
 

--- a/docs/content/docs/node/guides/resources/interception.mdx
+++ b/docs/content/docs/node/guides/resources/interception.mdx
@@ -1,5 +1,5 @@
 ---
-title: Enqueue interception
+title: Argument Interception
 description: "Validate, redact, or rewrite jobs before they are serialized."
 ---
 

--- a/docs/content/docs/node/guides/workflows/analysis.mdx
+++ b/docs/content/docs/node/guides/workflows/analysis.mdx
@@ -1,5 +1,5 @@
 ---
-title: Analysis
+title: Analysis & Visualization
 description: "Introspect a workflow run's DAG — dependencies, levels, critical path, and stats."
 ---
 

--- a/docs/content/docs/node/guides/workflows/caching.mdx
+++ b/docs/content/docs/node/guides/workflows/caching.mdx
@@ -1,5 +1,5 @@
 ---
-title: Caching
+title: Incremental Runs
 description: "Reuse a workflow step's result across runs — incremental runs with a dirty set."
 ---
 

--- a/docs/content/docs/node/guides/workflows/canvas.mdx
+++ b/docs/content/docs/node/guides/workflows/canvas.mdx
@@ -1,5 +1,5 @@
 ---
-title: Canvas
+title: Canvas Primitives
 description: "Chain, group, and chord shorthands for common workflow shapes."
 ---
 

--- a/docs/content/docs/node/guides/workflows/conditions.mdx
+++ b/docs/content/docs/node/guides/workflows/conditions.mdx
@@ -1,5 +1,5 @@
 ---
-title: Conditions
+title: Conditions & Error Handling
 description: "Run a step only when its predecessors succeeded, failed, or either."
 ---
 

--- a/docs/content/docs/node/guides/workflows/saga.mdx
+++ b/docs/content/docs/node/guides/workflows/saga.mdx
@@ -1,5 +1,5 @@
 ---
-title: Saga Compensation
+title: Sagas
 description: "Automatically roll back completed steps in reverse order when a workflow run fails."
 ---
 

--- a/docs/content/docs/node/guides/workflows/sub-workflows.mdx
+++ b/docs/content/docs/node/guides/workflows/sub-workflows.mdx
@@ -1,5 +1,5 @@
 ---
-title: Sub-Workflows
+title: Sub-Workflows & Scheduling
 description: "Compose workflow runs hierarchically — a parent step delegates to a child workflow."
 ---
 

--- a/docs/content/docs/node/more/examples/bulk-emails.mdx
+++ b/docs/content/docs/node/more/examples/bulk-emails.mdx
@@ -1,5 +1,5 @@
 ---
-title: Bulk emails
+title: Bulk Emails
 description: "Fan a large recipient list out with enqueueMany, then bound the send rate and concurrency with per-task limits."
 ---
 

--- a/docs/content/docs/node/more/examples/data-pipeline.mdx
+++ b/docs/content/docs/node/more/examples/data-pipeline.mdx
@@ -1,5 +1,5 @@
 ---
-title: ETL data pipeline
+title: ETL Data Pipeline
 description: "A diamond-shaped extract → transform → load DAG with progress reporting, error inspection, and skip-on-failure cascading."
 ---
 

--- a/docs/content/docs/node/more/examples/express-service.mdx
+++ b/docs/content/docs/node/more/examples/express-service.mdx
@@ -1,5 +1,5 @@
 ---
-title: Express image service
+title: Express Image Service
 description: "A REST API that enqueues image jobs, streams progress to the browser over SSE, and cancels work in flight."
 ---
 

--- a/docs/content/docs/node/more/examples/notifications.mdx
+++ b/docs/content/docs/node/more/examples/notifications.mdx
@@ -1,5 +1,5 @@
 ---
-title: Notification service
+title: Notification Service
 description: "Delayed sends, idempotent enqueues, priority lanes, periodic digests, and batch fan-out for a notification system."
 ---
 

--- a/docs/content/docs/node/more/examples/predicate-gated-jobs.mdx
+++ b/docs/content/docs/node/more/examples/predicate-gated-jobs.mdx
@@ -1,5 +1,5 @@
 ---
-title: Predicate-gated jobs
+title: Predicate-Gated Jobs
 description: "Reject enqueues that don't meet a policy at submit time, composing business-hours, feature-flag, and quota predicates."
 ---
 

--- a/docs/content/docs/node/more/examples/web-scraper.mdx
+++ b/docs/content/docs/node/more/examples/web-scraper.mdx
@@ -1,5 +1,5 @@
 ---
-title: Web scraper pipeline
+title: Web Scraper Pipeline
 description: "A polite, rate-limited scraper: retries, named queues, middleware logging, and a fan-in workflow that aggregates results."
 ---
 

--- a/docs/content/docs/node/more/examples/workflows.mdx
+++ b/docs/content/docs/node/more/examples/workflows.mdx
@@ -1,5 +1,5 @@
 ---
-title: DAG workflow examples
+title: DAG Workflow Examples
 description: "Fan-out/fan-in map-reduce, approval gates, error-handling conditions, sub-workflows, caching, and critical-path analysis."
 ---
 

--- a/docs/content/docs/node/more/meta.json
+++ b/docs/content/docs/node/more/meta.json
@@ -1,0 +1,5 @@
+{
+  "title": "Examples",
+  "root": true,
+  "pages": ["examples"]
+}


### PR DESCRIPTION
Landing-page and Node-docs polish.

## Landing page
- Hero code-snippet tab relabeled **TypeScript → Node.js**, with a **Beta** badge; Go/Java roadmap tabs removed (dead `SOON_PANES`/`SoonBox` cleaned up).
- Use-case cards now deep-link into the matching example/guide (they previously rendered a `→` arrow but linked nowhere): ETL→`data-pipeline`, Email→`notifications`, ML batch→`benchmark`, Scheduled→`core/scheduling` (no cron example exists).
- Homepage links are **SDK-aware**: use-case cards, footer Docs/More columns, and scenario-finder guide links flip between `/python` and `/node` via the active SDK. Two scenarios remap to Node's different slugs (`advanced-execution/streaming`→`core/streaming`, `workflows/sagas`→`workflows/saga`).
- Recovery demo now **auto-plays on open** (saga/workflow already did; the other live demos are unaffected).

## Node docs
- 38 page titles aligned to the Python docs' naming (Title Case + verbose), plus the previously-empty `node/more/meta.json`. Kept Node-specific titles where content genuinely differs (`migration` = BullMQ, `retries` keeps DLQ separate).

## Background docs prefetch
- Selecting a language warms every doc chunk for that SDK in the background, so the first navigation into its docs is instant. Idle-scheduled (`requestIdleCallback`), concurrency-capped, idempotent per SDK, and backs off under Save-Data / 2G — the quicklink/Gatsby prefetch playbook.

## Notes
- Scenario-finder snippets stay Python code; only their guide links are SDK-aware (rewriting snippets to TS is a separate pass).

## Verification
`pnpm --dir docs typecheck`, `lint`, and `build` (full static prerender of all node + python pages) all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic background prefetching of SDK documentation to speed up navigation across SDKs.
* **Improvements**
  * Updated landing navigation to be SDK-aware across the hero, footer, use-case cards, and “Read the guide” links (including Node/Python routing adjustments).
  * Recovery demo now begins playback immediately on open.
* **Documentation**
  * Refreshed multiple doc page headings/titles for consistency (e.g., capitalization and wording).
* **Style**
  * Adjusted landing card link styling to inherit text color and remove default underlines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->