### PR TITLE
docs: restructure READMEs (root overview + per-SDK)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,25 +26,10 @@ Each SDK is self-contained — see its README for install, quickstart, and the f
 
 ## Architecture
 
-One Rust core, one thin shell per language:
-
-```
-crates/              Rust core (storage, scheduler, worker traits) — no language bindings
-  taskito-core/      Storage trait + backends, scheduler, WorkerDispatcher trait
-  taskito-workflows/ DAG workflow engine (chain/group/chord, gates, saga)
-  taskito-mesh/      Decentralized work-stealing overlay
-  taskito-python/    PyO3 binding shell
-  taskito-node/      napi-rs binding shell
-sdks/                Language SDKs (thin shells over the core)
-  python/            pip install taskito          → PyPI
-  node/              npm install @byteveda/taskito → npm
-dashboard/           React monitoring UI (served by every SDK)
-docs/                Documentation site
-```
-
-The DB is the source of truth; the GIL/event loop is held only during task execution.
-`WorkerDispatcher` in `crates/taskito-core` is binding-free, so new language shells implement
-one trait against [`BINDING_CONTRACT.md`](crates/taskito-core/BINDING_CONTRACT.md).
+One Rust core (`crates/`), one thin SDK shell per language (`sdks/`). The DB is the source of
+truth; the GIL/event loop is held only during task execution. `WorkerDispatcher` in
+`taskito-core` is binding-free, so new language shells implement one trait against
+[`BINDING_CONTRACT.md`](crates/taskito-core/BINDING_CONTRACT.md).
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ Coming from Celery? See the **[Migration Guide](https://docs.byteveda.org/taskit
 
 ## Contributing
 
-Build and test commands live in [`CLAUDE.md`](CLAUDE.md) and each SDK's README. The repo is a
-Cargo workspace (`crates/`) plus per-language SDK packages (`sdks/`); all PRs target `master`.
+The repo is a Cargo workspace (`crates/`) plus per-language SDK packages (`sdks/`). Build and
+test commands live in each SDK's README. All PRs target `master`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -2,201 +2,86 @@
 
 # taskito
 
-A Rust-powered task queue for Python. No broker required — just SQLite or Postgres.
+A Rust-powered task queue with native SDKs. One engine — no broker required, just SQLite, Postgres, or Redis.
 
 [![PyPI version](https://img.shields.io/pypi/v/taskito.svg)](https://pypi.org/project/taskito/)
-[![Python versions](https://img.shields.io/pypi/pyversions/taskito.svg)](https://pypi.org/project/taskito/)
-[![License](https://img.shields.io/pypi/l/taskito.svg)](https://github.com/ByteVeda/taskito/blob/master/LICENSE)
+[![npm version](https://img.shields.io/npm/v/@byteveda/taskito.svg)](https://www.npmjs.com/package/@byteveda/taskito)
+[![License](https://img.shields.io/github/license/ByteVeda/taskito.svg)](https://github.com/ByteVeda/taskito/blob/master/LICENSE)
 
 </div>
 
+Most task queues need a separate broker (Redis, RabbitMQ) even for single-machine workloads.
+taskito embeds storage, scheduling, and worker management into one install with no external
+services. The engine is a single Rust core — a Tokio async scheduler, an OS-thread worker pool,
+and Diesel over SQLite in WAL mode — exposed to each language through a thin native SDK.
+
+## SDKs
+
+| Language | Install | Package | Docs |
+|----------|---------|---------|------|
+| **Python** | `pip install taskito` | [PyPI](https://pypi.org/project/taskito/) · [`sdks/python`](sdks/python) | [Python docs](https://docs.byteveda.org/taskito) |
+| **Node.js** | `npm install @byteveda/taskito` | [npm](https://www.npmjs.com/package/@byteveda/taskito) · [`sdks/node`](sdks/node) | [Node docs](https://docs.byteveda.org/taskito/node) |
+
+Each SDK is self-contained — see its README for install, quickstart, and the full API.
+
+## Architecture
+
+One Rust core, one thin shell per language:
+
 ```
-pip install taskito                # SQLite (default)
-pip install taskito[postgres]      # with Postgres backend
-```
-
-## Quickstart
-
-**1. Define tasks** in `tasks.py`:
-
-```python
-from taskito import Queue
-
-queue = Queue(db_path="tasks.db")
-
-@queue.task()
-def add(a: int, b: int) -> int:
-    return a + b
-```
-
-**2. Start a worker:**
-
-```bash
-taskito worker --app tasks:queue
-```
-
-**3. Enqueue jobs:**
-
-```python
-from tasks import add
-
-job = add.delay(2, 3)
-print(job.result(timeout=10))  # 5
+crates/              Rust core (storage, scheduler, worker traits) — no language bindings
+  taskito-core/      Storage trait + backends, scheduler, WorkerDispatcher trait
+  taskito-workflows/ DAG workflow engine (chain/group/chord, gates, saga)
+  taskito-mesh/      Decentralized work-stealing overlay
+  taskito-python/    PyO3 binding shell
+  taskito-node/      napi-rs binding shell
+sdks/                Language SDKs (thin shells over the core)
+  python/            pip install taskito          → PyPI
+  node/              npm install @byteveda/taskito → npm
+dashboard/           React monitoring UI (served by every SDK)
+docs/                Documentation site
 ```
 
-## Why taskito?
-
-Most Python task queues need a separate broker (Redis, RabbitMQ) even for single-machine
-workloads. taskito embeds storage, scheduling, and worker management into one `pip install`
-with no external services. An optional Postgres backend adds multi-machine workers with the
-same API.
-
-The engine runs in Rust — a Tokio async scheduler, an OS-thread worker pool, and Diesel over
-SQLite in WAL mode. The GIL is held only during task execution; run `--pool prefork` for true
-parallelism on CPU-bound work.
+The DB is the source of truth; the GIL/event loop is held only during task execution.
+`WorkerDispatcher` in `crates/taskito-core` is binding-free, so new language shells implement
+one trait against [`BINDING_CONTRACT.md`](crates/taskito-core/BINDING_CONTRACT.md).
 
 ## Features
 
-Grouped by what you're trying to do — each section has a one-line sample and a
-link to its deep-dive guide. New here? Start with
-**[Capabilities at a glance](https://docs.byteveda.org/taskito/capabilities)**.
-
-### Reliability
-
-Retries with exponential backoff, per-exception retry rules, soft timeouts, a
-dead-letter queue with replay, circuit breakers, and idempotent enqueue.
-
-```python
-@queue.task(max_retries=5, retry_backoff=2.0, retry_on=[TimeoutError])
-def fetch_url(url: str) -> str: ...
-```
-
-[→ Reliability guide](https://docs.byteveda.org/taskito/guides/reliability)
-
-### Workflows
-
-Compose tasks with `chain`, fan out with `group`, fan in with `chord` — plus
-task dependency graphs with cascade cancel.
-
-```python
-chain(fetch.s(url), parse.s(), store.s()).apply()
-```
-
-[→ Workflows guide](https://docs.byteveda.org/taskito/guides/workflows/canvas)
-
-### Concurrency
-
-A thread pool by default (ideal for I/O-bound tasks); switch to a **prefork**
-pool of child processes for true CPU parallelism with no GIL contention.
-
-```bash
-taskito worker --pool prefork --app tasks:queue   # CPU-bound: real parallelism
-```
-
-[→ Execution & prefork guide](https://docs.byteveda.org/taskito/guides/advanced-execution/prefork)
-
-### Scheduling
-
-Priorities, rate limiting, periodic (cron) tasks, delayed execution, and job
-expiration.
-
-```python
-@queue.task(priority=9, rate_limit="100/m")
-def notify(user_id: int) -> None: ...
-```
-
-[→ Scheduling guide](https://docs.byteveda.org/taskito/guides/core/scheduling)
-
-### Observability
-
-A built-in web dashboard, an events system, HMAC-signed webhooks, Prometheus and
-OpenTelemetry exporters, structured logging, and worker heartbeats.
-
-```bash
-taskito dashboard --app tasks:queue   # Flower-style monitoring UI
-```
-
-[→ Dashboard & monitoring guide](https://docs.byteveda.org/taskito/guides/dashboard)
-
-### Extensibility
-
-Pluggable serializers, per-task middleware, a fully async API, and Postgres or
-Redis backends for multi-machine workers.
-
-```python
-@queue.task(middleware=[MyMiddleware()])   # per-task hooks
-def handle(payload: dict) -> None: ...
-```
-
-[→ Extensibility guide](https://docs.byteveda.org/taskito/guides/extensibility)
-
-## Examples
-
-```python
-from taskito import chain, group, chord
-
-# Sequential pipeline — each step receives the previous result
-chain(fetch.s(url), parse.s(), store.s()).apply()
-
-# Parallel fan-out, then a callback once all complete
-chord([download.s(u) for u in urls], merge.s()).apply()
-```
-
-```python
-@queue.task(max_retries=5, retry_backoff=2.0, rate_limit="100/m")
-def fetch_url(url: str) -> str:
-    return requests.get(url).text
-```
-
-More examples — dependencies, progress tracking, middleware, FastAPI — in the
-**[docs](https://docs.byteveda.org/taskito)**.
-
-## Integrations
-
-| Extra | Install | What you get |
-|-------|---------|--------------|
-| **Flask** | `pip install taskito[flask]` | `Taskito(app)` extension, `flask taskito worker` CLI |
-| **FastAPI** | `pip install taskito[fastapi]` | `TaskitoRouter` for instant REST API over the queue |
-| **Django** | `pip install taskito[django]` | Admin integration, management commands |
-| **OpenTelemetry** | `pip install taskito[otel]` | Distributed tracing with span-per-task |
-| **Prometheus** | `pip install taskito[prometheus]` | `PrometheusMiddleware`, queue depth gauges, `/metrics` server |
-| **Sentry** | `pip install taskito[sentry]` | `SentryMiddleware` with auto error capture and task tags |
-| **Postgres** | `pip install taskito[postgres]` | Multi-machine workers via PostgreSQL backend |
-| **Redis** | `pip install taskito[redis]` | Redis storage backend |
-
-## Testing
-
-Built-in test mode — no worker needed:
-
-```python
-def test_add():
-    with queue.test_mode() as results:
-        add.delay(2, 3)
-        assert results[0].return_value == 5
-```
-
-## Documentation
-
-**[Read the docs →](https://docs.byteveda.org/taskito)** — guides, API reference, and architecture.
-Coming from Celery? See the **[Migration Guide](https://docs.byteveda.org/taskito/guides/operations/migration)**.
+- **Reliability** — retries with backoff, per-exception rules, soft timeouts, dead-letter queue with replay, circuit breakers, idempotent enqueue.
+- **Workflows** — chain, fan-out (`group`), fan-in (`chord`), dependency graphs with cascade cancel, approval gates, saga compensation.
+- **Concurrency** — thread pool for I/O, prefork pool for true CPU parallelism with no GIL contention.
+- **Scheduling** — priorities, rate limiting, periodic (cron) tasks, delayed execution, job expiration.
+- **Observability** — built-in web dashboard, events, HMAC-signed webhooks, Prometheus + OpenTelemetry exporters, worker heartbeats.
+- **Backends** — SQLite (default), Postgres or Redis for multi-machine workers; same API.
 
 ## Comparison
 
 | Feature | taskito | Celery | RQ | Dramatiq | Huey |
 |---|---|---|---|---|---|
 | Broker required | **No** | Yes | Yes | Yes | Yes |
-| Core language | **Rust + Python** | Python | Python | Python | Python |
+| Core language | **Rust** | Python | Python | Python | Python |
+| Language SDKs | **Python, Node** | Python | Python | Python | Python |
 | Priority queues | **Yes** | Yes | No | No | Yes |
 | Rate limiting | **Yes** | Yes | No | Yes | No |
 | Dead letter queue | **Yes** | No | Yes | No | No |
 | Task dependencies | **Yes** | No | No | No | No |
 | Workflows (chain/group/chord) | **Yes** | Yes | No | Yes | No |
 | Built-in dashboard | **Yes** | No | No | No | No |
-| FastAPI integration | **Yes** | No | No | No | No |
 | Cancel running tasks | **Yes** | Yes | No | No | No |
 | CPU parallelism (prefork pool) | **Yes** | Yes | Yes | Yes | Yes |
 | Postgres backend | **Yes** | Yes | No | No | No |
-| Setup | **`pip install`** | Broker + backend | Redis | Broker | Redis |
+| Setup | **one install** | Broker + backend | Redis | Broker | Redis |
+
+## Documentation
+
+**[Read the docs →](https://docs.byteveda.org/taskito)** — guides, API reference, and architecture.
+Coming from Celery? See the **[Migration Guide](https://docs.byteveda.org/taskito/guides/operations/migration)**.
+
+## Contributing
+
+Build and test commands live in [`CLAUDE.md`](CLAUDE.md) and each SDK's README. The repo is a
+Cargo workspace (`crates/`) plus per-language SDK packages (`sdks/`); all PRs target `master`.
 
 ## License
 

--- a/sdks/node/README.md
+++ b/sdks/node/README.md
@@ -1,9 +1,15 @@
 # taskito (Node.js)
 
+[![npm version](https://img.shields.io/npm/v/@byteveda/taskito.svg)](https://www.npmjs.com/package/@byteveda/taskito)
+[![License](https://img.shields.io/npm/l/@byteveda/taskito.svg)](https://github.com/ByteVeda/taskito/blob/master/LICENSE)
+
 Rust-powered task queue for Node.js — no broker required. A thin
 [napi-rs](https://napi.rs) shell over the Taskito Rust core, peer to the Python
 SDK. Enqueue work and run workers in the same process or across processes that
 share storage (SQLite, PostgreSQL, or Redis).
+
+Part of the [taskito](https://github.com/ByteVeda/taskito) project (Rust core + native
+SDKs for Python and Node). Full guides at the [Node docs](https://docs.byteveda.org/taskito/node).
 
 ## Install
 

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -1,8 +1,8 @@
 <div align="center">
 
-# taskito
+# taskito (Python)
 
-A Rust-powered task queue for Python. No broker required — just SQLite or Postgres.
+A Rust-powered task queue for Python. No broker required — just SQLite, Postgres, or Redis.
 
 [![PyPI version](https://img.shields.io/pypi/v/taskito.svg)](https://pypi.org/project/taskito/)
 [![Python versions](https://img.shields.io/pypi/pyversions/taskito.svg)](https://pypi.org/project/taskito/)
@@ -14,6 +14,11 @@ A Rust-powered task queue for Python. No broker required — just SQLite or Post
 pip install taskito                # SQLite (default)
 pip install taskito[postgres]      # with Postgres backend
 ```
+
+The engine runs in Rust — a Tokio async scheduler, an OS-thread worker pool, and Diesel over
+SQLite in WAL mode. The GIL is held only during task execution; run `--pool prefork` for true
+parallelism on CPU-bound work. Part of the [taskito](https://github.com/ByteVeda/taskito)
+project (Rust core + native SDKs for Python and Node).
 
 ## Quickstart
 
@@ -44,93 +49,17 @@ job = add.delay(2, 3)
 print(job.result(timeout=10))  # 5
 ```
 
-## Why taskito?
-
-Most Python task queues need a separate broker (Redis, RabbitMQ) even for single-machine
-workloads. taskito embeds storage, scheduling, and worker management into one `pip install`
-with no external services. An optional Postgres backend adds multi-machine workers with the
-same API.
-
-The engine runs in Rust — a Tokio async scheduler, an OS-thread worker pool, and Diesel over
-SQLite in WAL mode. The GIL is held only during task execution; run `--pool prefork` for true
-parallelism on CPU-bound work.
-
 ## Features
 
-Grouped by what you're trying to do — each section has a one-line sample and a
-link to its deep-dive guide. New here? Start with
+Each section links to its deep-dive guide. New here? Start with
 **[Capabilities at a glance](https://docs.byteveda.org/taskito/capabilities)**.
 
-### Reliability
-
-Retries with exponential backoff, per-exception retry rules, soft timeouts, a
-dead-letter queue with replay, circuit breakers, and idempotent enqueue.
-
-```python
-@queue.task(max_retries=5, retry_backoff=2.0, retry_on=[TimeoutError])
-def fetch_url(url: str) -> str: ...
-```
-
-[→ Reliability guide](https://docs.byteveda.org/taskito/guides/reliability)
-
-### Workflows
-
-Compose tasks with `chain`, fan out with `group`, fan in with `chord` — plus
-task dependency graphs with cascade cancel.
-
-```python
-chain(fetch.s(url), parse.s(), store.s()).apply()
-```
-
-[→ Workflows guide](https://docs.byteveda.org/taskito/guides/workflows/canvas)
-
-### Concurrency
-
-A thread pool by default (ideal for I/O-bound tasks); switch to a **prefork**
-pool of child processes for true CPU parallelism with no GIL contention.
-
-```bash
-taskito worker --pool prefork --app tasks:queue   # CPU-bound: real parallelism
-```
-
-[→ Execution & prefork guide](https://docs.byteveda.org/taskito/guides/advanced-execution/prefork)
-
-### Scheduling
-
-Priorities, rate limiting, periodic (cron) tasks, delayed execution, and job
-expiration.
-
-```python
-@queue.task(priority=9, rate_limit="100/m")
-def notify(user_id: int) -> None: ...
-```
-
-[→ Scheduling guide](https://docs.byteveda.org/taskito/guides/core/scheduling)
-
-### Observability
-
-A built-in web dashboard, an events system, HMAC-signed webhooks, Prometheus and
-OpenTelemetry exporters, structured logging, and worker heartbeats.
-
-```bash
-taskito dashboard --app tasks:queue   # Flower-style monitoring UI
-```
-
-[→ Dashboard & monitoring guide](https://docs.byteveda.org/taskito/guides/dashboard)
-
-### Extensibility
-
-Pluggable serializers, per-task middleware, a fully async API, and Postgres or
-Redis backends for multi-machine workers.
-
-```python
-@queue.task(middleware=[MyMiddleware()])   # per-task hooks
-def handle(payload: dict) -> None: ...
-```
-
-[→ Extensibility guide](https://docs.byteveda.org/taskito/guides/extensibility)
-
-## Examples
+- **Reliability** — retries with backoff, per-exception retry rules, soft timeouts, a dead-letter queue with replay, circuit breakers, idempotent enqueue. [→ guide](https://docs.byteveda.org/taskito/guides/reliability)
+- **Workflows** — compose with `chain`, fan out with `group`, fan in with `chord`, plus dependency graphs with cascade cancel. [→ guide](https://docs.byteveda.org/taskito/guides/workflows/canvas)
+- **Concurrency** — thread pool by default (I/O-bound); switch to `--pool prefork` for true CPU parallelism with no GIL contention. [→ guide](https://docs.byteveda.org/taskito/guides/advanced-execution/prefork)
+- **Scheduling** — priorities, rate limiting, periodic (cron) tasks, delayed execution, job expiration. [→ guide](https://docs.byteveda.org/taskito/guides/core/scheduling)
+- **Observability** — built-in web dashboard, events, HMAC-signed webhooks, Prometheus + OpenTelemetry exporters, worker heartbeats. [→ guide](https://docs.byteveda.org/taskito/guides/dashboard)
+- **Extensibility** — pluggable serializers, per-task middleware, a fully async API, Postgres/Redis backends. [→ guide](https://docs.byteveda.org/taskito/guides/extensibility)
 
 ```python
 from taskito import chain, group, chord
@@ -141,15 +70,6 @@ chain(fetch.s(url), parse.s(), store.s()).apply()
 # Parallel fan-out, then a callback once all complete
 chord([download.s(u) for u in urls], merge.s()).apply()
 ```
-
-```python
-@queue.task(max_retries=5, retry_backoff=2.0, rate_limit="100/m")
-def fetch_url(url: str) -> str:
-    return requests.get(url).text
-```
-
-More examples — dependencies, progress tracking, middleware, FastAPI — in the
-**[docs](https://docs.byteveda.org/taskito)**.
 
 ## Integrations
 
@@ -179,24 +99,7 @@ def test_add():
 
 **[Read the docs →](https://docs.byteveda.org/taskito)** — guides, API reference, and architecture.
 Coming from Celery? See the **[Migration Guide](https://docs.byteveda.org/taskito/guides/operations/migration)**.
-
-## Comparison
-
-| Feature | taskito | Celery | RQ | Dramatiq | Huey |
-|---|---|---|---|---|---|
-| Broker required | **No** | Yes | Yes | Yes | Yes |
-| Core language | **Rust + Python** | Python | Python | Python | Python |
-| Priority queues | **Yes** | Yes | No | No | Yes |
-| Rate limiting | **Yes** | Yes | No | Yes | No |
-| Dead letter queue | **Yes** | No | Yes | No | No |
-| Task dependencies | **Yes** | No | No | No | No |
-| Workflows (chain/group/chord) | **Yes** | Yes | No | Yes | No |
-| Built-in dashboard | **Yes** | No | No | No | No |
-| FastAPI integration | **Yes** | No | No | No | No |
-| Cancel running tasks | **Yes** | Yes | No | No | No |
-| CPU parallelism (prefork pool) | **Yes** | Yes | Yes | Yes | Yes |
-| Postgres backend | **Yes** | Yes | No | No | No |
-| Setup | **`pip install`** | Broker + backend | Redis | Broker | Redis |
+For a project overview and the other SDKs, see the [main repository](https://github.com/ByteVeda/taskito).
 
 ## License
 


### PR DESCRIPTION
## What

Splits the duplicated READMEs along the monorepo convention: a root README that introduces the **project** and links out, and per-SDK READMEs that are **self-contained, registry-facing** pages.

Before, `README.md` and `sdks/python/README.md` were near-identical (203 lines each, one trivial line of difference) — the root was just a copy of the Python SDK page.

## Changes

- **`README.md`** (203 → 88 lines) — repo overview: pitch, an SDK picker table (Python → PyPI, Node → npm), the architecture layout (Rust core + thin shells), language-agnostic feature list, the comparison table, and docs links. No Python-specific quickstart.
- **`sdks/python/README.md`** (203 → 106 lines) — PyPI shopfront: install, quickstart, feature highlights with guide links, integrations, test mode, docs link. This is the `readme` published to PyPI (`pyproject.toml`), so it stays self-contained. Dropped the project-level comparison table (now lives in the root).
- **`sdks/node/README.md`** — added npm + license badges and a backlink to the main repo / Node docs, for parity with the Python SDK page. (This is the README published to npm.)

## Rationale

Per monorepo documentation convention ([graphite](https://graphite.com/guides/managing-multiple-languages-in-a-monorepo), [monorepo.tools](https://monorepo.tools/)): root README = repository overview + organization guidance + links; per-package README = registry-facing, self-contained, language-specific. PyPI and npm render the SDK READMEs directly, so those stay complete rather than stubs.

No code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reworked the main README to highlight a Rust-powered, brokerless core with native SDKs and embedded storage/scheduling/worker management
  * Added **SDKs** and **Architecture** sections, and streamlined the **Features** section into a concise capability overview
  * Updated the comparison framing to match the new Rust-core positioning and removed outdated Python-first tutorial content
  * Revised the Python SDK documentation to reflect support for **SQLite (default), Postgres, and Redis**
  * Added npm version and license badges to the Node.js SDK README
<!-- end of auto-generated comment: release notes by coderabbit.ai -->