### PR TITLE
feat(python): support Python 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,14 +277,14 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         include:
           - os: macos-latest
-            python-version: "3.13"
+            python-version: "3.14"
           - os: macos-latest
             python-version: "3.10"
           - os: windows-2025
-            python-version: "3.13"
+            python-version: "3.14"
           - os: windows-2025
             python-version: "3.10"
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,9 +279,9 @@ jobs:
         os: [ubuntu-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         include:
-          - os: macos-latest
+          - os: macos-15
             python-version: "3.14"
-          - os: macos-latest
+          - os: macos-15
             python-version: "3.10"
           - os: windows-2025
             python-version: "3.14"

--- a/.github/workflows/publish-node.yml
+++ b/.github/workflows/publish-node.yml
@@ -113,7 +113,7 @@ jobs:
           - triple: x86_64-apple-darwin
             runner: macos-15-intel
           - triple: aarch64-apple-darwin
-            runner: macos-latest
+            runner: macos-15
           - triple: x86_64-pc-windows-msvc
             runner: windows-latest
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -105,7 +105,7 @@ jobs:
         uses: PyO3/maturin-action@v1.51.0
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --features extension-module,postgres,redis,native-async,workflows --interpreter 3.10 3.11 3.12 3.13
+          args: --release --out dist --features extension-module,postgres,redis,native-async,workflows --interpreter 3.10 3.11 3.12 3.13 3.14
           manylinux: 2_28
           maturin-version: v1.13.3
           working-directory: sdks/python
@@ -139,7 +139,7 @@ jobs:
         uses: PyO3/maturin-action@v1.51.0
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --features extension-module,postgres,redis,native-async,workflows --interpreter 3.10 3.11 3.12 3.13
+          args: --release --out dist --features extension-module,postgres,redis,native-async,workflows --interpreter 3.10 3.11 3.12 3.13 3.14
           manylinux: musllinux_1_2
           maturin-version: v1.13.3
           working-directory: sdks/python
@@ -187,11 +187,16 @@ jobs:
         with:
           python-version: "3.13"
 
+      - name: Set up Python 3.14
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+
       - name: Build wheels
         uses: PyO3/maturin-action@v1.51.0
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --features extension-module,postgres,redis,native-async,workflows --interpreter 3.10 3.11 3.12 3.13
+          args: --release --out dist --features extension-module,postgres,redis,native-async,workflows --interpreter 3.10 3.11 3.12 3.13 3.14
           maturin-version: v1.13.3
           working-directory: sdks/python
 
@@ -235,11 +240,16 @@ jobs:
         with:
           python-version: "3.13"
 
+      - name: Set up Python 3.14
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+
       - name: Build wheels
         uses: PyO3/maturin-action@v1.51.0
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --features extension-module,postgres,redis,native-async,workflows --interpreter 3.10 3.11 3.12 3.13
+          args: --release --out dist --features extension-module,postgres,redis,native-async,workflows --interpreter 3.10 3.11 3.12 3.13 3.14
           maturin-version: v1.13.3
           working-directory: sdks/python
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -155,7 +155,7 @@ jobs:
 
   build-wheels-macos:
     needs: build-dashboard
-    runs-on: macos-latest
+    runs-on: macos-15
     strategy:
       fail-fast: false
       matrix:

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Rust",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: System :: Distributed Computing",


### PR DESCRIPTION
Adds Python 3.14 to the build, test, and publish matrices. pyo3 0.29 (shipped in 0.16.4) supports 3.14.

## Verified locally on CPython 3.14.2

- `maturin develop` builds the `cp314` extension against pyo3 0.29 — clean.
- **763 taskito tests pass** on 3.14: core (314) + worker/workflows/resources/python/autoscale/observability (449). The single failure, `test_prometheus_middleware_has_resource_metrics`, is pre-existing on master (missing `_init_metrics`), unrelated to 3.14.
- Integration/dashboard suites not run locally — they pull third-party libs (flask/django/joserfc/boto3); their 3.14 readiness is the dependency's concern, not taskito's Rust↔Python ABI.

## Changes

- `publish.yml` — `--interpreter … 3.14` on all four wheel jobs (linux, musllinux, macOS, windows) + `Set up Python 3.14` steps for the macOS/Windows jobs.
- `ci.yml` — `3.14` added to the ubuntu test matrix; macOS/Windows newest bumped 3.13 → 3.14.
- `pyproject.toml` — `Programming Language :: Python :: 3.14` classifier (the PyPI pyversions badge picks this up on next publish).

Lands after 0.16.4 → first published in 0.16.5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Python 3.14 to the supported test matrix on Linux, macOS, and Windows.
  * Release artifacts now include wheels built for Python 3.14 (alongside 3.10–3.13).
* **Chores**
  * Updated the project’s metadata to advertise Python 3.14 support.
  * Updated CI build runners to newer macOS environments for release builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->