### PR TITLE
fix(node): build linux addons via docker run

### DIFF
--- a/.github/workflows/publish-node.yml
+++ b/.github/workflows/publish-node.yml
@@ -90,26 +90,22 @@ jobs:
     name: Build ${{ matrix.triple }}
     needs: preflight
     runs-on: ${{ matrix.runner }}
-    # Linux builds run inside the napi-rs images for a low glibc / musl baseline;
-    # macOS and Windows build natively on the runner. All builds are native
-    # (host == target), so postgres's bundled libpq compiles like any local build.
-    container: ${{ matrix.container }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - triple: x86_64-unknown-linux-gnu
             runner: ubuntu-latest
-            container: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian
+            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian
           - triple: aarch64-unknown-linux-gnu
             runner: ubuntu-24.04-arm
-            container: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian
+            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian
           - triple: x86_64-unknown-linux-musl
             runner: ubuntu-latest
-            container: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
+            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
           - triple: aarch64-unknown-linux-musl
             runner: ubuntu-24.04-arm
-            container: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
+            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
           - triple: x86_64-apple-darwin
             runner: macos-15-intel
           - triple: aarch64-apple-darwin
@@ -119,32 +115,47 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      # Linux: the napi-rs image already has Rust + Node; add pnpm and perl
-      # (needed by `openssl-sys` vendored + `pq-src` to build libpq from source).
-      - name: Set up Linux toolchain
-        if: matrix.container != ''
-        shell: bash
-        run: |
-          if command -v apk >/dev/null; then
-            apk add --no-cache perl build-base
-          else
-            apt-get update && apt-get install -y perl
-          fi
-          npm install -g pnpm@10.33.0
-          pnpm -C sdks/node install --frozen-lockfile
-
+      # macOS / Windows build natively on the runner.
       - name: Set up Rust
-        if: matrix.container == ''
+        if: matrix.docker == ''
         uses: ./.github/actions/setup-rust
 
       - name: Set up Node + pnpm
-        if: matrix.container == ''
+        if: matrix.docker == ''
         uses: ./.github/actions/setup-node
 
-      - name: Build native addon (full features, host target)
+      - name: Build native addon (host target)
+        if: matrix.docker == ''
         shell: bash
         working-directory: sdks/node
         run: pnpm run build:native
+
+      # Linux builds run inside the napi-rs image for a low glibc / musl baseline.
+      # Checkout and this `docker run` execute on the host runner — JavaScript
+      # actions (checkout) can't run inside an Alpine container on arm64 runners,
+      # so the job has no `container:` and shells into the image here instead.
+      # perl is needed by vendored openssl-sys + pq-src (libpq) to build from source;
+      # --force overwrites the pnpm the image preinstalls (otherwise EEXIST).
+      - name: Build native addon in docker
+        if: matrix.docker != ''
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}:/build" \
+            -w /build/sdks/node \
+            -e CARGO_HTTP_MULTIPLEXING \
+            -e CARGO_NET_RETRY \
+            "${{ matrix.docker }}" \
+            sh -c '
+              set -e
+              if command -v apk >/dev/null; then
+                apk add --no-cache perl build-base
+              else
+                apt-get update && apt-get install -y perl
+              fi
+              npm install -g pnpm@10.33.0 --force
+              pnpm install --frozen-lockfile
+              pnpm run build:native
+            '
 
       - name: Upload binding
         uses: actions/upload-artifact@v7

--- a/.github/workflows/publish-node.yml
+++ b/.github/workflows/publish-node.yml
@@ -115,6 +115,14 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # The postgres feature pulls openssl-sys (vendored), whose Configure runs
+      # perl. Under bash the MSYS perl shadows the runner's Strawberry Perl and
+      # lacks modules OpenSSL needs, so pin openssl-src to Strawberry Perl.
+      - name: Point vendored OpenSSL at Strawberry Perl (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: echo "OPENSSL_SRC_PERL=C:/Strawberry/perl/bin/perl.exe" >> "$GITHUB_ENV"
+
       # macOS / Windows build natively on the runner.
       - name: Set up Rust
         if: matrix.docker == ''
@@ -152,6 +160,8 @@ jobs:
               else
                 apt-get update && apt-get install -y perl
               fi
+              # The image ships an old Rust (1.82); some deps need edition2024.
+              rustup update stable && rustup default stable
               npm install -g pnpm@10.33.0 --force
               pnpm install --frozen-lockfile
               pnpm run build:native

--- a/.github/workflows/publish-node.yml
+++ b/.github/workflows/publish-node.yml
@@ -1,4 +1,4 @@
-name: Publish Node SDK to npm
+name: Publish to npm
 
 # Builds the napi addon as prebuilt per-platform `.node` binaries on native
 # runners (no cross-compilation — the same approach the Python publish.yml uses


### PR DESCRIPTION
First dry-run of `publish-node.yml` (0.16.3) surfaced two build failures:

1. **pnpm EEXIST** — the napi-rs images preinstall pnpm, so `npm install -g pnpm` failed on the gnu + musl-x64 jobs.
2. **aarch64-musl checkout** — `actions/checkout` (a JS action) can't run inside an Alpine container on an arm64 runner ("JavaScript Actions in Alpine containers are only supported on x64 Linux runners").

Fix mirrors the Python `publish.yml` (no job-level `container:`): linux builds now checkout on the host and build **inside** the napi image via `docker run`. `--force` resolves the preinstalled-pnpm collision. All 7 platforms build.

Also renames the workflow `Publish Node SDK to npm` → `Publish to npm` to match `Publish to PyPI`.

Validated via `workflow_dispatch` dry-run on this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the npm publishing workflow for clearer naming and streamlined builds across platforms.
  * Improved Linux CI by supporting both native and containerized builds with appropriate dependency installation.
  * Added a Windows-specific adjustment to ensure the vendored OpenSSL toolchain is handled correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->