### PR TITLE
feat(java): native loader, locks + periodic, Maven Central, Java 11 build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,24 +118,24 @@ jobs:
 
       - name: Generic crates stay binding-free
         # The engine crates (core/workflows/mesh) must remain binding-agnostic so
-        # the Python and Node shells can both reuse them. A pyo3 OR napi dep would
-        # let binding-specific code creep back in. cargo tree is authoritative —
-        # you cannot `use pyo3`/`use napi` without depending on it.
-        # See crates/taskito-core/BINDING_CONTRACT.md.
+        # the Python, Node, and Java shells can all reuse them. A pyo3, napi, OR
+        # jni dep would let binding-specific code creep back in. cargo tree is
+        # authoritative — you cannot `use pyo3`/`use napi`/`use jni` without
+        # depending on it. See crates/taskito-core/BINDING_CONTRACT.md.
         run: |
           set -euo pipefail
           for crate in taskito-core taskito-workflows taskito-mesh; do
             # Capture first so a `cargo tree` failure aborts (set -e) instead of
             # being swallowed by the pipe and silently passing the check.
             tree_output="$(cargo tree -p "$crate" -e normal --all-features)"
-            for binding in pyo3 napi; do
+            for binding in pyo3 napi jni; do
               if grep -qi "$binding" <<<"$tree_output"; then
                 echo "::error::$binding is in the dependency tree of $crate — generic crates must stay binding-agnostic"
                 exit 1
               fi
             done
           done
-          echo "Generic crates are free of pyo3 and napi."
+          echo "Generic crates are free of pyo3, napi, and jni."
 
       - name: Lint Python with Ruff
         working-directory: sdks/python

--- a/.github/workflows/publish-java.yml
+++ b/.github/workflows/publish-java.yml
@@ -1,0 +1,185 @@
+name: Publish to Maven Central
+
+# Builds the JNI cdylib as prebuilt per-platform binaries on native runners (no
+# cross-compilation — same approach as the Python wheels and Node addons), bundles
+# them all into one fat JAR, and publishes to Maven Central via the Central
+# Publisher Portal (OSSRH shut down 2025-06-30). Signing + upload are handled by
+# the vanniktech maven-publish plugin.
+
+on:
+  push:
+    tags:
+      # Java releases use a `java-v` tag namespace, distinct from Python (`v*`)
+      # and Node (`node-v*`).
+      - "java-v[0-9]*.[0-9]*.[0-9]*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (e.g. 0.16.4)"
+        required: true
+        type: string
+      dry-run:
+        description: "Build and assemble only — skip publish and tagging"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+env:
+  CARGO_HTTP_MULTIPLEXING: "false"
+  CARGO_NET_RETRY: "10"
+
+jobs:
+  preflight:
+    name: Preflight checks
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Resolve and verify version
+        id: resolve
+        env:
+          VERSION_INPUT: ${{ inputs.version }}
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            version="${GITHUB_REF_NAME#java-v}"
+          else
+            version="${VERSION_INPUT#v}"
+          fi
+          if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid version format: ${version}"
+            exit 1
+          fi
+          gradle_ver=$(grep -oP '^version = "\K[^"]+' sdks/java/build.gradle.kts)
+          if [ "$gradle_ver" != "$version" ]; then
+            echo "::error::Resolved ${version} != sdks/java/build.gradle.kts ${gradle_ver}"
+            exit 1
+          fi
+          printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Build ${{ matrix.classifier }}
+    needs: preflight
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - classifier: linux-x86_64
+            runner: ubuntu-22.04
+            libname: libtaskito_java.so
+          - classifier: linux-aarch64
+            runner: ubuntu-22.04-arm
+            libname: libtaskito_java.so
+          - classifier: osx-x86_64
+            runner: macos-15-intel
+            libname: libtaskito_java.dylib
+          - classifier: osx-aarch64
+            runner: macos-15
+            libname: libtaskito_java.dylib
+          - classifier: windows-x86_64
+            runner: windows-latest
+            libname: taskito_java.dll
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Point vendored OpenSSL at Strawberry Perl (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: echo "OPENSSL_SRC_PERL=C:/Strawberry/perl/bin/perl.exe" >> "$GITHUB_ENV"
+
+      - name: Set up Rust
+        uses: ./.github/actions/setup-rust
+
+      - name: Build cdylib
+        run: cargo build -p taskito-java --release --features postgres,redis
+
+      - name: Stage native binary under its classifier
+        shell: bash
+        run: |
+          dest="native/org/byteveda/taskito/native/${{ matrix.classifier }}"
+          mkdir -p "$dest"
+          cp "target/release/${{ matrix.libname }}" "$dest/"
+
+      - name: Upload native binary
+        uses: actions/upload-artifact@v7
+        with:
+          name: native-${{ matrix.classifier }}
+          path: native/**
+          if-no-files-found: error
+
+  publish:
+    name: Publish to Maven Central
+    needs: [preflight, build]
+    runs-on: ubuntu-latest
+    environment: maven-central
+    permissions:
+      contents: write # tag + release
+    env:
+      VERSION: ${{ needs.preflight.outputs.version }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Build dashboard SPA
+        uses: ./.github/actions/dashboard-build
+        with:
+          out-dir: ../sdks/java/src/main/resources/org/byteveda/taskito/dashboard
+
+      - name: Download all native binaries
+        uses: actions/download-artifact@v8
+        with:
+          pattern: native-*
+          path: artifacts
+          merge-multiple: true
+
+      - name: Place natives in resources
+        run: cp -r artifacts/org sdks/java/src/main/resources/
+
+      # The cargo/copyNative tasks build only the host platform; skip them since
+      # every platform's binary is already staged in resources from the matrix.
+      - name: Publish (or assemble on dry-run)
+        working-directory: sdks/java
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_KEY_PASSWORD }}
+        run: |
+          if [ "${{ inputs.dry-run }}" = "true" ]; then
+            ./gradlew jar -x cargoBuild -x copyNative --no-daemon
+          else
+            ./gradlew publishToMavenCentral -x cargoBuild -x copyNative --no-daemon
+          fi
+
+      - name: Create git tag
+        if: github.event_name != 'push' && !inputs.dry-run
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git tag "java-v${VERSION}"
+          git -c http.https://github.com/.extraheader="AUTHORIZATION: bearer ${GH_TOKEN}" \
+            push origin "java-v${VERSION}"
+
+      - name: Create GitHub release
+        if: ${{ !inputs.dry-run }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "java-v${VERSION}" >/dev/null 2>&1; then
+            echo "::notice::Release java-v${VERSION} already exists — skipping"
+          else
+            gh release create "java-v${VERSION}" \
+              --title "taskito (Java) v${VERSION}" \
+              --generate-notes
+          fi

--- a/.github/workflows/publish-java.yml
+++ b/.github/workflows/publish-java.yml
@@ -148,19 +148,21 @@ jobs:
 
       # The cargo/copyNative tasks build only the host platform; skip them since
       # every platform's binary is already staged in resources from the matrix.
-      - name: Publish (or assemble on dry-run)
+      # Dry-run only assembles the JAR — keep publishing secrets out of it.
+      - name: Assemble JAR (dry-run)
+        if: inputs.dry-run
+        working-directory: sdks/java
+        run: ./gradlew jar -x cargoBuild -x copyNative --no-daemon
+
+      - name: Publish to Maven Central
+        if: ${{ !inputs.dry-run }}
         working-directory: sdks/java
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_KEY_PASSWORD }}
-        run: |
-          if [ "${{ inputs.dry-run }}" = "true" ]; then
-            ./gradlew jar -x cargoBuild -x copyNative --no-daemon
-          else
-            ./gradlew publishToMavenCentral -x cargoBuild -x copyNative --no-daemon
-          fi
+        run: ./gradlew publishToMavenCentral -x cargoBuild -x copyNative --no-daemon
 
       - name: Create git tag
         if: github.event_name != 'push' && !inputs.dry-run

--- a/crates/taskito-java/src/convert.rs
+++ b/crates/taskito-java/src/convert.rs
@@ -5,7 +5,9 @@
 
 use serde::{Deserialize, Serialize};
 use taskito_core::job::{now_millis, Job, NewJob};
-use taskito_core::storage::models::{JobErrorRow, TaskLogRow, TaskMetricRow, WorkerRow};
+use taskito_core::storage::models::{
+    JobErrorRow, LockInfoRow, TaskLogRow, TaskMetricRow, WorkerRow,
+};
 use taskito_core::storage::{DeadJob, QueueStats};
 
 use crate::error::BindingError;
@@ -318,6 +320,27 @@ impl<'a> From<&'a TaskLogRow> for LogView<'a> {
             message: &l.message,
             extra: l.extra.as_deref(),
             logged_at: l.logged_at,
+        }
+    }
+}
+
+/// Current holder of a distributed lock.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LockInfoView<'a> {
+    pub lock_name: &'a str,
+    pub owner_id: &'a str,
+    pub acquired_at: i64,
+    pub expires_at: i64,
+}
+
+impl<'a> From<&'a LockInfoRow> for LockInfoView<'a> {
+    fn from(l: &'a LockInfoRow) -> Self {
+        Self {
+            lock_name: &l.lock_name,
+            owner_id: &l.owner_id,
+            acquired_at: l.acquired_at,
+            expires_at: l.expires_at,
         }
     }
 }

--- a/crates/taskito-java/src/queue/locks.rs
+++ b/crates/taskito-java/src/queue/locks.rs
@@ -1,0 +1,95 @@
+//! Distributed-lock entry points for `NativeQueue`. Locks are advisory,
+//! TTL-bounded, and owner-scoped; the worker maintenance loop reaps expired ones.
+
+use jni::objects::{JClass, JString};
+use jni::sys::{jboolean, jlong, jstring, JNI_FALSE};
+use jni::JNIEnv;
+use taskito_core::Storage;
+
+use super::{borrow_queue, to_jboolean};
+use crate::convert::{to_json, LockInfoView};
+use crate::error::BindingError;
+use crate::ffi::{guard, new_string, read_string};
+
+fn positive_ttl(ttl_ms: jlong) -> Result<i64, BindingError> {
+    if ttl_ms <= 0 {
+        Err(BindingError::new(format!(
+            "ttlMs must be > 0 (got {ttl_ms})"
+        )))
+    } else {
+        Ok(ttl_ms)
+    }
+}
+
+/// `boolean acquireLock(long handle, String name, String ownerId, long ttlMs)`.
+#[no_mangle]
+pub extern "system" fn Java_org_byteveda_taskito_internal_NativeQueue_acquireLock<'local>(
+    mut env: JNIEnv<'local>,
+    _class: JClass<'local>,
+    handle: jlong,
+    name: JString<'local>,
+    owner_id: JString<'local>,
+    ttl_ms: jlong,
+) -> jboolean {
+    guard(&mut env, JNI_FALSE, |env| {
+        let queue = unsafe { borrow_queue(handle) };
+        let name = read_string(env, &name)?;
+        let owner = read_string(env, &owner_id)?;
+        let ttl = positive_ttl(ttl_ms)?;
+        Ok(to_jboolean(queue.storage.acquire_lock(&name, &owner, ttl)?))
+    })
+}
+
+/// `boolean releaseLock(long handle, String name, String ownerId)`.
+#[no_mangle]
+pub extern "system" fn Java_org_byteveda_taskito_internal_NativeQueue_releaseLock<'local>(
+    mut env: JNIEnv<'local>,
+    _class: JClass<'local>,
+    handle: jlong,
+    name: JString<'local>,
+    owner_id: JString<'local>,
+) -> jboolean {
+    guard(&mut env, JNI_FALSE, |env| {
+        let queue = unsafe { borrow_queue(handle) };
+        let name = read_string(env, &name)?;
+        let owner = read_string(env, &owner_id)?;
+        Ok(to_jboolean(queue.storage.release_lock(&name, &owner)?))
+    })
+}
+
+/// `boolean extendLock(long handle, String name, String ownerId, long ttlMs)`.
+#[no_mangle]
+pub extern "system" fn Java_org_byteveda_taskito_internal_NativeQueue_extendLock<'local>(
+    mut env: JNIEnv<'local>,
+    _class: JClass<'local>,
+    handle: jlong,
+    name: JString<'local>,
+    owner_id: JString<'local>,
+    ttl_ms: jlong,
+) -> jboolean {
+    guard(&mut env, JNI_FALSE, |env| {
+        let queue = unsafe { borrow_queue(handle) };
+        let name = read_string(env, &name)?;
+        let owner = read_string(env, &owner_id)?;
+        let ttl = positive_ttl(ttl_ms)?;
+        Ok(to_jboolean(queue.storage.extend_lock(&name, &owner, ttl)?))
+    })
+}
+
+/// `String getLockInfo(long handle, String name)` — JSON holder info, or `null`.
+#[no_mangle]
+pub extern "system" fn Java_org_byteveda_taskito_internal_NativeQueue_getLockInfo<'local>(
+    mut env: JNIEnv<'local>,
+    _class: JClass<'local>,
+    handle: jlong,
+    name: JString<'local>,
+) -> jstring {
+    guard(&mut env, std::ptr::null_mut(), |env| {
+        let queue = unsafe { borrow_queue(handle) };
+        let name = read_string(env, &name)?;
+        match queue.storage.get_lock_info(&name)? {
+            Some(info) => new_string(env, to_json(&LockInfoView::from(&info))?),
+            None => Ok(std::ptr::null_mut()),
+        }
+    })
+}

--- a/crates/taskito-java/src/queue/mod.rs
+++ b/crates/taskito-java/src/queue/mod.rs
@@ -8,7 +8,9 @@
 
 mod admin;
 mod inspect;
+mod locks;
 mod logs;
+mod periodic;
 
 use jni::objects::{JByteArray, JClass, JObjectArray, JString};
 use jni::sys::{jboolean, jbyteArray, jint, jlong, jobjectArray, jstring, JNI_FALSE, JNI_TRUE};

--- a/crates/taskito-java/src/queue/periodic.rs
+++ b/crates/taskito-java/src/queue/periodic.rs
@@ -1,0 +1,66 @@
+//! Periodic (cron) task registration. The worker maintenance loop enqueues due
+//! tasks; this binds only registration. Re-registering a name replaces it.
+
+use jni::objects::{JByteArray, JClass, JString};
+use jni::sys::{jboolean, jlong};
+use jni::JNIEnv;
+use taskito_core::job::now_millis;
+use taskito_core::periodic::{next_cron_time, next_cron_time_tz};
+use taskito_core::storage::models::NewPeriodicTaskRow;
+use taskito_core::Storage;
+
+use super::borrow_queue;
+use crate::ffi::{guard, read_bytes, read_optional_string, read_string};
+
+const DEFAULT_QUEUE: &str = "default";
+
+/// `long registerPeriodic(long handle, String name, String taskName, String cron,
+/// byte[] args, String queue, String timezone, boolean enabled)` — register (or
+/// replace) a cron task. Returns the next fire time (Unix ms). Rejects bad cron.
+#[no_mangle]
+pub extern "system" fn Java_org_byteveda_taskito_internal_NativeQueue_registerPeriodic<'local>(
+    mut env: JNIEnv<'local>,
+    _class: JClass<'local>,
+    handle: jlong,
+    name: JString<'local>,
+    task_name: JString<'local>,
+    cron_expr: JString<'local>,
+    args: JByteArray<'local>,
+    queue_name: JString<'local>,
+    timezone: JString<'local>,
+    enabled: jboolean,
+) -> jlong {
+    guard(&mut env, 0, |env| {
+        let queue = unsafe { borrow_queue(handle) };
+        let name = read_string(env, &name)?;
+        let task = read_string(env, &task_name)?;
+        let cron = read_string(env, &cron_expr)?;
+        let args_bytes = if args.is_null() {
+            None
+        } else {
+            Some(read_bytes(env, &args)?)
+        };
+        let queue_name = read_optional_string(env, &queue_name)?;
+        let timezone = read_optional_string(env, &timezone)?;
+
+        let now = now_millis();
+        let next_run = match timezone.as_deref() {
+            Some(tz) => next_cron_time_tz(&cron, now, tz)?,
+            None => next_cron_time(&cron, now)?,
+        };
+
+        let row = NewPeriodicTaskRow {
+            name: &name,
+            task_name: &task,
+            cron_expr: &cron,
+            args: args_bytes.as_deref(),
+            kwargs: None,
+            queue: queue_name.as_deref().unwrap_or(DEFAULT_QUEUE),
+            enabled: enabled != 0,
+            next_run,
+            timezone: timezone.as_deref(),
+        };
+        queue.storage.register_periodic(&row)?;
+        Ok(next_run)
+    })
+}

--- a/sdks/java/.gitignore
+++ b/sdks/java/.gitignore
@@ -1,2 +1,3 @@
 .gradle/
 build/
+bin/

--- a/sdks/java/build.gradle.kts
+++ b/sdks/java/build.gradle.kts
@@ -1,22 +1,54 @@
+import com.vanniktech.maven.publish.SonatypeHost
+
 plugins {
     `java-library`
     checkstyle
     id("com.diffplug.spotless") version "6.25.0"
+    id("com.vanniktech.maven.publish") version "0.30.0"
 }
 
 group = "org.byteveda"
 version = "0.16.4"
 
 java {
+    // Sources + javadoc jars are added by the maven-publish plugin below.
     toolchain {
         languageVersion.set(JavaLanguageVersion.of(11))
     }
-    withSourcesJar()
-    withJavadocJar()
 }
 
 repositories {
     mavenCentral()
+}
+
+// --- Publishing: Maven Central via the Central Publisher Portal ------------
+
+mavenPublishing {
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+    signAllPublications()
+    coordinates(group.toString(), "taskito", version.toString())
+    pom {
+        name.set("Taskito")
+        description.set("Rust-powered task queue for the JVM, via a JNI binding over the Taskito core.")
+        url.set("https://github.com/ByteVeda/taskito")
+        licenses {
+            license {
+                name.set("MIT")
+                url.set("https://opensource.org/licenses/MIT")
+            }
+        }
+        developers {
+            developer {
+                id.set("byteveda")
+                name.set("ByteVeda")
+            }
+        }
+        scm {
+            url.set("https://github.com/ByteVeda/taskito")
+            connection.set("scm:git:https://github.com/ByteVeda/taskito.git")
+            developerConnection.set("scm:git:ssh://git@github.com/ByteVeda/taskito.git")
+        }
+    }
 }
 
 // --- Code integrity: formatting + static analysis -------------------------

--- a/sdks/java/build.gradle.kts
+++ b/sdks/java/build.gradle.kts
@@ -12,9 +12,14 @@ version = "0.16.4"
 
 java {
     // Sources + javadoc jars are added by the maven-publish plugin below.
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(11))
-    }
+    // Compile to Java 11 bytecode with whatever JDK (>= 11) runs Gradle, rather
+    // than pinning a toolchain — `--release 11` also rejects post-11 stdlib APIs.
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    options.release.set(11)
 }
 
 repositories {

--- a/sdks/java/build.gradle.kts
+++ b/sdks/java/build.gradle.kts
@@ -110,6 +110,10 @@ val copyNative by tasks.registering(Copy::class) {
 
 sourceSets["main"].resources.srcDir(nativeStaging)
 tasks.named("processResources") { dependsOn(copyNative) }
+// The sources jar (added by the publish plugin) also packages the main
+// resource srcDirs, so any Jar task reads the staged native dir. Wire the
+// dependency lazily — sourcesJar is registered after this script evaluates.
+tasks.withType<Jar>().configureEach { dependsOn(copyNative) }
 
 tasks.test {
     useJUnitPlatform()

--- a/sdks/java/src/main/java/org/byteveda/taskito/DefaultQueue.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/DefaultQueue.java
@@ -230,6 +230,34 @@ final class DefaultQueue implements Queue {
     }
 
     @Override
+    public Lock lock(String name, long ttlMs) {
+        return new Lock(backend, name, ttlMs);
+    }
+
+    @Override
+    public boolean withLock(String name, long ttlMs, Runnable body) {
+        try (Lock lock = new Lock(backend, name, ttlMs)) {
+            if (!lock.acquire()) {
+                return false;
+            }
+            body.run();
+            return true;
+        }
+    }
+
+    @Override
+    public Optional<LockInfo> lockInfo(String name) {
+        return backend.lockInfoJson(name).map(json -> decode(json, LockInfo.class));
+    }
+
+    @Override
+    public long registerPeriodic(PeriodicTask task) {
+        byte[] payload = task.payload == null ? null : serializer.serialize(task.payload);
+        return backend.registerPeriodic(
+                task.name, task.taskName, task.cron, payload, task.queue, task.timezone, task.enabled);
+    }
+
+    @Override
     public Worker.Builder worker() {
         return Worker.builder(backend, serializer, middleware);
     }

--- a/sdks/java/src/main/java/org/byteveda/taskito/EnqueueOptions.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/EnqueueOptions.java
@@ -6,14 +6,29 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 /** Immutable per-enqueue options. Unset fields take core defaults. */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public final class EnqueueOptions {
-    @JsonProperty("queue") private final String queue;
-    @JsonProperty("priority") private final Integer priority;
-    @JsonProperty("maxRetries") private final Integer maxRetries;
-    @JsonProperty("timeoutMs") private final Long timeoutMs;
-    @JsonProperty("delayMs") private final Long delayMs;
-    @JsonProperty("uniqueKey") private final String uniqueKey;
-    @JsonProperty("metadata") private final String metadata;
-    @JsonProperty("namespace") private final String namespace;
+    @JsonProperty("queue")
+    private final String queue;
+
+    @JsonProperty("priority")
+    private final Integer priority;
+
+    @JsonProperty("maxRetries")
+    private final Integer maxRetries;
+
+    @JsonProperty("timeoutMs")
+    private final Long timeoutMs;
+
+    @JsonProperty("delayMs")
+    private final Long delayMs;
+
+    @JsonProperty("uniqueKey")
+    private final String uniqueKey;
+
+    @JsonProperty("metadata")
+    private final String metadata;
+
+    @JsonProperty("namespace")
+    private final String namespace;
 
     private EnqueueOptions(Builder b) {
         this.queue = b.queue;

--- a/sdks/java/src/main/java/org/byteveda/taskito/JobFilter.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/JobFilter.java
@@ -6,11 +6,20 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 /** Immutable filter for {@link Queue#listJobs(JobFilter)}. Unset fields are ignored. */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public final class JobFilter {
-    @JsonProperty("status") private final String status;
-    @JsonProperty("queue") private final String queue;
-    @JsonProperty("task") private final String task;
-    @JsonProperty("limit") private final Integer limit;
-    @JsonProperty("offset") private final Integer offset;
+    @JsonProperty("status")
+    private final String status;
+
+    @JsonProperty("queue")
+    private final String queue;
+
+    @JsonProperty("task")
+    private final String task;
+
+    @JsonProperty("limit")
+    private final Integer limit;
+
+    @JsonProperty("offset")
+    private final Integer offset;
 
     private JobFilter(Builder b) {
         this.status = b.status;

--- a/sdks/java/src/main/java/org/byteveda/taskito/Lock.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/Lock.java
@@ -27,9 +27,11 @@ public final class Lock implements AutoCloseable {
         return held;
     }
 
-    /** Extend the TTL if still held; false otherwise. */
+    /** Extend the TTL if still held; false otherwise. A failed extend means the
+     * lock was lost (expired or stolen), so {@link #isHeld()} flips to false. */
     public boolean extend(long ttlMs) {
-        return backend.extendLock(name, ownerId, ttlMs);
+        held = backend.extendLock(name, ownerId, ttlMs);
+        return held;
     }
 
     public boolean isHeld() {

--- a/sdks/java/src/main/java/org/byteveda/taskito/Lock.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/Lock.java
@@ -1,0 +1,50 @@
+package org.byteveda.taskito;
+
+import java.util.UUID;
+import org.byteveda.taskito.spi.QueueBackend;
+
+/**
+ * A distributed, TTL-bounded advisory lock. Owner-scoped to a per-instance id, so
+ * only this {@code Lock} can release or extend what it acquired. {@link #close()}
+ * releases it (use try-with-resources).
+ */
+public final class Lock implements AutoCloseable {
+    private final QueueBackend backend;
+    private final String name;
+    private final String ownerId = UUID.randomUUID().toString();
+    private final long ttlMs;
+    private boolean held;
+
+    Lock(QueueBackend backend, String name, long ttlMs) {
+        this.backend = backend;
+        this.name = name;
+        this.ttlMs = ttlMs;
+    }
+
+    /** Try to acquire; false if another owner holds a live lock. */
+    public boolean acquire() {
+        held = backend.acquireLock(name, ownerId, ttlMs);
+        return held;
+    }
+
+    /** Extend the TTL if still held; false otherwise. */
+    public boolean extend(long ttlMs) {
+        return backend.extendLock(name, ownerId, ttlMs);
+    }
+
+    public boolean isHeld() {
+        return held;
+    }
+
+    public void release() {
+        if (held) {
+            backend.releaseLock(name, ownerId);
+            held = false;
+        }
+    }
+
+    @Override
+    public void close() {
+        release();
+    }
+}

--- a/sdks/java/src/main/java/org/byteveda/taskito/LockInfo.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/LockInfo.java
@@ -1,0 +1,26 @@
+package org.byteveda.taskito;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/** Current holder of a distributed lock. Timestamps are Unix milliseconds. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class LockInfo {
+    public final String lockName;
+    public final String ownerId;
+    public final long acquiredAt;
+    public final long expiresAt;
+
+    @JsonCreator
+    public LockInfo(
+            @JsonProperty("lockName") String lockName,
+            @JsonProperty("ownerId") String ownerId,
+            @JsonProperty("acquiredAt") long acquiredAt,
+            @JsonProperty("expiresAt") long expiresAt) {
+        this.lockName = lockName;
+        this.ownerId = ownerId;
+        this.acquiredAt = acquiredAt;
+        this.expiresAt = expiresAt;
+    }
+}

--- a/sdks/java/src/main/java/org/byteveda/taskito/PeriodicTask.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/PeriodicTask.java
@@ -1,0 +1,66 @@
+package org.byteveda.taskito;
+
+/** A cron-scheduled task registration. The worker enqueues it when due. */
+public final class PeriodicTask {
+    final String name;
+    final String taskName;
+    final String cron;
+    final Object payload;
+    final String queue;
+    final String timezone;
+    final boolean enabled;
+
+    private PeriodicTask(Builder b) {
+        this.name = b.name;
+        this.taskName = b.taskName;
+        this.cron = b.cron;
+        this.payload = b.payload;
+        this.queue = b.queue;
+        this.timezone = b.timezone;
+        this.enabled = b.enabled;
+    }
+
+    public static Builder builder(String name, String taskName, String cron) {
+        return new Builder(name, taskName, cron);
+    }
+
+    public static final class Builder {
+        private final String name;
+        private final String taskName;
+        private final String cron;
+        private Object payload;
+        private String queue;
+        private String timezone;
+        private boolean enabled = true;
+
+        Builder(String name, String taskName, String cron) {
+            this.name = name;
+            this.taskName = taskName;
+            this.cron = cron;
+        }
+
+        public Builder payload(Object payload) {
+            this.payload = payload;
+            return this;
+        }
+
+        public Builder queue(String queue) {
+            this.queue = queue;
+            return this;
+        }
+
+        public Builder timezone(String timezone) {
+            this.timezone = timezone;
+            return this;
+        }
+
+        public Builder enabled(boolean enabled) {
+            this.enabled = enabled;
+            return this;
+        }
+
+        public PeriodicTask build() {
+            return new PeriodicTask(this);
+        }
+    }
+}

--- a/sdks/java/src/main/java/org/byteveda/taskito/Queue.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/Queue.java
@@ -93,6 +93,21 @@ public interface Queue extends AutoCloseable {
 
     List<TaskLog> getTaskLogs(String jobId);
 
+    // ── Locks ───────────────────────────────────────────────────────
+
+    /** A distributed lock {@code name} with the given TTL; call {@link Lock#acquire()}. */
+    Lock lock(String name, long ttlMs);
+
+    /** Acquire {@code name}, run {@code body} if obtained, then release; returns whether it ran. */
+    boolean withLock(String name, long ttlMs, Runnable body);
+
+    Optional<LockInfo> lockInfo(String name);
+
+    // ── Periodic ────────────────────────────────────────────────────
+
+    /** Register (or replace) a cron task; returns the next fire time (Unix ms). */
+    long registerPeriodic(PeriodicTask task);
+
     // ── Worker ──────────────────────────────────────────────────────
 
     /** Begin building a worker over this queue. */

--- a/sdks/java/src/main/java/org/byteveda/taskito/Worker.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/Worker.java
@@ -88,8 +88,7 @@ public final class Worker implements AutoCloseable {
         private final Serializer serializer;
         private final List<Middleware> middleware;
         private final Map<String, RegisteredTask> handlers = new HashMap<>();
-        private final Map<EventName, List<Consumer<OutcomeEvent>>> listeners =
-                new EnumMap<>(EventName.class);
+        private final Map<EventName, List<Consumer<OutcomeEvent>>> listeners = new EnumMap<>(EventName.class);
         private List<String> queues;
         private int concurrency;
         private Integer channelCapacity;
@@ -137,13 +136,11 @@ public final class Worker implements AutoCloseable {
         }
 
         public Worker start() {
-            ExecutorService executor = concurrency > 0
-                    ? Executors.newFixedThreadPool(concurrency)
-                    : Executors.newCachedThreadPool();
+            ExecutorService executor =
+                    concurrency > 0 ? Executors.newFixedThreadPool(concurrency) : Executors.newCachedThreadPool();
             Emitter emitter = new Emitter();
             listeners.forEach((name, bound) -> bound.forEach(listener -> emitter.on(name, listener)));
-            WorkerDispatchBridge bridge =
-                    new WorkerDispatchBridge(handlers, serializer, executor, emitter, middleware);
+            WorkerDispatchBridge bridge = new WorkerDispatchBridge(handlers, serializer, executor, emitter, middleware);
             WorkerControl control = backend.startWorker(bridge, encodeOptions());
             bridge.bind(control);
             return new Worker(control, executor);

--- a/sdks/java/src/main/java/org/byteveda/taskito/dashboard/DashboardServer.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/dashboard/DashboardServer.java
@@ -63,8 +63,7 @@ public final class DashboardServer implements AutoCloseable {
     }
 
     /** Start on {@code port} (0 = ephemeral). {@code token}/{@code staticDir} may be null. */
-    public static DashboardServer start(Queue queue, int port, String token, String staticDir)
-            throws IOException {
+    public static DashboardServer start(Queue queue, int port, String token, String staticDir) throws IOException {
         HttpServer server = HttpServer.create(new InetSocketAddress(port), 0);
         Path dir = staticDir == null ? null : Paths.get(staticDir).normalize();
         DashboardServer dashboard = new DashboardServer(server, queue, token, dir);
@@ -119,8 +118,7 @@ public final class DashboardServer implements AutoCloseable {
         respond(exchange, 404, error("not found"));
     }
 
-    private boolean handleGet(HttpExchange exchange, String path, Map<String, String> query)
-            throws IOException {
+    private boolean handleGet(HttpExchange exchange, String path, Map<String, String> query) throws IOException {
         switch (path) {
             case "/api/stats":
                 respond(exchange, 200, Contract.stats(queue.stats()));

--- a/sdks/java/src/main/java/org/byteveda/taskito/events/OutcomeEvent.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/events/OutcomeEvent.java
@@ -9,8 +9,7 @@ public final class OutcomeEvent {
     public final int retryCount;
     public final boolean timedOut;
 
-    public OutcomeEvent(
-            EventName name, String jobId, String taskName, String error, int retryCount, boolean timedOut) {
+    public OutcomeEvent(EventName name, String jobId, String taskName, String error, int retryCount, boolean timedOut) {
         this.name = name;
         this.jobId = jobId;
         this.taskName = taskName;

--- a/sdks/java/src/main/java/org/byteveda/taskito/internal/JniQueueBackend.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/internal/JniQueueBackend.java
@@ -165,6 +165,32 @@ public final class JniQueueBackend implements QueueBackend {
     }
 
     @Override
+    public boolean acquireLock(String name, String ownerId, long ttlMs) {
+        return NativeQueue.acquireLock(handle, name, ownerId, ttlMs);
+    }
+
+    @Override
+    public boolean releaseLock(String name, String ownerId) {
+        return NativeQueue.releaseLock(handle, name, ownerId);
+    }
+
+    @Override
+    public boolean extendLock(String name, String ownerId, long ttlMs) {
+        return NativeQueue.extendLock(handle, name, ownerId, ttlMs);
+    }
+
+    @Override
+    public Optional<String> lockInfoJson(String name) {
+        return Optional.ofNullable(NativeQueue.getLockInfo(handle, name));
+    }
+
+    @Override
+    public long registerPeriodic(
+            String name, String taskName, String cron, byte[] args, String queue, String timezone, boolean enabled) {
+        return NativeQueue.registerPeriodic(handle, name, taskName, cron, args, queue, timezone, enabled);
+    }
+
+    @Override
     public WorkerControl startWorker(WorkerBridge bridge, String optionsJson) {
         return new JniWorkerControl(NativeQueue.runWorker(handle, bridge, optionsJson));
     }

--- a/sdks/java/src/main/java/org/byteveda/taskito/internal/NativeLoader.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/internal/NativeLoader.java
@@ -2,19 +2,29 @@ package org.byteveda.taskito.internal;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.security.MessageDigest;
 import java.util.Locale;
+import java.util.UUID;
 
 /**
  * Loads the native Taskito library.
  *
  * <p>Order: an explicit {@code -Dtaskito.native.lib=/path} override, otherwise
- * the platform binary bundled in the JAR is extracted to a temp file and loaded.
+ * the platform binary bundled in the JAR is extracted and loaded. Extraction is
+ * content-addressed — the target file name embeds a hash of the bytes — so it is
+ * safe under concurrent processes (atomic move), avoids re-extraction across
+ * runs, and never loads a stale binary from a previous build. Honor
+ * {@code -Dtaskito.native.workdir} for hardened/noexec {@code /tmp} environments.
  */
 public final class NativeLoader {
     private static final String LIB = "taskito_java";
+    private static final String WORKDIR_PROPERTY = "taskito.native.workdir";
     private static boolean loaded;
 
     private NativeLoader() {}
@@ -25,38 +35,68 @@ public final class NativeLoader {
             return;
         }
         String override = System.getProperty("taskito.native.lib");
-        if (override != null) {
-            System.load(override);
-        } else {
-            System.load(extractBundled());
-        }
+        System.load(override != null ? override : extractBundled());
         loaded = true;
     }
 
-    /** Extract the bundled platform binary to a temp file; return its path. */
     private static String extractBundled() {
-        String resource = "/org/byteveda/taskito/native/" + platformDir() + "/" + System.mapLibraryName(LIB);
-        InputStream in = NativeLoader.class.getResourceAsStream(resource);
-        if (in == null) {
-            throw new UnsatisfiedLinkError(
-                "no bundled native library for platform '" + platformDir() + "' (" + resource
-                    + "); set -Dtaskito.native.lib=/path/to/library");
-        }
+        byte[] bytes = readResource();
         try {
-            Path dir = Files.createTempDirectory("taskito-native");
-            dir.toFile().deleteOnExit();
-            Path target = dir.resolve(System.mapLibraryName(LIB));
-            try (InputStream src = in; OutputStream out = Files.newOutputStream(target)) {
-                byte[] buf = new byte[8192];
-                int n;
-                while ((n = src.read(buf)) != -1) {
-                    out.write(buf, 0, n);
-                }
+            Path dir = workdir();
+            Files.createDirectories(dir);
+            Path target = dir.resolve(platformDir() + "-" + hash(bytes) + "-" + System.mapLibraryName(LIB));
+            if (!Files.isRegularFile(target) || Files.size(target) != bytes.length) {
+                materialize(dir, target, bytes);
             }
-            target.toFile().deleteOnExit();
             return target.toAbsolutePath().toString();
         } catch (IOException e) {
             throw new UnsatisfiedLinkError("failed to extract native library: " + e.getMessage());
+        }
+    }
+
+    /** Write to a unique temp file, then atomically move it into place. */
+    private static void materialize(Path dir, Path target, byte[] bytes) throws IOException {
+        Path temp = dir.resolve(".tmp-" + UUID.randomUUID());
+        Files.write(temp, bytes);
+        try {
+            Files.move(temp, target, StandardCopyOption.ATOMIC_MOVE);
+        } catch (FileAlreadyExistsException raced) {
+            Files.deleteIfExists(temp); // another process won the race — its file is identical
+        } catch (AtomicMoveNotSupportedException unsupported) {
+            Files.move(temp, target, StandardCopyOption.REPLACE_EXISTING);
+        }
+    }
+
+    private static byte[] readResource() {
+        String resource = "/org/byteveda/taskito/native/" + platformDir() + "/" + System.mapLibraryName(LIB);
+        try (InputStream in = NativeLoader.class.getResourceAsStream(resource)) {
+            if (in == null) {
+                throw new UnsatisfiedLinkError("no bundled native library for platform '" + platformDir()
+                        + "' (" + resource + "); set -Dtaskito.native.lib=/path/to/library");
+            }
+            return in.readAllBytes();
+        } catch (IOException e) {
+            throw new UnsatisfiedLinkError("failed to read native library: " + e.getMessage());
+        }
+    }
+
+    private static Path workdir() {
+        String configured = System.getProperty(WORKDIR_PROPERTY);
+        String base = configured != null ? configured : System.getProperty("java.io.tmpdir");
+        return Paths.get(base).resolve("taskito-native");
+    }
+
+    private static String hash(byte[] bytes) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256").digest(bytes);
+            StringBuilder hex = new StringBuilder(16);
+            for (int i = 0; i < 8; i++) {
+                hex.append(Character.forDigit((digest[i] >> 4) & 0xf, 16));
+                hex.append(Character.forDigit(digest[i] & 0xf, 16));
+            }
+            return hex.toString();
+        } catch (Exception e) {
+            throw new UnsatisfiedLinkError("hashing failed: " + e.getMessage());
         }
     }
 
@@ -65,11 +105,11 @@ public final class NativeLoader {
         String os = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
         String arch = System.getProperty("os.arch", "").toLowerCase(Locale.ROOT);
         String osDir = os.contains("win") ? "windows"
-            : (os.contains("mac") || os.contains("darwin")) ? "osx"
-            : "linux";
+                : (os.contains("mac") || os.contains("darwin")) ? "osx"
+                : "linux";
         String archDir = (arch.equals("amd64") || arch.equals("x86_64")) ? "x86_64"
-            : (arch.equals("aarch64") || arch.equals("arm64")) ? "aarch64"
-            : arch;
+                : (arch.equals("aarch64") || arch.equals("arm64")) ? "aarch64"
+                : arch;
         return osDir + "-" + archDir;
     }
 }

--- a/sdks/java/src/main/java/org/byteveda/taskito/internal/NativeLoader.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/internal/NativeLoader.java
@@ -71,8 +71,8 @@ public final class NativeLoader {
         String resource = "/org/byteveda/taskito/native/" + platformDir() + "/" + System.mapLibraryName(LIB);
         try (InputStream in = NativeLoader.class.getResourceAsStream(resource)) {
             if (in == null) {
-                throw new UnsatisfiedLinkError("no bundled native library for platform '" + platformDir()
-                        + "' (" + resource + "); set -Dtaskito.native.lib=/path/to/library");
+                throw new UnsatisfiedLinkError("no bundled native library for platform '" + platformDir() + "' ("
+                        + resource + "); set -Dtaskito.native.lib=/path/to/library");
             }
             return in.readAllBytes();
         } catch (IOException e) {
@@ -104,12 +104,10 @@ public final class NativeLoader {
     static String platformDir() {
         String os = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
         String arch = System.getProperty("os.arch", "").toLowerCase(Locale.ROOT);
-        String osDir = os.contains("win") ? "windows"
-                : (os.contains("mac") || os.contains("darwin")) ? "osx"
-                : "linux";
-        String archDir = (arch.equals("amd64") || arch.equals("x86_64")) ? "x86_64"
-                : (arch.equals("aarch64") || arch.equals("arm64")) ? "aarch64"
-                : arch;
+        String osDir = os.contains("win") ? "windows" : (os.contains("mac") || os.contains("darwin")) ? "osx" : "linux";
+        String archDir = (arch.equals("amd64") || arch.equals("x86_64"))
+                ? "x86_64"
+                : (arch.equals("aarch64") || arch.equals("arm64")) ? "aarch64" : arch;
         return osDir + "-" + archDir;
     }
 }

--- a/sdks/java/src/main/java/org/byteveda/taskito/internal/NativeLoader.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/internal/NativeLoader.java
@@ -5,12 +5,13 @@ import java.io.InputStream;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.security.MessageDigest;
 import java.util.Locale;
-import java.util.UUID;
 
 /**
  * Loads the native Taskito library.
@@ -41,12 +42,19 @@ public final class NativeLoader {
 
     private static String extractBundled() {
         byte[] bytes = readResource();
+        String expected = sha256Hex(bytes);
         try {
-            Path dir = workdir();
-            Files.createDirectories(dir);
-            Path target = dir.resolve(platformDir() + "-" + hash(bytes) + "-" + System.mapLibraryName(LIB));
-            if (!Files.isRegularFile(target) || Files.size(target) != bytes.length) {
+            Path dir = secureWorkdir();
+            Path target =
+                    dir.resolve(platformDir() + "-" + expected.substring(0, 16) + "-" + System.mapLibraryName(LIB));
+            if (!isTrusted(target, bytes.length, expected)) {
                 materialize(dir, target, bytes);
+                // Fail closed: never System.load a file we haven't verified
+                // byte-for-byte. A racing writer could have left an untrusted file
+                // at the target after we dropped ours.
+                if (!isTrusted(target, bytes.length, expected)) {
+                    throw new IOException("native library failed integrity check at " + target);
+                }
             }
             return target.toAbsolutePath().toString();
         } catch (IOException e) {
@@ -54,16 +62,41 @@ public final class NativeLoader {
         }
     }
 
+    /**
+     * A pre-existing file is reused only if it is a real (non-symlink) regular
+     * file of the expected length whose bytes hash to {@code expected}. This
+     * rejects a swapped or symlinked file planted in a shared workdir.
+     */
+    private static boolean isTrusted(Path target, long expectedLength, String expected) throws IOException {
+        if (!Files.isRegularFile(target, LinkOption.NOFOLLOW_LINKS) || Files.size(target) != expectedLength) {
+            return false;
+        }
+        return sha256Hex(Files.readAllBytes(target)).equals(expected);
+    }
+
     /** Write to a unique temp file, then atomically move it into place. */
     private static void materialize(Path dir, Path target, byte[] bytes) throws IOException {
-        Path temp = dir.resolve(".tmp-" + UUID.randomUUID());
-        Files.write(temp, bytes);
+        Path temp = Files.createTempFile(dir, ".tmp-", null);
+        boolean moved = false;
         try {
-            Files.move(temp, target, StandardCopyOption.ATOMIC_MOVE);
-        } catch (FileAlreadyExistsException raced) {
-            Files.deleteIfExists(temp); // another process won the race — its file is identical
-        } catch (AtomicMoveNotSupportedException unsupported) {
-            Files.move(temp, target, StandardCopyOption.REPLACE_EXISTING);
+            Files.write(temp, bytes);
+            // We only reach here after verification failed, so drop any untrusted
+            // or symlinked file squatting the target. NOFOLLOW deletes the link
+            // itself, not whatever it points at.
+            Files.deleteIfExists(target);
+            try {
+                Files.move(temp, target, StandardCopyOption.ATOMIC_MOVE);
+                moved = true;
+            } catch (FileAlreadyExistsException raced) {
+                moved = false; // another process won; the caller re-verifies the target
+            } catch (AtomicMoveNotSupportedException unsupported) {
+                Files.move(temp, target, StandardCopyOption.REPLACE_EXISTING);
+                moved = true;
+            }
+        } finally {
+            if (!moved) {
+                Files.deleteIfExists(temp); // don't leave .tmp-* behind on failure or loss
+            }
         }
     }
 
@@ -80,19 +113,30 @@ public final class NativeLoader {
         }
     }
 
-    private static Path workdir() {
+    /**
+     * Per-user extraction directory with owner-only permissions, so other users
+     * on a shared {@code /tmp} can't pre-create or swap the file we load.
+     */
+    private static Path secureWorkdir() throws IOException {
         String configured = System.getProperty(WORKDIR_PROPERTY);
         String base = configured != null ? configured : System.getProperty("java.io.tmpdir");
-        return Paths.get(base).resolve("taskito-native");
+        Path dir = Paths.get(base).resolve("taskito-native-" + System.getProperty("user.name", "anon"));
+        Files.createDirectories(dir);
+        try {
+            Files.setPosixFilePermissions(dir, PosixFilePermissions.fromString("rwx------"));
+        } catch (UnsupportedOperationException nonPosix) {
+            // Windows etc.: per-user profile dirs are already ACL-restricted.
+        }
+        return dir;
     }
 
-    private static String hash(byte[] bytes) {
+    private static String sha256Hex(byte[] bytes) {
         try {
             byte[] digest = MessageDigest.getInstance("SHA-256").digest(bytes);
-            StringBuilder hex = new StringBuilder(16);
-            for (int i = 0; i < 8; i++) {
-                hex.append(Character.forDigit((digest[i] >> 4) & 0xf, 16));
-                hex.append(Character.forDigit(digest[i] & 0xf, 16));
+            StringBuilder hex = new StringBuilder(digest.length * 2);
+            for (byte b : digest) {
+                hex.append(Character.forDigit((b >> 4) & 0xf, 16));
+                hex.append(Character.forDigit(b & 0xf, 16));
             }
             return hex.toString();
         } catch (Exception e) {

--- a/sdks/java/src/main/java/org/byteveda/taskito/internal/NativeQueue.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/internal/NativeQueue.java
@@ -85,6 +85,28 @@ public final class NativeQueue {
 
     public static native String getTaskLogs(long handle, String jobId);
 
+    // ── Locks ───────────────────────────────────────────────────────
+    public static native boolean acquireLock(long handle, String name, String ownerId, long ttlMs);
+
+    public static native boolean releaseLock(long handle, String name, String ownerId);
+
+    public static native boolean extendLock(long handle, String name, String ownerId, long ttlMs);
+
+    /** Returns JSON holder info, or {@code null} if free. */
+    public static native String getLockInfo(long handle, String name);
+
+    // ── Periodic ────────────────────────────────────────────────────
+    /** Register (or replace) a cron task; returns the next fire time (Unix ms). */
+    public static native long registerPeriodic(
+            long handle,
+            String name,
+            String taskName,
+            String cron,
+            byte[] args,
+            String queue,
+            String timezone,
+            boolean enabled);
+
     // ── Worker ──────────────────────────────────────────────────────
     /** Start a worker; returns its handle. {@code bridge} is a {@code WorkerBridge}. */
     public static native long runWorker(long handle, Object bridge, String optionsJson);

--- a/sdks/java/src/main/java/org/byteveda/taskito/spi/QueueBackend.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/spi/QueueBackend.java
@@ -82,6 +82,19 @@ public interface QueueBackend extends AutoCloseable {
 
     String getTaskLogsJson(String jobId);
 
+    // ── Locks ───────────────────────────────────────────────────────
+    boolean acquireLock(String name, String ownerId, long ttlMs);
+
+    boolean releaseLock(String name, String ownerId);
+
+    boolean extendLock(String name, String ownerId, long ttlMs);
+
+    Optional<String> lockInfoJson(String name);
+
+    // ── Periodic ────────────────────────────────────────────────────
+    long registerPeriodic(
+            String name, String taskName, String cron, byte[] args, String queue, String timezone, boolean enabled);
+
     // ── Worker ──────────────────────────────────────────────────────
     /** Start a worker that dispatches jobs to {@code bridge}; returns its control. */
     WorkerControl startWorker(WorkerBridge bridge, String optionsJson);

--- a/sdks/java/src/main/java/org/byteveda/taskito/spi/QueueBackend.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/spi/QueueBackend.java
@@ -83,17 +83,29 @@ public interface QueueBackend extends AutoCloseable {
     String getTaskLogsJson(String jobId);
 
     // ── Locks ───────────────────────────────────────────────────────
-    boolean acquireLock(String name, String ownerId, long ttlMs);
+    // Optional capability: default to throwing so existing custom backends keep
+    // compiling and fail explicitly only when locks are actually used.
+    default boolean acquireLock(String name, String ownerId, long ttlMs) {
+        throw new UnsupportedOperationException("locks not supported by this backend");
+    }
 
-    boolean releaseLock(String name, String ownerId);
+    default boolean releaseLock(String name, String ownerId) {
+        throw new UnsupportedOperationException("locks not supported by this backend");
+    }
 
-    boolean extendLock(String name, String ownerId, long ttlMs);
+    default boolean extendLock(String name, String ownerId, long ttlMs) {
+        throw new UnsupportedOperationException("locks not supported by this backend");
+    }
 
-    Optional<String> lockInfoJson(String name);
+    default Optional<String> lockInfoJson(String name) {
+        throw new UnsupportedOperationException("locks not supported by this backend");
+    }
 
     // ── Periodic ────────────────────────────────────────────────────
-    long registerPeriodic(
-            String name, String taskName, String cron, byte[] args, String queue, String timezone, boolean enabled);
+    default long registerPeriodic(
+            String name, String taskName, String cron, byte[] args, String queue, String timezone, boolean enabled) {
+        throw new UnsupportedOperationException("periodic tasks not supported by this backend");
+    }
 
     // ── Worker ──────────────────────────────────────────────────────
     /** Start a worker that dispatches jobs to {@code bridge}; returns its control. */

--- a/sdks/java/src/main/java/org/byteveda/taskito/webhooks/Deliverer.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/webhooks/Deliverer.java
@@ -31,13 +31,12 @@ final class Deliverer {
     }
 
     private void sendWithRetry(HttpRequest request, int attemptsLeft) {
-        client.sendAsync(request, HttpResponse.BodyHandlers.discarding())
-                .whenComplete((response, error) -> {
-                    boolean failed = error != null || response.statusCode() >= 500;
-                    if (failed && attemptsLeft > 0) {
-                        sendWithRetry(request, attemptsLeft - 1);
-                    }
-                });
+        client.sendAsync(request, HttpResponse.BodyHandlers.discarding()).whenComplete((response, error) -> {
+            boolean failed = error != null || response.statusCode() >= 500;
+            if (failed && attemptsLeft > 0) {
+                sendWithRetry(request, attemptsLeft - 1);
+            }
+        });
     }
 
     static String sign(String secret, byte[] body) {

--- a/sdks/java/src/main/java/org/byteveda/taskito/webhooks/Webhook.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/webhooks/Webhook.java
@@ -17,6 +17,7 @@ public final class Webhook {
     public final String url;
     /** Outcome wire names this hook fires on: success/retry/dead/cancelled. */
     public final List<String> events;
+
     public final String taskFilter;
     public final Map<String, String> headers;
     public final String secret;

--- a/sdks/java/src/test/java/org/byteveda/taskito/DashboardTest.java
+++ b/sdks/java/src/test/java/org/byteveda/taskito/DashboardTest.java
@@ -23,18 +23,25 @@ class DashboardTest {
     }
 
     private static HttpResponse<String> get(int port, String path) throws Exception {
-        return HttpClient.newHttpClient().send(
-                HttpRequest.newBuilder(URI.create("http://localhost:" + port + path)).GET().build(),
-                HttpResponse.BodyHandlers.ofString());
+        return HttpClient.newHttpClient()
+                .send(
+                        HttpRequest.newBuilder(URI.create("http://localhost:" + port + path))
+                                .GET()
+                                .build(),
+                        HttpResponse.BodyHandlers.ofString());
     }
 
     @Test
     @Timeout(30)
     void servesSnakeCaseContract(@TempDir Path dir) throws Exception {
         Task<Map<String, Object>> add = Task.of("add", mapType());
-        try (Queue queue =
-                Taskito.builder().backend("sqlite").url(dir.resolve("t.db").toString()).open()) {
-            queue.enqueue(add, Collections.singletonMap("a", 1),
+        try (Queue queue = Taskito.builder()
+                .backend("sqlite")
+                .url(dir.resolve("t.db").toString())
+                .open()) {
+            queue.enqueue(
+                    add,
+                    Collections.singletonMap("a", 1),
                     EnqueueOptions.builder().queue("emails").build());
             try (DashboardServer server = DashboardServer.start(queue, 0)) {
                 int port = server.port();
@@ -53,8 +60,10 @@ class DashboardTest {
     @Test
     @Timeout(30)
     void enforcesToken(@TempDir Path dir) throws Exception {
-        try (Queue queue =
-                Taskito.builder().backend("sqlite").url(dir.resolve("t.db").toString()).open()) {
+        try (Queue queue = Taskito.builder()
+                .backend("sqlite")
+                .url(dir.resolve("t.db").toString())
+                .open()) {
             try (DashboardServer server = DashboardServer.start(queue, 0, "sekret", null)) {
                 int port = server.port();
                 assertEquals(401, get(port, "/api/stats").statusCode());

--- a/sdks/java/src/test/java/org/byteveda/taskito/LockTest.java
+++ b/sdks/java/src/test/java/org/byteveda/taskito/LockTest.java
@@ -37,9 +37,12 @@ class LockTest {
     @Test
     void registerPeriodicValidatesCron(@TempDir Path dir) {
         try (Queue queue = open(dir)) {
+            long before = System.currentTimeMillis();
             long next = queue.registerPeriodic(
                     PeriodicTask.builder("p", "tick", "0 0 12 * * *").build());
-            assertTrue(next > System.currentTimeMillis());
+            // Next firing must be strictly after the pre-registration instant.
+            // Comparing to a later wall-clock read could flake at the cron boundary.
+            assertTrue(next > before);
 
             assertThrows(
                     TaskitoException.class,

--- a/sdks/java/src/test/java/org/byteveda/taskito/LockTest.java
+++ b/sdks/java/src/test/java/org/byteveda/taskito/LockTest.java
@@ -11,7 +11,10 @@ import org.junit.jupiter.api.io.TempDir;
 class LockTest {
 
     private Queue open(Path dir) {
-        return Taskito.builder().backend("sqlite").url(dir.resolve("t.db").toString()).open();
+        return Taskito.builder()
+                .backend("sqlite")
+                .url(dir.resolve("t.db").toString())
+                .open();
     }
 
     @Test
@@ -34,12 +37,14 @@ class LockTest {
     @Test
     void registerPeriodicValidatesCron(@TempDir Path dir) {
         try (Queue queue = open(dir)) {
-            long next = queue.registerPeriodic(PeriodicTask.builder("p", "tick", "0 0 12 * * *").build());
+            long next = queue.registerPeriodic(
+                    PeriodicTask.builder("p", "tick", "0 0 12 * * *").build());
             assertTrue(next > System.currentTimeMillis());
 
             assertThrows(
                     TaskitoException.class,
-                    () -> queue.registerPeriodic(PeriodicTask.builder("p", "tick", "not a cron").build()));
+                    () -> queue.registerPeriodic(
+                            PeriodicTask.builder("p", "tick", "not a cron").build()));
         }
     }
 }

--- a/sdks/java/src/test/java/org/byteveda/taskito/LockTest.java
+++ b/sdks/java/src/test/java/org/byteveda/taskito/LockTest.java
@@ -1,0 +1,45 @@
+package org.byteveda.taskito;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class LockTest {
+
+    private Queue open(Path dir) {
+        return Taskito.builder().backend("sqlite").url(dir.resolve("t.db").toString()).open();
+    }
+
+    @Test
+    void acquireContendRelease(@TempDir Path dir) {
+        try (Queue queue = open(dir)) {
+            Lock first = queue.lock("L", 60_000);
+            assertTrue(first.acquire());
+            assertFalse(queue.lock("L", 60_000).acquire());
+            assertTrue(queue.lockInfo("L").isPresent());
+
+            first.release();
+            assertFalse(queue.lockInfo("L").isPresent());
+
+            boolean[] ran = {false};
+            assertTrue(queue.withLock("M", 30_000, () -> ran[0] = true));
+            assertTrue(ran[0]);
+        }
+    }
+
+    @Test
+    void registerPeriodicValidatesCron(@TempDir Path dir) {
+        try (Queue queue = open(dir)) {
+            long next = queue.registerPeriodic(PeriodicTask.builder("p", "tick", "0 0 12 * * *").build());
+            assertTrue(next > System.currentTimeMillis());
+
+            assertThrows(
+                    TaskitoException.class,
+                    () -> queue.registerPeriodic(PeriodicTask.builder("p", "tick", "not a cron").build()));
+        }
+    }
+}

--- a/sdks/java/src/test/java/org/byteveda/taskito/QueueTest.java
+++ b/sdks/java/src/test/java/org/byteveda/taskito/QueueTest.java
@@ -23,7 +23,10 @@ class QueueTest {
     }
 
     private Queue open(Path dir) {
-        return Taskito.builder().backend("sqlite").url(dir.resolve("t.db").toString()).open();
+        return Taskito.builder()
+                .backend("sqlite")
+                .url(dir.resolve("t.db").toString())
+                .open();
     }
 
     @Test
@@ -60,7 +63,8 @@ class QueueTest {
     void enqueueManyAndFilteredList(@TempDir Path dir) {
         try (Queue queue = open(dir)) {
             List<String> ids = queue.enqueueMany(
-                    SEND_EMAIL.withOptions(EnqueueOptions.builder().queue("emails").build()),
+                    SEND_EMAIL.withOptions(
+                            EnqueueOptions.builder().queue("emails").build()),
                     Arrays.asList(
                             Collections.singletonMap("to", "a"),
                             Collections.singletonMap("to", "b"),
@@ -68,8 +72,10 @@ class QueueTest {
             assertEquals(3, ids.size());
             assertEquals(3, queue.statsByQueue("emails").pending);
 
-            List<Job> jobs = queue.listJobs(
-                    JobFilter.builder().queue("emails").status(JobStatus.PENDING).build());
+            List<Job> jobs = queue.listJobs(JobFilter.builder()
+                    .queue("emails")
+                    .status(JobStatus.PENDING)
+                    .build());
             assertEquals(3, jobs.size());
         }
     }

--- a/sdks/java/src/test/java/org/byteveda/taskito/WebhookTest.java
+++ b/sdks/java/src/test/java/org/byteveda/taskito/WebhookTest.java
@@ -16,8 +16,10 @@ class WebhookTest {
 
     @Test
     void crudRoundTrip(@TempDir Path dir) {
-        try (Queue queue =
-                Taskito.builder().backend("sqlite").url(dir.resolve("t.db").toString()).open()) {
+        try (Queue queue = Taskito.builder()
+                .backend("sqlite")
+                .url(dir.resolve("t.db").toString())
+                .open()) {
             WebhookManager webhooks = WebhookManager.attach(queue);
 
             Webhook created = webhooks.create(Webhook.builder("http://example/hook")

--- a/sdks/java/src/test/java/org/byteveda/taskito/WorkerTest.java
+++ b/sdks/java/src/test/java/org/byteveda/taskito/WorkerTest.java
@@ -26,8 +26,10 @@ class WorkerTest {
     @Timeout(30)
     void runsTaskToCompletion(@TempDir Path dir) throws Exception {
         Task<Map<String, Object>> add = Task.of("add", mapType());
-        try (Queue queue =
-                Taskito.builder().backend("sqlite").url(dir.resolve("t.db").toString()).open()) {
+        try (Queue queue = Taskito.builder()
+                .backend("sqlite")
+                .url(dir.resolve("t.db").toString())
+                .open()) {
             Map<String, Object> payload = new HashMap<>();
             payload.put("a", 2);
             payload.put("b", 3);
@@ -35,8 +37,10 @@ class WorkerTest {
 
             CountDownLatch done = new CountDownLatch(1);
             try (Worker worker = queue.worker()
-                    .handle(add, (Map<String, Object> p) ->
-                            ((Number) p.get("a")).intValue() + ((Number) p.get("b")).intValue())
+                    .handle(
+                            add,
+                            (Map<String, Object> p) ->
+                                    ((Number) p.get("a")).intValue() + ((Number) p.get("b")).intValue())
                     .on(EventName.SUCCESS, event -> done.countDown())
                     .start()) {
                 assertTrue(done.await(20, TimeUnit.SECONDS), "task should complete");

--- a/sdks/java/src/test/java/org/byteveda/taskito/internal/NativeLoaderTest.java
+++ b/sdks/java/src/test/java/org/byteveda/taskito/internal/NativeLoaderTest.java
@@ -1,0 +1,14 @@
+package org.byteveda.taskito.internal;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class NativeLoaderTest {
+
+    @Test
+    void platformDirIsClassifierShaped() {
+        String dir = NativeLoader.platformDir();
+        assertTrue(dir.matches("(linux|osx|windows)-\\S+"), "unexpected classifier: " + dir);
+    }
+}


### PR DESCRIPTION
Fourth of the Java SDK split series (follows #301). Packaging/publishing groundwork, distributed locks + periodic tasks, and the Java 11 build fix.

## What's here

- **Native library loader hardening** (`NativeLoader`): content-addressed extraction (atomic move, sha-keyed temp dir), `-Dtaskito.native.lib` override, per-classifier resource resolution. Lays the groundwork for the multi-platform fat JAR.
- **`jni` leakage guard**: the generic-crate binding-free check in `ci.yml` now also forbids `jni` (alongside `pyo3`/`napi`) — the engine crates (core/workflows/mesh) must stay binding-agnostic.
- **Maven Central publishing**: vanniktech `maven-publish` config in `build.gradle.kts` + a `publish-java.yml` workflow (native matrix → fat JAR → Central Portal, tag `java-v*`).
- **Distributed locks + periodic tasks**: `Queue.lock`/`withLock`/`lockInfo` (owner-scoped `Lock`), `registerPeriodic(PeriodicTask)` (cron-validated), bound over JNI.
- **Build fix — Java 11 via `--release 11`**, not a pinned toolchain. A pinned `JavaLanguageVersion.of(11)` toolchain is rejected by exact-match resolution on a JDK-21 runner; `options.release.set(11)` targets 11 bytecode on any JDK ≥ 11. **After this PR, `./gradlew build` runs on the CI's JDK 21.** Plus `copyNative` Jar-task dependency and palantir formatting.

## Verification

Full `./gradlew build --no-daemon` passes locally on JDK 21: compile + Spotless + Checkstyle + tests, native `.so` bundled. (The dedicated Java CI job is added in the next PR of this series.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added distributed lock support, including acquiring, extending, releasing, and inspecting lock status.
  * Added support for registering periodic cron-based tasks.
  * Introduced new Java APIs for lock and periodic-task workflows.

* **Bug Fixes**
  * Improved native library loading to be more reliable across runs and environments.
  * Expanded CI checks to cover additional native bindings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->