### PR TITLE
fix(docs): migration guide link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ truth; the GIL/event loop is held only during task execution. `WorkerDispatcher`
 ## Documentation
 
 **[Read the docs →](https://docs.byteveda.org/taskito)** — guides, API reference, and architecture.
-Coming from Celery? See the **[Migration Guide](https://docs.byteveda.org/taskito/guides/operations/migration)**.
+Coming from Celery? See the **[Migration Guide](https://docs.byteveda.org/taskito/python/guides/operations/migration)**.
 
 ## Contributing
 


### PR DESCRIPTION
Updated the link to the Migration Guide in the README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Celery migration guide link in the README to point to the new Python guide location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->