### PR TITLE
fix(node): build glibc addons natively, not in cross image

### DIFF
--- a/.github/workflows/publish-node.yml
+++ b/.github/workflows/publish-node.yml
@@ -94,12 +94,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # glibc builds run natively on the host runner: the napi cross image's
+          # old-glibc sysroot (manylinux baseline) #defines strsep as a macro,
+          # which collides with pq-src's libpq-18 headers. 22.04 keeps a low glibc
+          # baseline (2.35). Only musl needs the Alpine container.
           - triple: x86_64-unknown-linux-gnu
-            runner: ubuntu-latest
-            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian
+            runner: ubuntu-22.04
           - triple: aarch64-unknown-linux-gnu
-            runner: ubuntu-24.04-arm
-            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian
+            runner: ubuntu-22.04-arm
           - triple: x86_64-unknown-linux-musl
             runner: ubuntu-latest
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine


### PR DESCRIPTION
## Problem
Second dry-run: musl + macOS built green, but **both glibc (gnu) targets failed** compiling `pq-src` (libpq 18):

```
port.h:463: error: expected identifier or '('
  extern char *strsep(char **stringp, const char *delim);
string2.h:1285: note: expanded from macro 'strsep'
```

The napi `nodejs-rust:lts-debian` image cross-compiles against an **old-glibc napi-cross sysroot** (manylinux baseline) that still `#define`s `strsep` — which collides with libpq-18's `strsep` declaration. musl/macOS don't use that sysroot, so they pass.

## Fix
Build the **gnu** targets natively on host runners (`ubuntu-22.04`, `ubuntu-22.04-arm`) like macOS — host gcc + modern glibc, no cross sysroot. Only **musl** keeps the Alpine container (needs musl libc; builds its C deps natively in-container). `ubuntu-22.04` keeps a low glibc baseline (2.35).

## Research
Standard napi-rs CI advice — `cross` for gnu, `cargo-zigbuild`+zig for musl — targets **pure-Rust** addons. taskito compiles **C from source** (libpq via pq-src, vendored OpenSSL), where cross/zig C-compilation is fragile. Native builds sidestep that entirely, and GitHub's native ARM64 runners make cross-compiling gnu unnecessary. musl still builds its C natively inside the Alpine container.

Sources: [napi-rs #1656 (zig/musl)](https://github.com/napi-rs/napi-rs/issues/1656), [napi-rs/cross-build](https://github.com/napi-rs/cross-build), [napi.rs getting-started](https://napi.rs/docs/introduction/getting-started), [oxc multi-platform build](https://deepwiki.com/oxc-project/oxc/13.1-multi-platform-build-system).

Validated via dry-run on this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure for improved compilation efficiency on Linux systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->