### PR TITLE
ci(node): token auth for first npm publish

### DIFF
--- a/.github/workflows/publish-node.yml
+++ b/.github/workflows/publish-node.yml
@@ -177,16 +177,6 @@ jobs:
       - name: Update npm (trusted publishing + provenance)
         run: npm install -g npm@latest
 
-      # First publish only: npm has no OIDC path for a not-yet-existing package
-      # (the trusted-publisher config can't be added until the package exists), so
-      # authenticate this initial release with a token. Once trusted publishing is
-      # configured on every package, delete this step + the NPM_TOKEN secret and
-      # publishing falls back to OIDC-only (provenance still works either way).
-      - name: Configure npm auth (first publish — pre-OIDC)
-        run: npm config set //registry.npmjs.org/:_authToken "${NODE_AUTH_TOKEN}"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
       - name: Build dashboard SPA
         uses: ./.github/actions/dashboard-build
         with:
@@ -225,6 +215,18 @@ jobs:
           console.log("optionalDependencies:", pkg.optionalDependencies);
           NODE
 
+      # First publish only: npm has no OIDC path for a not-yet-existing package
+      # (the trusted-publisher config can't be added until the package exists), so
+      # authenticate this initial release with a token. Written right before the
+      # publish steps and skipped on dry-runs to keep the token out of build/assembly.
+      # Once trusted publishing is configured on every package, delete this step +
+      # the NPM_TOKEN secret and publishing falls back to OIDC-only.
+      - name: Configure npm auth (first publish — pre-OIDC)
+        if: ${{ !inputs.dry-run }}
+        run: npm config set //registry.npmjs.org/:_authToken "${NODE_AUTH_TOKEN}"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Publish per-platform packages
         if: ${{ !inputs.dry-run }}
         working-directory: sdks/node
@@ -250,6 +252,11 @@ jobs:
           else
             npm publish --provenance --access public
           fi
+
+      # Drop the token from npm config even if a publish step failed.
+      - name: Clear npm auth
+        if: ${{ always() && !inputs.dry-run }}
+        run: npm config delete //registry.npmjs.org/:_authToken || true
 
       - name: Verify version on npm
         if: ${{ !inputs.dry-run }}

--- a/.github/workflows/publish-node.yml
+++ b/.github/workflows/publish-node.yml
@@ -177,6 +177,16 @@ jobs:
       - name: Update npm (trusted publishing + provenance)
         run: npm install -g npm@latest
 
+      # First publish only: npm has no OIDC path for a not-yet-existing package
+      # (the trusted-publisher config can't be added until the package exists), so
+      # authenticate this initial release with a token. Once trusted publishing is
+      # configured on every package, delete this step + the NPM_TOKEN secret and
+      # publishing falls back to OIDC-only (provenance still works either way).
+      - name: Configure npm auth (first publish — pre-OIDC)
+        run: npm config set //registry.npmjs.org/:_authToken "${NODE_AUTH_TOKEN}"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Build dashboard SPA
         uses: ./.github/actions/dashboard-build
         with:


### PR DESCRIPTION
First npm publish of `taskito` (Node SDK) can't use OIDC trusted publishing — npm requires a package to exist before its trusted-publisher config can be added, and `publish-node.yml` is currently OIDC-only.

Adds a token-auth step (`NPM_TOKEN`, the `npm` environment secret) to the publish job for the initial release. `--provenance` is retained (works with token + `id-token: write`).

After the first release publishes all 8 packages (`taskito` + 7 platform), configure trusted publishing on each and revert this step + delete the secret → publishing returns to OIDC-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the npm publishing workflow to support the very first publish by setting up npm registry authentication with the provided token when not in dry-run mode.
  * Added an automatic cleanup step to remove the npm auth token from npm configuration even if publishing fails (while still skipping cleanup during dry-runs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->