### PR TITLE
chore(release): 0.16.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,4 @@
----
-title: Changelog
-description: "Release history for taskito — every notable change, fix, and feature."
----
-
-{/* AUTO-GENERATED from /CHANGELOG.md by scripts/sync-changelog.mjs — do not edit directly. */}
+# Changelog
 
 All notable changes to taskito are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the project follows
@@ -788,4 +783,3 @@ Re-release of 0.2.0 — PyPI does not allow re-uploads of deleted versions.
 - cloudpickle serialization for arguments and results
 
 </details>
-

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1422,7 +1422,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "taskito-core"
-version = "0.16.3"
+version = "0.16.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1446,7 +1446,7 @@ dependencies = [
 
 [[package]]
 name = "taskito-mesh"
-version = "0.16.3"
+version = "0.16.4"
 dependencies = [
  "base64",
  "bincode",
@@ -1461,7 +1461,7 @@ dependencies = [
 
 [[package]]
 name = "taskito-node"
-version = "0.16.3"
+version = "0.16.4"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
@@ -1480,7 +1480,7 @@ dependencies = [
 
 [[package]]
 name = "taskito-python"
-version = "0.16.3"
+version = "0.16.4"
 dependencies = [
  "async-trait",
  "base64",
@@ -1500,7 +1500,7 @@ dependencies = [
 
 [[package]]
 name = "taskito-workflows"
-version = "0.16.3"
+version = "0.16.4"
 dependencies = [
  "dagron-core",
  "diesel",

--- a/crates/taskito-core/Cargo.toml
+++ b/crates/taskito-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-core"
-version = "0.16.3"
+version = "0.16.4"
 edition = "2021"
 
 [features]

--- a/crates/taskito-mesh/Cargo.toml
+++ b/crates/taskito-mesh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-mesh"
-version = "0.16.3"
+version = "0.16.4"
 edition = "2021"
 
 [dependencies]

--- a/crates/taskito-node/Cargo.toml
+++ b/crates/taskito-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-node"
-version = "0.16.3"
+version = "0.16.4"
 edition = "2021"
 description = "Node.js (napi-rs) bindings for the Taskito task-queue core"
 license = "MIT"

--- a/crates/taskito-python/Cargo.toml
+++ b/crates/taskito-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-python"
-version = "0.16.3"
+version = "0.16.4"
 edition = "2021"
 
 [features]

--- a/crates/taskito-workflows/Cargo.toml
+++ b/crates/taskito-workflows/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-workflows"
-version = "0.16.3"
+version = "0.16.4"
 edition = "2021"
 
 [features]

--- a/docs/package.json
+++ b/docs/package.json
@@ -4,8 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "react-router build",
-    "dev": "react-router dev",
+    "sync:changelog": "node ../scripts/sync-changelog.mjs",
+    "build": "pnpm sync:changelog && react-router build",
+    "dev": "pnpm sync:changelog && react-router dev",
     "start": "serve build/client",
     "typecheck": "react-router typegen && tsc --noEmit",
     "lint": "biome check",

--- a/scripts/sync-changelog.mjs
+++ b/scripts/sync-changelog.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+// Generate the docs changelog page from the canonical root CHANGELOG.md.
+//
+// CHANGELOG.md (Keep a Changelog) is the single source of truth — edit it there.
+// This script wraps its body in the frontmatter the docs site needs and writes
+// docs/content/docs/resources/changelog.mdx. Run automatically before `docs` dev/build.
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = new URL("../", import.meta.url);
+const source = fileURLToPath(new URL("CHANGELOG.md", repoRoot));
+const target = fileURLToPath(
+  new URL("docs/content/docs/resources/changelog.mdx", repoRoot),
+);
+
+// Drop the top-level "# Changelog" heading — the frontmatter title renders it.
+const body = readFileSync(source, "utf8").replace(/^#\s+Changelog\s*\n/, "").trimStart();
+
+const frontmatter = [
+  "---",
+  "title: Changelog",
+  'description: "Release history for taskito — every notable change, fix, and feature."',
+  "---",
+  "",
+  "{/* AUTO-GENERATED from /CHANGELOG.md by scripts/sync-changelog.mjs — do not edit directly. */}",
+  "",
+].join("\n");
+
+writeFileSync(target, `${frontmatter}\n${body}\n`);
+console.log(`synced ${target} from CHANGELOG.md`);

--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byteveda/taskito",
-  "version": "0.16.3",
+  "version": "0.16.4",
   "description": "Rust-powered task queue for Node.js — no broker required.",
   "license": "MIT",
   "type": "module",

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "taskito"
-version = "0.16.3"
+version = "0.16.4"
 description = "Rust-powered task queue for Python. No broker required."
 requires-python = ">=3.10"
 license = { file = "LICENSE" }

--- a/sdks/python/taskito/__init__.py
+++ b/sdks/python/taskito/__init__.py
@@ -122,4 +122,4 @@ try:
 
     __version__ = _get_version("taskito")
 except PackageNotFoundError:
-    __version__ = "0.16.3"
+    __version__ = "0.16.4"


### PR DESCRIPTION
Release 0.16.4 (lock-step across all SDKs + crates).

## Version bumps (0.16.3 → 0.16.4)

5 crates (`taskito-core`, `taskito-python`, `taskito-workflows`, `taskito-mesh`, `taskito-node`), `sdks/python/pyproject.toml`, `sdks/python/taskito/__init__.py`, `sdks/node/package.json`.

## Changelog

Adds a canonical root `CHANGELOG.md` (Keep a Changelog). The docs changelog page is now **generated** from it by `scripts/sync-changelog.mjs` (run automatically before `docs` dev/build) — single source of truth, no double-entry. Previous per-version history was migrated in; `<SdkLink>` components were converted to plain doc links so the file renders correctly on GitHub, PyPI, and npm too.

## 0.16.4 contents

- **PyO3 0.29** — binding layer upgraded 0.22 → 0.29 (+ `pyo3-log` 0.13). Internal; no Python API change. Groundwork for Python 3.14 / free-threaded.
- **Node default SQLite settings** (#292).
- **Docs** — README restructure + root CHANGELOG.

## Publishing (after merge, from master)

- **PyPI** (Python): tag `0.16.4` → `publish.yml`.
- **npm** (`@byteveda/taskito`): tag `node-v0.16.4` → `publish-node.yml` (separate tag namespace).

Both also runnable via `workflow_dispatch` (version input + dry-run).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive CHANGELOG documenting release history from 0.16.4 through 0.1.0 with detailed per-version sections and categorized changes
  * Updated documentation to include changelog content with improved link formatting

* **Chores**
  * Bumped version to 0.16.4 across core, mesh, node, Python SDK, Node SDK, and workflows packages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->