### PR TITLE
chore(deps): upgrade pyo3 to 0.29

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -639,15 +639,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "inventory"
 version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -745,15 +736,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -1062,38 +1044,33 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.22.6"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f402062616ab18202ae8319da13fa4279883a2b8a9d9f83f20dbade813ce1884"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
- "cfg-if",
- "indoc",
  "inventory",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.22.6"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b14b5775b5ff446dd1056212d778012cbe8a0fbffd368029fd9e25b514479c38"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.22.6"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ab5bcf04a2cdcbb50c7d6105de943f543f9ed92af55818fd17b660390fc8636"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1101,9 +1078,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-log"
-version = "0.11.0"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ac84e6eec1159bc2a575c9ae6723baa6ee9d45873e9bebad1e3ad7e8d28a443"
+checksum = "f64083bd3a16a353d9d62335808e8e13d0552d2a2b83fdb084496192dcfa9fcd"
 dependencies = [
  "arc-swap",
  "log",
@@ -1112,9 +1089,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.22.6"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fd24d897903a9e6d80b968368a34e1525aeb719d568dba8b3d4bfa5dc67d453"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1124,13 +1101,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.22.6"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c011a03ba1e50152b4b394b479826cad97e7a21eb52df179cd91ac411cbfbe"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn",
 ]
@@ -1440,9 +1416,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "taskito-core"
@@ -1655,12 +1631,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,6 @@ chrono-tz = "0.10"
 log = "0.4"
 redis = { version = "1.2", features = ["script"] }
 openssl-sys = { version = "0.9", features = ["vendored"] }
-pyo3 = { version = "0.22", features = ["multiple-pymethods"] }
+pyo3 = { version = "0.29", features = ["multiple-pymethods"] }
 async-trait = "0.1"
 dagron-core = { git = "https://github.com/ByteVeda/dagron.git", rev = "d1b61aaf2ed2d516b9a239f089a55b143cb05f65" }

--- a/crates/taskito-python/Cargo.toml
+++ b/crates/taskito-python/Cargo.toml
@@ -31,5 +31,5 @@ serde_json = { workspace = true }
 serde = { workspace = true }
 base64 = "0.22"
 log = { workspace = true }
-pyo3-log = "0.11"
+pyo3-log = "0.13"
 gethostname = "1.1.0"

--- a/crates/taskito-python/src/async_worker.rs
+++ b/crates/taskito-python/src/async_worker.rs
@@ -19,16 +19,16 @@ use crate::py_worker::{
 /// All GIL acquisition happens inside spawn_blocking — never in async context.
 pub struct AsyncWorkerPool {
     num_workers: usize,
-    task_registry: Arc<PyObject>,
-    retry_filters: Arc<PyObject>,
+    task_registry: Arc<Py<PyAny>>,
+    retry_filters: Arc<Py<PyAny>>,
     shutdown: AtomicBool,
 }
 
 impl AsyncWorkerPool {
     pub fn new(
         num_workers: usize,
-        task_registry: Arc<PyObject>,
-        retry_filters: Arc<PyObject>,
+        task_registry: Arc<Py<PyAny>>,
+        retry_filters: Arc<Py<PyAny>>,
     ) -> Self {
         Self {
             num_workers,
@@ -73,7 +73,7 @@ impl WorkerDispatcher for AsyncWorkerPool {
                 let start = std::time::Instant::now();
                 log::info!("[taskito] Task {task_name}[{job_id}] received");
 
-                let result = Python::with_gil(|py| -> PyResult<Option<Vec<u8>>> {
+                let result = Python::attach(|py| -> PyResult<Option<Vec<u8>>> {
                     execute_task(py, &registry, &job)
                 });
 
@@ -93,7 +93,7 @@ impl WorkerDispatcher for AsyncWorkerPool {
                     Err(e) => {
                         // Single GIL acquisition: extract the error info and the
                         // retry decision together instead of taking the GIL twice.
-                        let (error_msg, is_cancelled, should_retry) = Python::with_gil(|py| {
+                        let (error_msg, is_cancelled, should_retry) = Python::attach(|py| {
                             let msg = format_python_error(py, &e);
                             let cancelled = is_cancelled_error(py, &e);
                             let retry = if cancelled {

--- a/crates/taskito-python/src/lib.rs
+++ b/crates/taskito-python/src/lib.rs
@@ -26,7 +26,10 @@ fn _init_rust_logging() {
     let _ = pyo3_log::try_init();
 }
 
-#[pymodule]
+// `gil_used = true`: this extension relies on the GIL for its shared mutable
+// state (scheduler, workflow tracker). Until that state is audited for the
+// free-threaded build, advertise GIL dependence so 3.13t/3.14t fall back safely.
+#[pymodule(gil_used = true)]
 fn _taskito(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(_init_rust_logging, m)?)?;
     m.add_class::<PyQueue>()?;

--- a/crates/taskito-python/src/native_async/pool.rs
+++ b/crates/taskito-python/src/native_async/pool.rs
@@ -17,18 +17,18 @@ use super::task_executor::execute_sync_task;
 /// sync tasks use `spawn_blocking` (bounded by a semaphore).
 pub struct NativeAsyncPool {
     num_workers: usize,
-    task_registry: Arc<PyObject>,
-    retry_filters: Arc<PyObject>,
-    async_executor: Arc<PyObject>,
+    task_registry: Arc<Py<PyAny>>,
+    retry_filters: Arc<Py<PyAny>>,
+    async_executor: Arc<Py<PyAny>>,
     shutdown: AtomicBool,
 }
 
 impl NativeAsyncPool {
     pub fn new(
         num_workers: usize,
-        task_registry: Arc<PyObject>,
-        retry_filters: Arc<PyObject>,
-        async_executor: Arc<PyObject>,
+        task_registry: Arc<Py<PyAny>>,
+        retry_filters: Arc<Py<PyAny>>,
+        async_executor: Arc<Py<PyAny>>,
     ) -> Self {
         Self {
             num_workers,
@@ -54,9 +54,9 @@ impl WorkerDispatcher for NativeAsyncPool {
                 break;
             }
 
-            let is_async = Python::with_gil(|py| {
+            let is_async = Python::attach(|py| {
                 let registry = self.task_registry.bind(py);
-                if let Ok(dict) = registry.downcast::<pyo3::types::PyDict>() {
+                if let Ok(dict) = registry.cast::<pyo3::types::PyDict>() {
                     if let Ok(Some(wrapper)) = dict.get_item(&job.task_name) {
                         return wrapper
                             .getattr("_taskito_is_async")
@@ -70,9 +70,9 @@ impl WorkerDispatcher for NativeAsyncPool {
             if is_async {
                 // Submit to the Python async executor — brief GIL hold, non-blocking
                 let executor = self.async_executor.clone();
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let exec = executor.bind(py);
-                    let payload = PyBytes::new_bound(py, &job.payload);
+                    let payload = PyBytes::new(py, &job.payload);
                     if let Err(e) = exec.call_method1(
                         "submit_job",
                         (

--- a/crates/taskito-python/src/native_async/task_executor.rs
+++ b/crates/taskito-python/src/native_async/task_executor.rs
@@ -11,8 +11,8 @@ use taskito_core::scheduler::JobResult;
 /// wrapper from the registry, serializes the result, and sends a `JobResult`
 /// to the scheduler via `result_tx`.
 pub fn execute_sync_task(
-    task_registry: &PyObject,
-    retry_filters: &PyObject,
+    task_registry: &Py<PyAny>,
+    retry_filters: &Py<PyAny>,
     job: &Job,
     result_tx: &Sender<JobResult>,
 ) {
@@ -25,7 +25,7 @@ pub fn execute_sync_task(
     log::info!("[taskito] Task {task_name}[{job_id}] received");
 
     let result =
-        Python::with_gil(|py| -> PyResult<Option<Vec<u8>>> { run_task(py, task_registry, job) });
+        Python::attach(|py| -> PyResult<Option<Vec<u8>>> { run_task(py, task_registry, job) });
 
     let wall_time_ns: i64 = start.elapsed().as_nanos().try_into().unwrap_or(i64::MAX);
 
@@ -41,7 +41,7 @@ pub fn execute_sync_task(
             }
         }
         Err(e) => {
-            let (error_msg, is_cancelled, exc_class_name) = Python::with_gil(|py| {
+            let (error_msg, is_cancelled, exc_class_name) = Python::attach(|py| {
                 let msg = format_python_error(py, &e);
                 let cancelled = is_cancelled_error(py, &e);
                 let class_name = get_exception_class_name(py, &e);
@@ -55,7 +55,7 @@ pub fn execute_sync_task(
                     wall_time_ns,
                 }
             } else {
-                let should_retry = Python::with_gil(|py| {
+                let should_retry = Python::attach(|py| {
                     check_should_retry(py, retry_filters, &task_name, &exc_class_name, &e)
                 });
 
@@ -79,11 +79,11 @@ pub fn execute_sync_task(
 
 /// Inner task execution: deserialize payload, look up and call the task function,
 /// serialize the return value.
-fn run_task(py: Python<'_>, task_registry: &PyObject, job: &Job) -> PyResult<Option<Vec<u8>>> {
-    let cloudpickle = py.import_bound("cloudpickle")?;
+fn run_task(py: Python<'_>, task_registry: &Py<PyAny>, job: &Job) -> PyResult<Option<Vec<u8>>> {
+    let cloudpickle = py.import("cloudpickle")?;
     let registry = task_registry.bind(py);
 
-    let registry_dict: &Bound<'_, PyDict> = registry.downcast()?;
+    let registry_dict: &Bound<'_, PyDict> = registry.cast()?;
     let task_fn = registry_dict
         .get_item(&job.task_name)?
         .or_else(|| {
@@ -109,7 +109,7 @@ fn run_task(py: Python<'_>, task_registry: &PyObject, job: &Job) -> PyResult<Opt
         })?;
 
     // Set job context before execution
-    let context_mod = py.import_bound("taskito.context")?;
+    let context_mod = py.import("taskito.context")?;
     context_mod.call_method1(
         "_set_context",
         (&job.id, &job.task_name, job.retry_count, &job.queue),
@@ -117,14 +117,14 @@ fn run_task(py: Python<'_>, task_registry: &PyObject, job: &Job) -> PyResult<Opt
 
     let result = (|| -> PyResult<Bound<'_, pyo3::PyAny>> {
         // Deserialize arguments using per-task or queue-level serializer
-        let payload_bytes = PyBytes::new_bound(py, &job.payload);
+        let payload_bytes = PyBytes::new(py, &job.payload);
         let queue_ref = context_mod.getattr("_queue_ref")?;
         let unpickled = if !queue_ref.is_none() {
             queue_ref.call_method1("_deserialize_payload", (&job.task_name, &payload_bytes))?
         } else {
             cloudpickle.call_method1("loads", (&payload_bytes,))?
         };
-        let args_tuple: Bound<'_, PyTuple> = unpickled.downcast_into()?;
+        let args_tuple: Bound<'_, PyTuple> = unpickled.cast_into()?;
 
         if args_tuple.len() != 2 {
             return Err(pyo3::exceptions::PyValueError::new_err(format!(
@@ -137,11 +137,11 @@ fn run_task(py: Python<'_>, task_registry: &PyObject, job: &Job) -> PyResult<Opt
         let kwargs = args_tuple.get_item(1)?;
 
         if kwargs.is_none() {
-            let args_tuple_inner: Bound<'_, PyTuple> = args.downcast_into()?;
+            let args_tuple_inner: Bound<'_, PyTuple> = args.cast_into()?;
             task_fn.call(args_tuple_inner, None)
         } else {
-            let kwargs_dict: Bound<'_, PyDict> = kwargs.downcast_into()?;
-            let args_tuple_inner: Bound<'_, PyTuple> = args.downcast_into()?;
+            let kwargs_dict: Bound<'_, PyDict> = kwargs.cast_into()?;
+            let args_tuple_inner: Bound<'_, PyTuple> = args.cast_into()?;
             task_fn.call(args_tuple_inner, Some(&kwargs_dict))
         }
     })();
@@ -159,14 +159,10 @@ fn run_task(py: Python<'_>, task_registry: &PyObject, job: &Job) -> PyResult<Opt
 }
 
 fn format_python_error(py: Python<'_>, e: &PyErr) -> String {
-    if let Ok(tb_mod) = py.import_bound("traceback") {
+    if let Ok(tb_mod) = py.import("traceback") {
         if let Ok(formatted) = tb_mod.call_method1(
             "format_exception",
-            (
-                e.get_type_bound(py),
-                e.value_bound(py),
-                e.traceback_bound(py),
-            ),
+            (e.get_type(py), e.value(py), e.traceback(py)),
         ) {
             if let Ok(lines) = formatted.extract::<Vec<String>>() {
                 return lines.join("");
@@ -177,19 +173,16 @@ fn format_python_error(py: Python<'_>, e: &PyErr) -> String {
 }
 
 fn is_cancelled_error(py: Python<'_>, e: &PyErr) -> bool {
-    if let Ok(exceptions_mod) = py.import_bound("taskito.exceptions") {
+    if let Ok(exceptions_mod) = py.import("taskito.exceptions") {
         if let Ok(cancelled_cls) = exceptions_mod.getattr("TaskCancelledError") {
-            return e
-                .get_type_bound(py)
-                .is_subclass(&cancelled_cls)
-                .unwrap_or(false);
+            return e.get_type(py).is_subclass(&cancelled_cls).unwrap_or(false);
         }
     }
     false
 }
 
 fn get_exception_class_name(py: Python<'_>, e: &PyErr) -> String {
-    let type_obj = e.get_type_bound(py);
+    let type_obj = e.get_type(py);
     let module = type_obj
         .getattr("__module__")
         .and_then(|m| m.extract::<String>())
@@ -208,13 +201,13 @@ fn get_exception_class_name(py: Python<'_>, e: &PyErr) -> String {
 
 fn check_should_retry(
     py: Python<'_>,
-    retry_filters: &PyObject,
+    retry_filters: &Py<PyAny>,
     task_name: &str,
     _exc_class_name: &str,
     exc: &PyErr,
 ) -> bool {
     let filters = retry_filters.bind(py);
-    let filters_dict: &Bound<'_, PyDict> = match filters.downcast() {
+    let filters_dict: &Bound<'_, PyDict> = match filters.cast() {
         Ok(d) => d,
         Err(_) => return true,
     };
@@ -224,15 +217,15 @@ fn check_should_retry(
         _ => return true,
     };
 
-    let task_dict: &Bound<'_, PyDict> = match task_filters.downcast() {
+    let task_dict: &Bound<'_, PyDict> = match task_filters.cast() {
         Ok(d) => d,
         Err(_) => return true,
     };
 
     if let Ok(Some(dont_retry)) = task_dict.get_item("dont_retry_on") {
-        if let Ok(list) = dont_retry.downcast::<PyList>() {
+        if let Ok(list) = dont_retry.cast::<PyList>() {
             for cls in list.iter() {
-                if exc.get_type_bound(py).is_subclass(&cls).unwrap_or(false) {
+                if exc.get_type(py).is_subclass(&cls).unwrap_or(false) {
                     return false;
                 }
             }
@@ -240,10 +233,10 @@ fn check_should_retry(
     }
 
     if let Ok(Some(retry_on)) = task_dict.get_item("retry_on") {
-        if let Ok(list) = retry_on.downcast::<PyList>() {
+        if let Ok(list) = retry_on.cast::<PyList>() {
             if !list.is_empty() {
                 for cls in list.iter() {
-                    if exc.get_type_bound(py).is_subclass(&cls).unwrap_or(false) {
+                    if exc.get_type(py).is_subclass(&cls).unwrap_or(false) {
                         return true;
                     }
                 }

--- a/crates/taskito-python/src/py_config.rs
+++ b/crates/taskito-python/src/py_config.rs
@@ -1,7 +1,7 @@
 use pyo3::prelude::*;
 
 /// Task configuration exposed to Python.
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Clone)]
 pub struct PyTaskConfig {
     #[pyo3(get, set)]

--- a/crates/taskito-python/src/py_job.rs
+++ b/crates/taskito-python/src/py_job.rs
@@ -3,7 +3,7 @@ use pyo3::prelude::*;
 use taskito_core::job::{Job, JobStatus};
 
 /// Python-visible handle to a queued job.
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Clone)]
 pub struct PyJob {
     #[pyo3(get)]

--- a/crates/taskito-python/src/py_queue/inspection.rs
+++ b/crates/taskito-python/src/py_queue/inspection.rs
@@ -80,7 +80,7 @@ impl PyQueue {
 
     /// List dead letter queue entries.
     #[pyo3(signature = (limit=10, offset=0))]
-    pub fn dead_letters(&self, limit: i64, offset: i64) -> PyResult<Vec<PyObject>> {
+    pub fn dead_letters(&self, limit: i64, offset: i64) -> PyResult<Vec<Py<PyAny>>> {
         if limit < 0 || offset < 0 {
             return Err(pyo3::exceptions::PyValueError::new_err(
                 "limit and offset must be non-negative",
@@ -91,10 +91,10 @@ impl PyQueue {
             .list_dead(limit, offset)
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut result = Vec::with_capacity(dead.len());
             for d in dead {
-                let dict = PyDict::new_bound(py);
+                let dict = PyDict::new(py);
                 dict.set_item("id", d.id)?;
                 dict.set_item("original_job_id", d.original_job_id)?;
                 dict.set_item("queue", d.queue)?;
@@ -133,16 +133,16 @@ impl PyQueue {
     }
 
     /// Get error history for a job.
-    pub fn get_job_errors(&self, job_id: &str) -> PyResult<Vec<PyObject>> {
+    pub fn get_job_errors(&self, job_id: &str) -> PyResult<Vec<Py<PyAny>>> {
         let errors = self
             .storage
             .get_job_errors(job_id)
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut result = Vec::with_capacity(errors.len());
             for err in errors {
-                let dict = PyDict::new_bound(py);
+                let dict = PyDict::new(py);
                 dict.set_item("id", err.id)?;
                 dict.set_item("job_id", err.job_id)?;
                 dict.set_item("attempt", err.attempt)?;
@@ -162,17 +162,17 @@ impl PyQueue {
         &self,
         task_name: Option<&str>,
         since_seconds: i64,
-    ) -> PyResult<Vec<PyObject>> {
+    ) -> PyResult<Vec<Py<PyAny>>> {
         let since_ms = now_millis().saturating_sub(since_seconds.saturating_mul(1000));
         let rows = self
             .storage
             .get_metrics(task_name, since_ms)
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut result = Vec::with_capacity(rows.len());
             for r in rows {
-                let dict = PyDict::new_bound(py);
+                let dict = PyDict::new(py);
                 dict.set_item("id", r.id)?;
                 dict.set_item("task_name", r.task_name)?;
                 dict.set_item("job_id", r.job_id)?;
@@ -233,16 +233,16 @@ impl PyQueue {
     }
 
     /// Get replay history for a job.
-    pub fn get_replay_history(&self, job_id: &str) -> PyResult<Vec<PyObject>> {
+    pub fn get_replay_history(&self, job_id: &str) -> PyResult<Vec<Py<PyAny>>> {
         let rows = self
             .storage
             .get_replay_history(job_id)
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut result = Vec::with_capacity(rows.len());
             for r in rows {
-                let dict = PyDict::new_bound(py);
+                let dict = PyDict::new(py);
                 dict.set_item("id", r.id)?;
                 dict.set_item("original_job_id", r.original_job_id)?;
                 dict.set_item("replay_job_id", r.replay_job_id)?;
@@ -273,16 +273,16 @@ impl PyQueue {
     }
 
     /// Get logs for a specific job.
-    pub fn get_task_logs(&self, job_id: &str) -> PyResult<Vec<PyObject>> {
+    pub fn get_task_logs(&self, job_id: &str) -> PyResult<Vec<Py<PyAny>>> {
         let rows = self
             .storage
             .get_task_logs(job_id)
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut result = Vec::with_capacity(rows.len());
             for r in rows {
-                let dict = PyDict::new_bound(py);
+                let dict = PyDict::new(py);
                 dict.set_item("id", r.id)?;
                 dict.set_item("job_id", r.job_id)?;
                 dict.set_item("task_name", r.task_name)?;
@@ -304,7 +304,7 @@ impl PyQueue {
         level: Option<&str>,
         since_seconds: i64,
         limit: i64,
-    ) -> PyResult<Vec<PyObject>> {
+    ) -> PyResult<Vec<Py<PyAny>>> {
         if limit < 0 {
             return Err(pyo3::exceptions::PyValueError::new_err(
                 "limit must be non-negative",
@@ -316,10 +316,10 @@ impl PyQueue {
             .query_task_logs(task_name, level, since_ms, limit)
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut result = Vec::with_capacity(rows.len());
             for r in rows {
-                let dict = PyDict::new_bound(py);
+                let dict = PyDict::new(py);
                 dict.set_item("id", r.id)?;
                 dict.set_item("job_id", r.job_id)?;
                 dict.set_item("task_name", r.task_name)?;
@@ -336,16 +336,16 @@ impl PyQueue {
     // ── Circuit Breaker API ──────────────────────────────────────
 
     /// List all circuit breaker states.
-    pub fn list_circuit_breakers(&self) -> PyResult<Vec<PyObject>> {
+    pub fn list_circuit_breakers(&self) -> PyResult<Vec<Py<PyAny>>> {
         let rows = self
             .storage
             .list_circuit_breakers()
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut result = Vec::with_capacity(rows.len());
             for r in rows {
-                let dict = PyDict::new_bound(py);
+                let dict = PyDict::new(py);
                 let state_str = match r.state {
                     1 => "open",
                     2 => "half_open",
@@ -368,16 +368,16 @@ impl PyQueue {
     // ── Worker API ───────────────────────────────────────────────
 
     /// List all registered workers.
-    pub fn list_workers(&self) -> PyResult<Vec<PyObject>> {
+    pub fn list_workers(&self) -> PyResult<Vec<Py<PyAny>>> {
         let rows = self
             .storage
             .list_workers()
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut result = Vec::with_capacity(rows.len());
             for r in rows {
-                let dict = PyDict::new_bound(py);
+                let dict = PyDict::new(py);
                 dict.set_item("worker_id", r.worker_id)?;
                 dict.set_item("last_heartbeat", r.last_heartbeat)?;
                 dict.set_item("queues", r.queues)?;
@@ -432,15 +432,15 @@ impl PyQueue {
     }
 
     /// Get info about a lock. Returns dict or None.
-    pub fn get_lock_info(&self, lock_name: &str) -> PyResult<Option<PyObject>> {
+    pub fn get_lock_info(&self, lock_name: &str) -> PyResult<Option<Py<PyAny>>> {
         let info = self
             .storage
             .get_lock_info(lock_name)
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
 
         match info {
-            Some(lock) => Python::with_gil(|py| {
-                let dict = PyDict::new_bound(py);
+            Some(lock) => Python::attach(|py| {
+                let dict = PyDict::new(py);
                 dict.set_item("lock_name", lock.lock_name)?;
                 dict.set_item("owner_id", lock.owner_id)?;
                 dict.set_item("acquired_at", lock.acquired_at)?;

--- a/crates/taskito-python/src/py_queue/mod.rs
+++ b/crates/taskito-python/src/py_queue/mod.rs
@@ -116,7 +116,7 @@ impl PyQueue {
         // `log::*` records from worker threads. With the pyo3-log bridge
         // active, those records need the GIL to deliver to Python — so we
         // must release it here to avoid a deadlock.
-        let storage = py.allow_threads(|| -> PyResult<StorageBackend> {
+        let storage = py.detach(|| -> PyResult<StorageBackend> {
             match backend {
                 "sqlite" => {
                     let s = SqliteStorage::new(db_path)
@@ -479,14 +479,14 @@ impl PyQueue {
     }
 
     /// Get queue statistics.
-    pub fn stats(&self) -> PyResult<PyObject> {
+    pub fn stats(&self) -> PyResult<Py<PyAny>> {
         let stats = self
             .storage
             .stats()
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
 
-        Python::with_gil(|py| {
-            let dict = PyDict::new_bound(py);
+        Python::attach(|py| {
+            let dict = PyDict::new(py);
             dict.set_item("pending", stats.pending)?;
             dict.set_item("running", stats.running)?;
             dict.set_item("completed", stats.completed)?;
@@ -498,14 +498,14 @@ impl PyQueue {
     }
 
     /// Get queue statistics for a specific queue.
-    pub fn stats_by_queue(&self, queue_name: &str) -> PyResult<PyObject> {
+    pub fn stats_by_queue(&self, queue_name: &str) -> PyResult<Py<PyAny>> {
         let stats = self
             .storage
             .stats_by_queue(queue_name)
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
 
-        Python::with_gil(|py| {
-            let dict = PyDict::new_bound(py);
+        Python::attach(|py| {
+            let dict = PyDict::new(py);
             dict.set_item("pending", stats.pending)?;
             dict.set_item("running", stats.running)?;
             dict.set_item("completed", stats.completed)?;
@@ -517,16 +517,16 @@ impl PyQueue {
     }
 
     /// Get queue statistics broken down by queue name.
-    pub fn stats_all_queues(&self) -> PyResult<PyObject> {
+    pub fn stats_all_queues(&self) -> PyResult<Py<PyAny>> {
         let all = self
             .storage
             .stats_all_queues()
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
 
-        Python::with_gil(|py| {
-            let outer = PyDict::new_bound(py);
+        Python::attach(|py| {
+            let outer = PyDict::new(py);
             for (queue, stats) in all {
-                let dict = PyDict::new_bound(py);
+                let dict = PyDict::new(py);
                 dict.set_item("pending", stats.pending)?;
                 dict.set_item("running", stats.running)?;
                 dict.set_item("completed", stats.completed)?;

--- a/crates/taskito-python/src/py_queue/worker.rs
+++ b/crates/taskito-python/src/py_queue/worker.rs
@@ -2,7 +2,8 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use pyo3::prelude::*;
-use pyo3::types::PyDict;
+use pyo3::types::{PyDict, PyTuple};
+use pyo3::BoundObject;
 
 use taskito_core::resilience::circuit_breaker::CircuitBreakerConfig;
 use taskito_core::resilience::rate_limiter::RateLimitConfig;
@@ -80,7 +81,7 @@ async fn run_mesh_bridge(
 /// Called with the GIL held after `handle_result()` returns.
 fn dispatch_outcome(py: Python<'_>, outcome: &ResultOutcome) {
     let result = (|| -> PyResult<()> {
-        let context_mod = py.import_bound("taskito.context")?;
+        let context_mod = py.import("taskito.context")?;
         let queue_ref = context_mod.getattr("_queue_ref")?;
         if queue_ref.is_none() {
             return Ok(());
@@ -96,9 +97,9 @@ fn dispatch_outcome(py: Python<'_>, outcome: &ResultOutcome) {
                 timed_out,
             } => {
                 // Emit JOB_RETRYING event
-                let events_mod = py.import_bound("taskito.events")?;
+                let events_mod = py.import("taskito.events")?;
                 let event_type = events_mod.getattr("EventType")?.getattr("JOB_RETRYING")?;
-                let payload = PyDict::new_bound(py);
+                let payload = PyDict::new(py);
                 payload.set_item("job_id", job_id)?;
                 payload.set_item("task_name", task_name)?;
                 payload.set_item("error", error)?;
@@ -113,8 +114,9 @@ fn dispatch_outcome(py: Python<'_>, outcome: &ResultOutcome) {
 
                 // Call on_retry middleware
                 let ctx = build_lightweight_ctx(py, job_id, task_name, queue)?;
-                let error_obj =
-                    pyo3::exceptions::PyRuntimeError::new_err(error.clone()).into_py(py);
+                let error_obj: Py<PyAny> = pyo3::exceptions::PyRuntimeError::new_err(error.clone())
+                    .into_value(py)
+                    .into_any();
                 call_middleware_hook(
                     py,
                     &queue_ref,
@@ -131,9 +133,9 @@ fn dispatch_outcome(py: Python<'_>, outcome: &ResultOutcome) {
                 timed_out,
             } => {
                 // Emit JOB_DEAD event
-                let events_mod = py.import_bound("taskito.events")?;
+                let events_mod = py.import("taskito.events")?;
                 let event_type = events_mod.getattr("EventType")?.getattr("JOB_DEAD")?;
-                let payload = PyDict::new_bound(py);
+                let payload = PyDict::new(py);
                 payload.set_item("job_id", job_id)?;
                 payload.set_item("task_name", task_name)?;
                 payload.set_item("error", error)?;
@@ -147,8 +149,9 @@ fn dispatch_outcome(py: Python<'_>, outcome: &ResultOutcome) {
 
                 // Call on_dead_letter middleware
                 let ctx = build_lightweight_ctx(py, job_id, task_name, queue)?;
-                let error_obj =
-                    pyo3::exceptions::PyRuntimeError::new_err(error.clone()).into_py(py);
+                let error_obj: Py<PyAny> = pyo3::exceptions::PyRuntimeError::new_err(error.clone())
+                    .into_value(py)
+                    .into_any();
                 call_middleware_hook(
                     py,
                     &queue_ref,
@@ -163,9 +166,9 @@ fn dispatch_outcome(py: Python<'_>, outcome: &ResultOutcome) {
                 queue,
             } => {
                 // Emit JOB_CANCELLED event
-                let events_mod = py.import_bound("taskito.events")?;
+                let events_mod = py.import("taskito.events")?;
                 let event_type = events_mod.getattr("EventType")?.getattr("JOB_CANCELLED")?;
-                let payload = PyDict::new_bound(py);
+                let payload = PyDict::new(py);
                 payload.set_item("job_id", job_id)?;
                 payload.set_item("task_name", task_name)?;
                 queue_ref.call_method1("_emit_event", (event_type, payload))?;
@@ -194,7 +197,7 @@ fn build_lightweight_ctx<'py>(
     task_name: &str,
     queue_name: &str,
 ) -> PyResult<Bound<'py, pyo3::PyAny>> {
-    let types_mod = py.import_bound("types")?;
+    let types_mod = py.import("types")?;
     let ns = types_mod.call_method1("SimpleNamespace", ())?;
     ns.setattr("id", job_id)?;
     ns.setattr("task_name", task_name)?;
@@ -204,20 +207,23 @@ fn build_lightweight_ctx<'py>(
 }
 
 /// Call a middleware hook on all middleware in the chain for a given task.
-fn call_middleware_hook(
-    py: Python<'_>,
-    queue_ref: &Bound<'_, pyo3::PyAny>,
+fn call_middleware_hook<'py, A>(
+    py: Python<'py>,
+    queue_ref: &Bound<'py, pyo3::PyAny>,
     task_name: &str,
     hook_name: &str,
-    args: impl pyo3::IntoPy<pyo3::Py<pyo3::types::PyTuple>>,
-) -> PyResult<()> {
+    args: A,
+) -> PyResult<()>
+where
+    A: IntoPyObject<'py, Target = PyTuple>,
+    A::Error: Into<PyErr>,
+{
     let chain = queue_ref.call_method1("_get_middleware_chain", (task_name,))?;
-    let args_tuple = args.into_py(py);
-    let args_bound = args_tuple.bind(py);
-    for mw in chain.iter()? {
+    let args_tuple = args.into_pyobject(py).map_err(Into::into)?.into_bound();
+    for mw in chain.try_iter()? {
         let mw = mw?;
-        if let Err(e) = mw.call_method(hook_name, args_bound, None) {
-            let logging = py.import_bound("logging")?;
+        if let Err(e) = mw.call_method(hook_name, args_tuple.clone(), None) {
+            let logging = py.import("logging")?;
             let logger = logging.call_method1("getLogger", ("taskito",))?;
             logger.call_method1("warning", (format!("middleware {hook_name}() error: {e}"),))?;
         }
@@ -251,7 +257,7 @@ impl PyQueue {
     pub fn run_worker(
         &self,
         py: Python<'_>,
-        task_registry: PyObject,
+        task_registry: Py<PyAny>,
         task_configs: Vec<PyTaskConfig>,
         queues: Option<Vec<String>>,
         drain_timeout_secs: Option<u64>,
@@ -289,16 +295,16 @@ impl PyQueue {
         );
 
         // Build retry filters dict from the Queue's _task_retry_filters
-        let retry_filters = py.eval_bound("{}", None, None)?;
+        let retry_filters = PyDict::new(py).into_any();
         // Get the Queue's retry filters from the app module
         let app_queue_ref = {
-            let context_mod = py.import_bound("taskito.context")?;
+            let context_mod = py.import("taskito.context")?;
             context_mod.getattr("_queue_ref")?
         };
         if !app_queue_ref.is_none() {
             if let Ok(filters) = app_queue_ref.getattr("_task_retry_filters") {
-                let filters_dict: &Bound<'_, PyDict> = filters.downcast()?;
-                let out_dict: &Bound<'_, PyDict> = retry_filters.downcast()?;
+                let filters_dict: &Bound<'_, PyDict> = filters.cast()?;
+                let out_dict: &Bound<'_, PyDict> = retry_filters.cast()?;
                 for (key, val) in filters_dict.iter() {
                     out_dict.set_item(key, val)?;
                 }
@@ -414,7 +420,7 @@ impl PyQueue {
         let (result_tx, result_rx) = crossbeam_channel::bounded(self.num_workers * 2);
 
         let registry_arc = Arc::new(task_registry);
-        let filters_arc: Arc<PyObject> = Arc::new(retry_filters.into());
+        let filters_arc: Arc<Py<PyAny>> = Arc::new(retry_filters.into());
 
         let scheduler_arc = Arc::new(scheduler);
         let scheduler_for_dispatch = scheduler_arc.clone();
@@ -439,11 +445,11 @@ impl PyQueue {
         #[cfg(feature = "native-async")]
         let async_executor = {
             let sender = crate::native_async::PyResultSender::new(result_tx.clone());
-            Python::with_gil(|py| -> PyResult<Arc<PyObject>> {
+            Python::attach(|py| -> PyResult<Arc<Py<PyAny>>> {
                 let sender_obj = pyo3::Py::new(py, sender)?;
-                let mod_ = py.import_bound("taskito.async_support.executor")?;
+                let mod_ = py.import("taskito.async_support.executor")?;
                 let cls = mod_.getattr("AsyncTaskExecutor")?;
-                let context_mod = py.import_bound("taskito.context")?;
+                let context_mod = py.import("taskito.context")?;
                 let queue_ref = context_mod.getattr("_queue_ref")?;
                 let executor = cls.call1((
                     sender_obj,
@@ -452,7 +458,7 @@ impl PyQueue {
                     async_concurrency,
                 ))?;
                 executor.call_method0("start")?;
-                Ok(Arc::new(executor.into_py(py)))
+                Ok(Arc::new(executor.unbind()))
             })?
         };
 
@@ -463,7 +469,7 @@ impl PyQueue {
         // For in-process pools (native-async, classic async) `notify_cancel` is
         // a no-op — running tasks observe cancellation via the storage flag —
         // so we deliberately do NOT install the dispatcher on `self`.
-        // Installing it would keep an `Arc<PyObject>` reference (the async
+        // Installing it would keep an `Arc<Py<PyAny>>` reference (the async
         // executor / PyResultSender chain) alive on the parent thread until
         // `set_dispatcher(None)` runs after `runtime_handle.join()`, deadlocking
         // shutdown: the drain loop waits for the result channel to disconnect,
@@ -620,7 +626,7 @@ impl PyQueue {
 
         loop {
             // Release GIL for one iteration of result polling
-            let action = py.allow_threads(|| {
+            let action = py.detach(|| {
                 if flag.load(Ordering::SeqCst) {
                     return PollAction::Shutdown;
                 }
@@ -637,12 +643,12 @@ impl PyQueue {
             match action {
                 PollAction::Shutdown => {
                     // Stop the scheduler from dispatching new jobs
-                    py.allow_threads(|| shutdown.notify_one());
+                    py.detach(|| shutdown.notify_one());
 
                     // Drain remaining results with a timeout
                     let drain_start = std::time::Instant::now();
                     while drain_start.elapsed() < drain_timeout {
-                        let drain_action = py.allow_threads(|| {
+                        let drain_action = py.detach(|| {
                             match result_rx.recv_timeout(std::time::Duration::from_millis(100)) {
                                 Ok(result) => PollAction::Result(result),
                                 Err(crossbeam_channel::RecvTimeoutError::Timeout) => {
@@ -659,8 +665,8 @@ impl PyQueue {
 
                         match drain_action {
                             PollAction::Result(result) => {
-                                let outcome = py
-                                    .allow_threads(|| scheduler_for_results.handle_result(result));
+                                let outcome =
+                                    py.detach(|| scheduler_for_results.handle_result(result));
                                 match outcome {
                                     Ok(ref o) => dispatch_outcome(py, o),
                                     Err(e) => {
@@ -676,7 +682,7 @@ impl PyQueue {
                     break;
                 }
                 PollAction::Result(result) => {
-                    let outcome = py.allow_threads(|| scheduler_for_results.handle_result(result));
+                    let outcome = py.detach(|| scheduler_for_results.handle_result(result));
                     match outcome {
                         Ok(ref o) => dispatch_outcome(py, o),
                         Err(e) => log::error!("[taskito] result handling error: {e}"),

--- a/crates/taskito-python/src/py_queue/workflow_ops/fan_out.rs
+++ b/crates/taskito-python/src/py_queue/workflow_ops/fan_out.rs
@@ -60,7 +60,7 @@ impl PyQueue {
         let task_name_owned = task_name.to_string();
         let queue_owned = queue.to_string();
 
-        let result: CoreResult<Vec<String>> = py.allow_threads(|| {
+        let result: CoreResult<Vec<String>> = py.detach(|| {
             let now = now_millis();
             let count = child_names.len() as i32;
 
@@ -153,7 +153,7 @@ impl PyQueue {
         let task_name_owned = task_name.to_string();
         let queue_owned = queue.to_string();
 
-        let result: CoreResult<String> = py.allow_threads(|| {
+        let result: CoreResult<String> = py.detach(|| {
             let now = now_millis();
             let new_job = NewJob {
                 queue: queue_owned,
@@ -196,7 +196,7 @@ impl PyQueue {
         let run_id_owned = run_id.to_string();
         let parent_name_owned = parent_node_name.to_string();
 
-        let result: CoreResult<Option<(bool, Vec<String>)>> = py.allow_threads(|| {
+        let result: CoreResult<Option<(bool, Vec<String>)>> = py.detach(|| {
             let prefix = format!("{parent_name_owned}[");
             let children = wf_storage.get_workflow_nodes_by_prefix(&run_id_owned, &prefix)?;
 
@@ -241,8 +241,8 @@ mod tests {
     /// silent partial expansion.
     #[test]
     fn expand_fan_out_rejects_mismatched_lengths() {
-        pyo3::prepare_freethreaded_python();
-        pyo3::Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|py| {
             let queue = make_test_pyqueue();
             let wf = wf_storage(&queue);
             let run_id = seed_run(wf);
@@ -272,8 +272,8 @@ mod tests {
     /// nothing to wait on. No child jobs are enqueued.
     #[test]
     fn expand_fan_out_completes_parent_immediately_on_empty_children() {
-        pyo3::prepare_freethreaded_python();
-        pyo3::Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|py| {
             let queue = make_test_pyqueue();
             let wf = wf_storage(&queue);
             let run_id = seed_run(wf);
@@ -306,8 +306,8 @@ mod tests {
     /// parent's `fan_out_count`, and returns the child job ids in order.
     #[test]
     fn expand_fan_out_creates_children_and_records_count() {
-        pyo3::prepare_freethreaded_python();
-        pyo3::Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|py| {
             let queue = make_test_pyqueue();
             let wf = wf_storage(&queue);
             let run_id = seed_run(wf);
@@ -353,8 +353,8 @@ mod tests {
     /// `create_deferred_job` enqueues a job and binds it to the named node.
     #[test]
     fn create_deferred_job_enqueues_and_attaches_to_node() {
-        pyo3::prepare_freethreaded_python();
-        pyo3::Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|py| {
             let queue = make_test_pyqueue();
             let wf = wf_storage(&queue);
             let run_id = seed_run(wf);
@@ -391,8 +391,8 @@ mod tests {
     /// non-terminal.
     #[test]
     fn check_fan_out_completion_returns_none_while_children_running() {
-        pyo3::prepare_freethreaded_python();
-        pyo3::Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|py| {
             let queue = make_test_pyqueue();
             let wf = wf_storage(&queue);
             let run_id = seed_run(wf);
@@ -417,8 +417,8 @@ mod tests {
     /// and return `(true, child_job_ids)`.
     #[test]
     fn check_fan_out_completion_finalizes_parent_on_all_success() {
-        pyo3::prepare_freethreaded_python();
-        pyo3::Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|py| {
             let queue = make_test_pyqueue();
             let wf = wf_storage(&queue);
             let run_id = seed_run(wf);
@@ -464,8 +464,8 @@ mod tests {
     /// `(false, child_job_ids)`.
     #[test]
     fn check_fan_out_completion_finalizes_parent_as_failed_on_any_failure() {
-        pyo3::prepare_freethreaded_python();
-        pyo3::Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|py| {
             let queue = make_test_pyqueue();
             let wf = wf_storage(&queue);
             let run_id = seed_run(wf);
@@ -501,8 +501,8 @@ mod tests {
     /// parent on a zero-child set.
     #[test]
     fn check_fan_out_completion_is_noop_when_no_children_exist() {
-        pyo3::prepare_freethreaded_python();
-        pyo3::Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|py| {
             let queue = make_test_pyqueue();
             let wf = wf_storage(&queue);
             let run_id = seed_run(wf);

--- a/crates/taskito-python/src/py_queue/workflow_ops/gates.rs
+++ b/crates/taskito-python/src/py_queue/workflow_ops/gates.rs
@@ -28,7 +28,7 @@ impl PyQueue {
         let run_id_owned = run_id.to_string();
         let node_name_owned = node_name.to_string();
 
-        let result: CoreResult<()> = py.allow_threads(|| {
+        let result: CoreResult<()> = py.detach(|| {
             let now = now_millis();
             if approved {
                 wf_storage.set_workflow_node_completed(

--- a/crates/taskito-python/src/py_queue/workflow_ops/lifecycle.rs
+++ b/crates/taskito-python/src/py_queue/workflow_ops/lifecycle.rs
@@ -248,7 +248,7 @@ impl PyQueue {
         let wf_storage = workflow_storage(self)?;
         let root = run_id.to_string();
 
-        let result: CoreResult<()> = py.allow_threads(|| {
+        let result: CoreResult<()> = py.detach(|| {
             let mut visited: HashSet<String> = HashSet::new();
             let mut stack: Vec<String> = vec![root];
             let now = now_millis();
@@ -302,10 +302,8 @@ impl PyQueue {
     ) -> PyResult<()> {
         let wf = workflow_storage(self)?;
         let rid = run_id.to_string();
-        py.allow_threads(|| {
-            wf.update_workflow_run_state(&rid, WorkflowState::CompletedWithFailures, None)
-        })
-        .map_err(|e| PyRuntimeError::new_err(e.to_string()))
+        py.detach(|| wf.update_workflow_run_state(&rid, WorkflowState::CompletedWithFailures, None))
+            .map_err(|e| PyRuntimeError::new_err(e.to_string()))
     }
 
     /// Check whether all workflow nodes are terminal and finalize the run.
@@ -322,7 +320,7 @@ impl PyQueue {
         let wf_storage = workflow_storage(self)?;
         let run_id_owned = run_id.to_string();
 
-        let result: CoreResult<Option<String>> = py.allow_threads(|| {
+        let result: CoreResult<Option<String>> = py.detach(|| {
             let nodes = wf_storage.get_workflow_nodes(&run_id_owned)?;
             if !nodes.iter().all(|n| n.status.is_terminal()) {
                 return Ok(None);
@@ -363,8 +361,8 @@ mod tests {
     /// `depends_on` chain.
     #[test]
     fn submit_workflow_links_linear_dag_via_depends_on() {
-        pyo3::prepare_freethreaded_python();
-        pyo3::Python::with_gil(|_py| {
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|_py| {
             let queue = make_test_pyqueue();
             let dag = make_dag_bytes(&["a", "b"], &[("a", "b")]);
             let metadata = make_step_metadata_json(&[("a", "task_a"), ("b", "task_b")]);
@@ -398,8 +396,8 @@ mod tests {
     /// downstream successors omit the deferred predecessor from `depends_on`.
     #[test]
     fn submit_workflow_skips_job_creation_for_deferred_nodes() {
-        pyo3::prepare_freethreaded_python();
-        pyo3::Python::with_gil(|_py| {
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|_py| {
             let queue = make_test_pyqueue();
             let dag = make_dag_bytes(&["a", "b"], &[("a", "b")]);
             let metadata = make_step_metadata_json(&[("a", "task_a"), ("b", "task_b")]);
@@ -444,8 +442,8 @@ mod tests {
     /// need a real job id) as cache hits, so the test mirrors that invariant.
     #[test]
     fn submit_workflow_marks_cache_hit_nodes_terminal_without_job() {
-        pyo3::prepare_freethreaded_python();
-        pyo3::Python::with_gil(|_py| {
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|_py| {
             let queue = make_test_pyqueue();
             let dag = make_dag_bytes(&["a"], &[]);
             let metadata = make_step_metadata_json(&[("a", "task_a")]);
@@ -484,8 +482,8 @@ mod tests {
     /// inserting a duplicate row.
     #[test]
     fn submit_workflow_reuses_existing_definition_by_name_and_version() {
-        pyo3::prepare_freethreaded_python();
-        pyo3::Python::with_gil(|_py| {
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|_py| {
             let queue = make_test_pyqueue();
             let dag = make_dag_bytes(&["a"], &[]);
             let metadata = make_step_metadata_json(&[("a", "task_a")]);
@@ -530,8 +528,8 @@ mod tests {
     /// `PyValueError` — callers must supply per-step task config.
     #[test]
     fn submit_workflow_rejects_missing_step_metadata() {
-        pyo3::prepare_freethreaded_python();
-        pyo3::Python::with_gil(|_py| {
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|_py| {
             let queue = make_test_pyqueue();
             let dag = make_dag_bytes(&["a", "b"], &[("a", "b")]);
             // step_metadata only describes 'a' — 'b' is intentionally missing.
@@ -553,8 +551,8 @@ mod tests {
     /// and cancels their underlying jobs.
     #[test]
     fn cancel_workflow_run_cancels_pending_jobs_and_marks_terminal() {
-        pyo3::prepare_freethreaded_python();
-        pyo3::Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|py| {
             let queue = make_test_pyqueue();
             let wf = wf_storage(&queue);
             let run_id = seed_run(wf);
@@ -585,8 +583,8 @@ mod tests {
     /// non-terminal and does not transition the run.
     #[test]
     fn finalize_run_if_terminal_is_noop_when_nodes_pending() {
-        pyo3::prepare_freethreaded_python();
-        pyo3::Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|py| {
             let queue = make_test_pyqueue();
             let wf = wf_storage(&queue);
             let run_id = seed_run(wf);
@@ -604,8 +602,8 @@ mod tests {
     /// All-success terminal nodes promote the run to `Completed`.
     #[test]
     fn finalize_run_if_terminal_promotes_run_to_completed_on_all_success() {
-        pyo3::prepare_freethreaded_python();
-        pyo3::Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|py| {
             let queue = make_test_pyqueue();
             let wf = wf_storage(&queue);
             let run_id = seed_run(wf);
@@ -624,8 +622,8 @@ mod tests {
     /// Any failed terminal node demotes the run to `Failed`.
     #[test]
     fn finalize_run_if_terminal_promotes_run_to_failed_on_any_failure() {
-        pyo3::prepare_freethreaded_python();
-        pyo3::Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|py| {
             let queue = make_test_pyqueue();
             let wf = wf_storage(&queue);
             let run_id = seed_run(wf);
@@ -644,8 +642,8 @@ mod tests {
     /// to `CompletedWithFailures` for `on_failure="continue"` semantics.
     #[test]
     fn set_workflow_run_completed_with_failures_overrides_failed_state() {
-        pyo3::prepare_freethreaded_python();
-        pyo3::Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|py| {
             let queue = make_test_pyqueue();
             let wf = wf_storage(&queue);
             let run_id = seed_run(wf);

--- a/crates/taskito-python/src/py_queue/workflow_ops/mod.rs
+++ b/crates/taskito-python/src/py_queue/workflow_ops/mod.rs
@@ -171,7 +171,7 @@ mod tests {
     #[test]
     fn parse_step_metadata_rejects_invalid_json() {
         // PyValueError construction needs a live Python interpreter.
-        pyo3::prepare_freethreaded_python();
+        pyo3::Python::initialize();
         let err = parse_step_metadata("not-json").unwrap_err();
         assert!(err.to_string().contains("invalid step_metadata JSON"));
     }

--- a/crates/taskito-python/src/py_queue/workflow_ops/nodes.rs
+++ b/crates/taskito-python/src/py_queue/workflow_ops/nodes.rs
@@ -50,7 +50,7 @@ impl PyQueue {
             },
         }
 
-        let outcome: CoreResult<Outcome> = py.allow_threads(|| {
+        let outcome: CoreResult<Outcome> = py.detach(|| {
             let job = match self.storage.get_job(&job_id_owned)? {
                 Some(j) => j,
                 None => return Ok(Outcome::NotFound),
@@ -155,7 +155,7 @@ impl PyQueue {
         let run_id_owned = run_id.to_string();
         let node_name_owned = node_name.to_string();
 
-        py.allow_threads(|| {
+        py.detach(|| {
             wf_storage.update_workflow_node_status(
                 &run_id_owned,
                 &node_name_owned,
@@ -181,7 +181,7 @@ impl PyQueue {
         let run_id_owned = run_id.to_string();
         let node_name_owned = node_name.to_string();
 
-        py.allow_threads(|| {
+        py.detach(|| {
             wf_storage.set_workflow_node_running(&run_id_owned, &node_name_owned, now_millis())
         })
         .map_err(|e| PyRuntimeError::new_err(e.to_string()))
@@ -199,7 +199,7 @@ impl PyQueue {
         let run_id_owned = run_id.to_string();
         let node_name_owned = node_name.to_string();
 
-        py.allow_threads(|| {
+        py.detach(|| {
             wf_storage.set_workflow_node_fan_out_count(&run_id_owned, &node_name_owned, count)
         })
         .map_err(|e| PyRuntimeError::new_err(e.to_string()))
@@ -222,7 +222,7 @@ impl PyQueue {
         let node_name_owned = node_name.to_string();
         let error_owned = error.to_string();
 
-        py.allow_threads(|| {
+        py.detach(|| {
             wf_storage.set_workflow_node_error(&run_id_owned, &node_name_owned, &error_owned)
         })
         .map_err(|e| PyRuntimeError::new_err(e.to_string()))
@@ -243,7 +243,7 @@ impl PyQueue {
         let run_id_owned = run_id.to_string();
         let node_name_owned = node_name.to_string();
 
-        let result: CoreResult<()> = py.allow_threads(|| {
+        let result: CoreResult<()> = py.detach(|| {
             let node = wf_storage.get_workflow_node(&run_id_owned, &node_name_owned)?;
             if let Some(node) = node {
                 if let Some(job_id) = &node.job_id {
@@ -280,8 +280,8 @@ mod tests {
     /// leaves the run unchanged.
     #[test]
     fn mark_workflow_node_result_returns_none_for_non_workflow_job() {
-        pyo3::prepare_freethreaded_python();
-        pyo3::Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|py| {
             let queue = make_test_pyqueue();
             let job_id = enqueue_test_job(&queue.storage, "standalone_task");
 
@@ -295,8 +295,8 @@ mod tests {
     /// Missing job id surfaces as a `PyValueError` rather than a silent no-op.
     #[test]
     fn mark_workflow_node_result_errors_on_unknown_job_id() {
-        pyo3::prepare_freethreaded_python();
-        pyo3::Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|py| {
             let queue = make_test_pyqueue();
             let result =
                 queue.mark_workflow_node_result(py, "no-such-job", true, None, false, None);
@@ -312,8 +312,8 @@ mod tests {
     /// `Completed` and reports the final state back to the caller.
     #[test]
     fn mark_workflow_node_result_finalizes_run_on_last_success() {
-        pyo3::prepare_freethreaded_python();
-        pyo3::Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|py| {
             let queue = make_test_pyqueue();
             let wf = wf_storage(&queue);
             let run_id = seed_run(wf);
@@ -343,8 +343,8 @@ mod tests {
     /// status are skipped and the run finalizes as `Failed`.
     #[test]
     fn mark_workflow_node_result_cascades_failure_to_pending_siblings() {
-        pyo3::prepare_freethreaded_python();
-        pyo3::Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|py| {
             let queue = make_test_pyqueue();
             let wf = wf_storage(&queue);
             let run_id = seed_run(wf);
@@ -391,8 +391,8 @@ mod tests {
     /// alone — the tracker handles the cascade for conditional/continue runs.
     #[test]
     fn mark_workflow_node_result_skips_cascade_when_requested() {
-        pyo3::prepare_freethreaded_python();
-        pyo3::Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|py| {
             let queue = make_test_pyqueue();
             let wf = wf_storage(&queue);
             let run_id = seed_run(wf);
@@ -431,8 +431,8 @@ mod tests {
     /// incremental layer can resolve future cache hits.
     #[test]
     fn mark_workflow_node_result_persists_result_hash_on_success() {
-        pyo3::prepare_freethreaded_python();
-        pyo3::Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|py| {
             let queue = make_test_pyqueue();
             let wf = wf_storage(&queue);
             let run_id = seed_run(wf);
@@ -466,8 +466,8 @@ mod tests {
     /// until externally resolved.
     #[test]
     fn set_workflow_node_waiting_approval_transitions_node() {
-        pyo3::prepare_freethreaded_python();
-        pyo3::Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|py| {
             let queue = make_test_pyqueue();
             let wf = wf_storage(&queue);
             let run_id = seed_run(wf);
@@ -488,8 +488,8 @@ mod tests {
     /// non-null `started_at`.
     #[test]
     fn set_workflow_node_running_stamps_started_at() {
-        pyo3::prepare_freethreaded_python();
-        pyo3::Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|py| {
             let queue = make_test_pyqueue();
             let wf = wf_storage(&queue);
             let run_id = seed_run(wf);
@@ -509,8 +509,8 @@ mod tests {
     /// the parent to `Running`, gating downstream finalization on the count.
     #[test]
     fn set_workflow_node_fan_out_count_records_count_and_promotes() {
-        pyo3::prepare_freethreaded_python();
-        pyo3::Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|py| {
             let queue = make_test_pyqueue();
             let wf = wf_storage(&queue);
             let run_id = seed_run(wf);
@@ -530,8 +530,8 @@ mod tests {
     /// the status to `Failed` without touching siblings.
     #[test]
     fn fail_workflow_node_marks_failed_with_error() {
-        pyo3::prepare_freethreaded_python();
-        pyo3::Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|py| {
             let queue = make_test_pyqueue();
             let wf = wf_storage(&queue);
             let run_id = seed_run(wf);
@@ -556,8 +556,8 @@ mod tests {
     /// node `Skipped`.
     #[test]
     fn skip_workflow_node_cancels_job_and_marks_skipped() {
-        pyo3::prepare_freethreaded_python();
-        pyo3::Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|py| {
             let queue = make_test_pyqueue();
             let wf = wf_storage(&queue);
             let run_id = seed_run(wf);
@@ -585,8 +585,8 @@ mod tests {
     /// tracker may race the storage and we accept that.
     #[test]
     fn skip_workflow_node_is_noop_for_unknown_node() {
-        pyo3::prepare_freethreaded_python();
-        pyo3::Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|py| {
             let queue = make_test_pyqueue();
             let wf = wf_storage(&queue);
             let run_id = seed_run(wf);

--- a/crates/taskito-python/src/py_queue/workflow_ops/queries.rs
+++ b/crates/taskito-python/src/py_queue/workflow_ops/queries.rs
@@ -21,7 +21,7 @@ impl PyQueue {
         let wf_storage = workflow_storage(self)?;
         let run_id_owned = run_id.to_string();
 
-        let result: CoreResult<Option<PyWorkflowRunStatus>> = py.allow_threads(|| {
+        let result: CoreResult<Option<PyWorkflowRunStatus>> = py.detach(|| {
             let run = match wf_storage.get_workflow_run(&run_id_owned)? {
                 Some(r) => r,
                 None => return Ok(None),
@@ -64,7 +64,7 @@ impl PyQueue {
         let wf_storage = workflow_storage(self)?;
         let base_run_id_owned = base_run_id.to_string();
 
-        let result: CoreResult<Vec<(String, String, Option<String>)>> = py.allow_threads(|| {
+        let result: CoreResult<Vec<(String, String, Option<String>)>> = py.detach(|| {
             let nodes = wf_storage.get_workflow_nodes(&base_run_id_owned)?;
             Ok(nodes
                 .into_iter()
@@ -101,7 +101,7 @@ impl PyQueue {
             None => None,
         };
 
-        let result: CoreResult<Vec<PyWorkflowRun>> = py.allow_threads(|| {
+        let result: CoreResult<Vec<PyWorkflowRun>> = py.detach(|| {
             let runs = wf_storage.list_workflow_runs(
                 definition_owned.as_deref(),
                 state_parsed,
@@ -127,16 +127,15 @@ impl PyQueue {
         let wf_storage = workflow_storage(self)?;
         let run_id_owned = run_id.to_string();
 
-        let result: CoreResult<Option<(PyWorkflowRun, Vec<PyWorkflowRunNode>)>> =
-            py.allow_threads(|| {
-                let run = match wf_storage.get_workflow_run(&run_id_owned)? {
-                    Some(r) => r,
-                    None => return Ok(None),
-                };
-                let nodes = wf_storage.get_workflow_nodes(&run_id_owned)?;
-                let node_rows = nodes.into_iter().map(PyWorkflowRunNode::from).collect();
-                Ok(Some((PyWorkflowRun::from(run), node_rows)))
-            });
+        let result: CoreResult<Option<(PyWorkflowRun, Vec<PyWorkflowRunNode>)>> = py.detach(|| {
+            let run = match wf_storage.get_workflow_run(&run_id_owned)? {
+                Some(r) => r,
+                None => return Ok(None),
+            };
+            let nodes = wf_storage.get_workflow_nodes(&run_id_owned)?;
+            let node_rows = nodes.into_iter().map(PyWorkflowRunNode::from).collect();
+            Ok(Some((PyWorkflowRun::from(run), node_rows)))
+        });
 
         result
             .map_err(|e| PyRuntimeError::new_err(e.to_string()))?
@@ -152,7 +151,7 @@ impl PyQueue {
         let wf_storage = workflow_storage(self)?;
         let parent_owned = parent_run_id.to_string();
 
-        let result: CoreResult<Vec<PyWorkflowRun>> = py.allow_threads(|| {
+        let result: CoreResult<Vec<PyWorkflowRun>> = py.detach(|| {
             let runs = wf_storage.get_child_workflow_runs(&parent_owned)?;
             Ok(runs.into_iter().map(PyWorkflowRun::from).collect())
         });
@@ -173,7 +172,7 @@ impl PyQueue {
             Found(Vec<u8>),
         }
 
-        let outcome: CoreResult<Outcome> = py.allow_threads(|| {
+        let outcome: CoreResult<Outcome> = py.detach(|| {
             let run = match wf_storage.get_workflow_run(&run_id_owned)? {
                 Some(r) => r,
                 None => return Ok(Outcome::RunMissing),

--- a/crates/taskito-python/src/py_queue/workflow_ops/saga.rs
+++ b/crates/taskito-python/src/py_queue/workflow_ops/saga.rs
@@ -26,7 +26,7 @@ impl PyQueue {
     pub fn set_workflow_run_compensating(&self, py: Python<'_>, run_id: &str) -> PyResult<()> {
         let wf = workflow_storage(self)?;
         let rid = run_id.to_string();
-        py.allow_threads(|| wf.update_workflow_run_state(&rid, WorkflowState::Compensating, None))
+        py.detach(|| wf.update_workflow_run_state(&rid, WorkflowState::Compensating, None))
             .map_err(|e| PyRuntimeError::new_err(e.to_string()))
     }
 
@@ -39,7 +39,7 @@ impl PyQueue {
     ) -> PyResult<()> {
         let wf = workflow_storage(self)?;
         let rid = run_id.to_string();
-        py.allow_threads(|| {
+        py.detach(|| {
             wf.update_workflow_run_state(&rid, WorkflowState::Compensated, None)?;
             wf.set_workflow_run_completed(&rid, completed_at)?;
             Ok::<_, taskito_core::error::QueueError>(())
@@ -59,7 +59,7 @@ impl PyQueue {
     ) -> PyResult<()> {
         let wf = workflow_storage(self)?;
         let rid = run_id.to_string();
-        py.allow_threads(|| {
+        py.detach(|| {
             wf.update_workflow_run_state(
                 &rid,
                 WorkflowState::CompensationFailed,
@@ -85,7 +85,7 @@ impl PyQueue {
         let rid = run_id.to_string();
         let nn = node_name.to_string();
         let cjid = compensation_job_id.to_string();
-        py.allow_threads(|| wf.set_workflow_node_compensation_job(&rid, &nn, &cjid, started_at))
+        py.detach(|| wf.set_workflow_node_compensation_job(&rid, &nn, &cjid, started_at))
             .map_err(|e| PyRuntimeError::new_err(e.to_string()))
     }
 
@@ -100,7 +100,7 @@ impl PyQueue {
         let wf = workflow_storage(self)?;
         let rid = run_id.to_string();
         let nn = node_name.to_string();
-        py.allow_threads(|| wf.set_workflow_node_compensated(&rid, &nn, completed_at))
+        py.detach(|| wf.set_workflow_node_compensated(&rid, &nn, completed_at))
             .map_err(|e| PyRuntimeError::new_err(e.to_string()))
     }
 
@@ -118,7 +118,7 @@ impl PyQueue {
         let rid = run_id.to_string();
         let nn = node_name.to_string();
         let err = error.to_string();
-        py.allow_threads(|| wf.set_workflow_node_compensation_failed(&rid, &nn, &err, completed_at))
+        py.detach(|| wf.set_workflow_node_compensation_failed(&rid, &nn, &err, completed_at))
             .map_err(|e| PyRuntimeError::new_err(e.to_string()))
     }
 }

--- a/crates/taskito-python/src/py_worker.rs
+++ b/crates/taskito-python/src/py_worker.rs
@@ -22,8 +22,8 @@ impl WorkerPool {
         num_workers: usize,
         job_rx: Receiver<Job>,
         result_tx: Sender<JobResult>,
-        task_registry: Arc<PyObject>,
-        retry_filters: Arc<PyObject>,
+        task_registry: Arc<Py<PyAny>>,
+        retry_filters: Arc<Py<PyAny>>,
     ) -> Self {
         let mut handles = Vec::with_capacity(num_workers);
 
@@ -55,8 +55,8 @@ fn worker_loop(
     _worker_id: usize,
     job_rx: Receiver<Job>,
     result_tx: Sender<JobResult>,
-    task_registry: Arc<PyObject>,
-    retry_filters: Arc<PyObject>,
+    task_registry: Arc<Py<PyAny>>,
+    retry_filters: Arc<Py<PyAny>>,
 ) {
     while let Ok(job) = job_rx.recv() {
         let job_id = job.id.clone();
@@ -67,7 +67,7 @@ fn worker_loop(
         let start = std::time::Instant::now();
         log::info!("[taskito] Task {task_name}[{job_id}] received");
 
-        let result = Python::with_gil(|py| -> PyResult<Option<Vec<u8>>> {
+        let result = Python::attach(|py| -> PyResult<Option<Vec<u8>>> {
             execute_task(py, &task_registry, &job)
         });
 
@@ -87,7 +87,7 @@ fn worker_loop(
             Err(e) => {
                 // Single GIL acquisition: extract the error info and the retry
                 // decision together instead of taking the GIL twice.
-                let (error_msg, is_cancelled, should_retry) = Python::with_gil(|py| {
+                let (error_msg, is_cancelled, should_retry) = Python::attach(|py| {
                     let msg = format_python_error(py, &e);
                     let cancelled = is_cancelled_error(py, &e);
                     let retry = if cancelled {
@@ -129,14 +129,14 @@ fn worker_loop(
 
 pub fn execute_task(
     py: Python<'_>,
-    task_registry: &PyObject,
+    task_registry: &Py<PyAny>,
     job: &Job,
 ) -> PyResult<Option<Vec<u8>>> {
-    let cloudpickle = py.import_bound("cloudpickle")?;
+    let cloudpickle = py.import("cloudpickle")?;
     let registry = task_registry.bind(py);
 
     // Look up the task function
-    let registry_dict: &Bound<'_, PyDict> = registry.downcast()?;
+    let registry_dict: &Bound<'_, PyDict> = registry.cast()?;
     let task_fn = registry_dict
         .get_item(&job.task_name)?
         .or_else(|| {
@@ -163,7 +163,7 @@ pub fn execute_task(
         })?;
 
     // Set job context before execution
-    let context_mod = py.import_bound("taskito.context")?;
+    let context_mod = py.import("taskito.context")?;
     context_mod.call_method1(
         "_set_context",
         (&job.id, &job.task_name, job.retry_count, &job.queue),
@@ -172,14 +172,14 @@ pub fn execute_task(
     // Wrap deserialization + call so _clear_context is always called
     let result = (|| -> PyResult<Bound<'_, pyo3::PyAny>> {
         // Deserialize arguments using per-task or queue-level serializer
-        let payload_bytes = PyBytes::new_bound(py, &job.payload);
+        let payload_bytes = PyBytes::new(py, &job.payload);
         let queue_ref = context_mod.getattr("_queue_ref")?;
         let unpickled = if !queue_ref.is_none() {
             queue_ref.call_method1("_deserialize_payload", (&job.task_name, &payload_bytes))?
         } else {
             cloudpickle.call_method1("loads", (&payload_bytes,))?
         };
-        let args_tuple: Bound<'_, PyTuple> = unpickled.downcast_into()?;
+        let args_tuple: Bound<'_, PyTuple> = unpickled.cast_into()?;
 
         if args_tuple.len() != 2 {
             return Err(pyo3::exceptions::PyValueError::new_err(format!(
@@ -193,11 +193,11 @@ pub fn execute_task(
 
         // Call the task function
         if kwargs.is_none() {
-            let args_tuple_inner: Bound<'_, PyTuple> = args.downcast_into()?;
+            let args_tuple_inner: Bound<'_, PyTuple> = args.cast_into()?;
             task_fn.call(args_tuple_inner, None)
         } else {
-            let kwargs_dict: Bound<'_, PyDict> = kwargs.downcast_into()?;
-            let args_tuple_inner: Bound<'_, PyTuple> = args.downcast_into()?;
+            let kwargs_dict: Bound<'_, PyDict> = kwargs.cast_into()?;
+            let args_tuple_inner: Bound<'_, PyTuple> = args.cast_into()?;
             task_fn.call(args_tuple_inner, Some(&kwargs_dict))
         }
     })();
@@ -219,14 +219,10 @@ pub fn execute_task(
 
 pub fn format_python_error(py: Python<'_>, e: &PyErr) -> String {
     // Try to get a full traceback
-    if let Ok(tb_mod) = py.import_bound("traceback") {
+    if let Ok(tb_mod) = py.import("traceback") {
         if let Ok(formatted) = tb_mod.call_method1(
             "format_exception",
-            (
-                e.get_type_bound(py),
-                e.value_bound(py),
-                e.traceback_bound(py),
-            ),
+            (e.get_type(py), e.value(py), e.traceback(py)),
         ) {
             if let Ok(lines) = formatted.extract::<Vec<String>>() {
                 return lines.join("");
@@ -238,12 +234,9 @@ pub fn format_python_error(py: Python<'_>, e: &PyErr) -> String {
 
 /// Check if the Python exception is a TaskCancelledError.
 pub fn is_cancelled_error(py: Python<'_>, e: &PyErr) -> bool {
-    if let Ok(exceptions_mod) = py.import_bound("taskito.exceptions") {
+    if let Ok(exceptions_mod) = py.import("taskito.exceptions") {
         if let Ok(cancelled_cls) = exceptions_mod.getattr("TaskCancelledError") {
-            return e
-                .get_type_bound(py)
-                .is_subclass(&cancelled_cls)
-                .unwrap_or(false);
+            return e.get_type(py).is_subclass(&cancelled_cls).unwrap_or(false);
         }
     }
     false
@@ -251,7 +244,7 @@ pub fn is_cancelled_error(py: Python<'_>, e: &PyErr) -> bool {
 
 /// Get the fully-qualified class name of a Python exception.
 pub fn get_exception_class_name(py: Python<'_>, e: &PyErr) -> String {
-    let type_obj = e.get_type_bound(py);
+    let type_obj = e.get_type(py);
     let module = type_obj
         .getattr("__module__")
         .and_then(|m| m.extract::<String>())
@@ -272,13 +265,13 @@ pub fn get_exception_class_name(py: Python<'_>, e: &PyErr) -> String {
 /// Returns true by default (retry everything unless filtered).
 pub fn check_should_retry(
     py: Python<'_>,
-    retry_filters: &PyObject,
+    retry_filters: &Py<PyAny>,
     task_name: &str,
     _exc_class_name: &str,
     exc: &PyErr,
 ) -> bool {
     let filters = retry_filters.bind(py);
-    let filters_dict: &Bound<'_, PyDict> = match filters.downcast() {
+    let filters_dict: &Bound<'_, PyDict> = match filters.cast() {
         Ok(d) => d,
         Err(_) => return true,
     };
@@ -288,16 +281,16 @@ pub fn check_should_retry(
         _ => return true, // No filters for this task
     };
 
-    let task_dict: &Bound<'_, PyDict> = match task_filters.downcast() {
+    let task_dict: &Bound<'_, PyDict> = match task_filters.cast() {
         Ok(d) => d,
         Err(_) => return true,
     };
 
     // Check dont_retry_on first
     if let Ok(Some(dont_retry)) = task_dict.get_item("dont_retry_on") {
-        if let Ok(list) = dont_retry.downcast::<PyList>() {
+        if let Ok(list) = dont_retry.cast::<PyList>() {
             for cls in list.iter() {
-                if exc.get_type_bound(py).is_subclass(&cls).unwrap_or(false) {
+                if exc.get_type(py).is_subclass(&cls).unwrap_or(false) {
                     return false;
                 }
             }
@@ -306,10 +299,10 @@ pub fn check_should_retry(
 
     // Check retry_on (if set, only retry for these exceptions)
     if let Ok(Some(retry_on)) = task_dict.get_item("retry_on") {
-        if let Ok(list) = retry_on.downcast::<PyList>() {
+        if let Ok(list) = retry_on.cast::<PyList>() {
             if !list.is_empty() {
                 for cls in list.iter() {
-                    if exc.get_type_bound(py).is_subclass(&cls).unwrap_or(false) {
+                    if exc.get_type(py).is_subclass(&cls).unwrap_or(false) {
                         return true;
                     }
                 }

--- a/crates/taskito-python/src/py_workflow/mod.rs
+++ b/crates/taskito-python/src/py_workflow/mod.rs
@@ -128,7 +128,7 @@ impl PyWorkflowBuilder {
 }
 
 /// Opaque handle returned from `PyQueue::submit_workflow`.
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct PyWorkflowHandle {
     #[pyo3(get)]
@@ -150,7 +150,7 @@ impl PyWorkflowHandle {
 }
 
 /// Snapshot of a workflow run's state and per-node status.
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct PyWorkflowRunStatus {
     #[pyo3(get)]
@@ -172,9 +172,9 @@ impl PyWorkflowRunStatus {
     ///
     /// Each value is a dict with keys `status`, `job_id`, and `error`.
     fn node_statuses<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
-        let out = PyDict::new_bound(py);
+        let out = PyDict::new(py);
         for (name, status, job_id, error) in &self.nodes {
-            let entry = PyDict::new_bound(py);
+            let entry = PyDict::new(py);
             entry.set_item("status", status)?;
             entry.set_item("job_id", job_id.clone())?;
             entry.set_item("error", error.clone())?;
@@ -198,7 +198,7 @@ impl PyWorkflowRunStatus {
 /// Mirrors the core ``WorkflowRun`` struct but uses ``String`` for the
 /// state (so the wire shape stays stable when the enum gets new variants)
 /// and exposes only the fields the dashboard actually renders.
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct PyWorkflowRun {
     #[pyo3(get)]
@@ -251,7 +251,7 @@ impl PyWorkflowRun {
 ///
 /// Includes compensation columns (added in 0.13.0) so the dashboard can show
 /// "this node was compensated at ts, comp job xxx" without an extra query.
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct PyWorkflowRunNode {
     #[pyo3(get)]


### PR DESCRIPTION
## What

Upgrades `pyo3` 0.22 → **0.29.0** and `pyo3-log` 0.11 → **0.13.4**. Only `crates/taskito-python` touches pyo3 (core/workflows/mesh are pyo3-free; node uses napi).

Single compiler-driven jump — every API that was deprecated in 0.25/0.26 is hard-removed in 0.29, so all migration lands in commit 1 (which compiles), with the free-threading declaration in commit 2.

## API migration

- `PyObject` → `Py<PyAny>` (alias removed)
- `into_py` / `IntoPy` → `IntoPyObject`. `call_middleware_hook` rewritten as generic `IntoPyObject<Target = PyTuple>` + `.into_bound()` (`use pyo3::BoundObject`); the tuple is passed by `.clone()` because a `&Bound<PyTuple>` argument triggers an `IntoPyObject` recursion-overflow. `PyErr::into_value(py).into_any()` replaces `err.into_py(py)` for exception objects.
- `*_bound` constructors → drop suffix (`PyDict::new`, `PyBytes::new`, `py.import`, `err.get_type/value/traceback`)
- `Python::with_gil` → `attach`, `Python::allow_threads` → `detach`, `prepare_freethreaded_python()` → `Python::initialize()`
- `.downcast`/`.downcast_into` → `.cast`/`.cast_into`
- `py.eval_bound("{}", ...)` → `PyDict::new(py).into_any()` (`eval` now needs `&CStr`; a dict is cleaner)
- `#[pyclass(from_py_object)]` on the 6 extracted Clone pyclasses (0.28 deprecates auto-derive)
- `#[pymodule(gil_used = true)]` — this extension keeps shared mutable state under the GIL; declaring GIL-dependence lets free-threaded 3.13t/3.14t fall back safely

## Verification

- `cargo fmt --check`, `cargo clippy --workspace --all-features --tests -- -D warnings` clean
- `cargo test --workspace` all pass; lib compiles default + postgres/redis/native-async/workflows/mesh
- `maturin develop` (cp312); pytest **1077 passed, 4 skipped**; ruff + mypy clean
- rustc 1.95 (0.27+ MSRV is 1.74)

## Deferred (separate follow-ups)

- Unpin `sdks/python/.python-version` 3.12 → 3.14 (pyo3 0.29 supports it — the payoff; needs a 3.14-interpreter test pass)
- abi3 adoption (`abi3-py310`) — build-once-run-on-3.10+
- Free-threaded (`gil_used = false`) — only after a shared-state audit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dependencies**
  * Updated pyo3 library from 0.22 to 0.29
  * Updated pyo3-log library from 0.11 to 0.13

* **Chores**
  * Modernized Python integration layer to use latest PyO3 APIs for improved type safety and better Python environment compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->