### PR TITLE
feat(java): producer ergonomics, @TaskHandler processor, CoreFacade

### DIFF
--- a/sdks/java/README.md
+++ b/sdks/java/README.md
@@ -13,25 +13,31 @@ A typed Java 11+ client over the Taskito Rust core, via a hand-written JNI shell
 ### Enqueue
 
 ```java
+import com.fasterxml.jackson.core.type.TypeReference;
 import org.byteveda.taskito.Queue;
 import org.byteveda.taskito.Taskito;
 import org.byteveda.taskito.model.Job;
 import org.byteveda.taskito.model.JobStatus;
 import org.byteveda.taskito.model.QueueStats;
-import org.byteveda.taskito.task.EnqueueOptions;
 import org.byteveda.taskito.task.Task;
 import java.util.Map;
 
-Task<Map> sendEmail = Task.of("send_email", Map.class)
-        .withOptions(EnqueueOptions.builder().queue("emails").priority(5).build());
+// TypeReference preserves generics that a Class token can't; fluent options
+// replace the EnqueueOptions builder for the common cases.
+Task<Map<String, Object>> sendEmail =
+        Task.of("send_email", new TypeReference<Map<String, Object>>() {})
+                .queue("emails")
+                .priority(5);
 
-try (Queue queue = Taskito.builder().backend("sqlite").url("taskito.db").open()) {
+try (Queue queue = Taskito.builder().sqlite("taskito.db").open()) {
     String id = queue.enqueue(sendEmail, Map.of("to", "a@b.c"));
     Job job = queue.getJob(id).orElseThrow();   // job.status == JobStatus.PENDING
     QueueStats stats = queue.stats();
     queue.cancel(id);
 }
 ```
+
+`Taskito.builder()` also has `.postgres(url)` / `.redis(url)` shortcuts.
 
 ### Run a worker
 
@@ -58,6 +64,33 @@ Runtime.getRuntime().addShutdownHook(new Thread(() -> {
 }));
 worker.awaitShutdown();
 ```
+
+### Typed tasks from `@TaskHandler` (compile-time, no reflection)
+
+Annotate handler methods; a compile-time processor generates a `<Class>Tasks`
+companion with a typed `Task` constant per method (full generics, name declared
+once) plus a `bind(...)`. Add the processor with
+`annotationProcessor("org.byteveda:taskito-processor")`.
+
+```java
+class EmailTasks {
+    @TaskHandler("send_email")          // explicit name
+    String send(EmailPayload p) { ... }
+
+    @TaskHandler                        // name defaults to "report"
+    Report report(List<Metric> metrics) { ... }
+}
+
+// generated EmailTasksTasks:
+String id = queue.enqueue(EmailTasksTasks.SEND, payload);
+
+queue.worker()
+        .apply(b -> EmailTasksTasks.bind(b, new EmailTasks()))
+        .start();
+```
+
+The annotation is source-retention and the processor emits plain code — zero
+runtime reflection, GraalVM-native-image friendly.
 
 ### Workflows
 
@@ -159,12 +192,17 @@ org.byteveda.taskito
 ├── scheduling/        PeriodicTask
 ├── workflows/         Workflow DAG builder, run, status, tracker
 ├── serialization/     Serializer SPI + JsonSerializer (Jackson) default
+├── annotation/        @TaskHandler (source-retention; see :processor)
 ├── middleware/        Middleware hooks
 ├── events/            worker outcome events
 ├── dashboard/ webhooks/ cli/
 ├── spi/               QueueBackend — seam between API and the native layer
 └── internal/          JNI bindings (NativeQueue, NativeWorkflows, NativeLoader, ...)
 ```
+
+The `:processor` subproject is a standalone compile-time annotation processor
+(`TaskHandlerProcessor`) — it depends on nothing, reading `@TaskHandler`
+structurally and emitting plain task companions.
 
 The `spi.QueueBackend` seam keeps the public API independent of JNI: it can be
 backed by the native library (default) or an in-memory fake in tests, and leaves

--- a/sdks/java/build.gradle.kts
+++ b/sdks/java/build.gradle.kts
@@ -82,6 +82,10 @@ dependencies {
     api("com.fasterxml.jackson.core:jackson-databind:2.17.2")
     implementation("info.picocli:picocli:4.7.6")
 
+    // Run the @TaskHandler processor over the tests so the generated companions
+    // are exercised end-to-end. Consumers wire it the same way.
+    testAnnotationProcessor(project(":processor"))
+
     testImplementation(platform("org.junit:junit-bom:5.10.3"))
     testImplementation("org.junit.jupiter:junit-jupiter")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/sdks/java/processor/build.gradle.kts
+++ b/sdks/java/processor/build.gradle.kts
@@ -1,0 +1,40 @@
+// Standalone compile-time annotation processor for @TaskHandler. Dependency-free
+// (reads annotations structurally via javax.lang.model), so it never forms a
+// cycle with the runtime it serves. Consumers add it via `annotationProcessor`.
+plugins {
+    `java-library`
+    checkstyle
+    id("com.diffplug.spotless") version "6.25.0"
+}
+
+group = "org.byteveda"
+version = "0.16.4"
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    options.release.set(11)
+}
+
+repositories {
+    mavenCentral()
+}
+
+spotless {
+    java {
+        target("src/**/*.java")
+        palantirJavaFormat("2.50.0")
+        removeUnusedImports()
+        trimTrailingWhitespace()
+        endWithNewline()
+    }
+}
+
+checkstyle {
+    toolVersion = "10.21.4"
+    configFile = file("../config/checkstyle/checkstyle.xml")
+    isIgnoreFailures = false
+}

--- a/sdks/java/processor/src/main/java/org/byteveda/taskito/processor/TaskHandlerProcessor.java
+++ b/sdks/java/processor/src/main/java/org/byteveda/taskito/processor/TaskHandlerProcessor.java
@@ -1,0 +1,242 @@
+package org.byteveda.taskito.processor;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeElement;
+import javax.tools.Diagnostic;
+import javax.tools.JavaFileObject;
+
+/**
+ * Generates, for each class with {@code @TaskHandler} methods, a {@code <Class>Tasks}
+ * companion holding a typed {@code Task} constant per handler plus a static
+ * {@code bind(Worker.Builder, <Class>)}. Reads the annotation structurally, so it
+ * needs no dependency on the runtime module.
+ */
+@SupportedAnnotationTypes(TaskHandlerProcessor.ANNOTATION)
+@SupportedSourceVersion(SourceVersion.RELEASE_11)
+public final class TaskHandlerProcessor extends AbstractProcessor {
+    static final String ANNOTATION = "org.byteveda.taskito.annotation.TaskHandler";
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        TypeElement marker = processingEnv.getElementUtils().getTypeElement(ANNOTATION);
+        if (marker == null) {
+            return false;
+        }
+        // Group handler methods by their enclosing class.
+        Map<TypeElement, List<ExecutableElement>> byClass = new LinkedHashMap<>();
+        for (Element element : roundEnv.getElementsAnnotatedWith(marker)) {
+            if (element.getKind() != ElementKind.METHOD) {
+                continue;
+            }
+            ExecutableElement method = (ExecutableElement) element;
+            if (!validate(method)) {
+                continue;
+            }
+            TypeElement owner = (TypeElement) method.getEnclosingElement();
+            byClass.computeIfAbsent(owner, key -> new java.util.ArrayList<>()).add(method);
+        }
+        byClass.forEach(this::generate);
+        return true;
+    }
+
+    private boolean validate(ExecutableElement method) {
+        if (method.getParameters().size() != 1) {
+            error(method, "@TaskHandler method must take exactly one parameter (the payload)");
+            return false;
+        }
+        if (method.getModifiers().contains(Modifier.PRIVATE)) {
+            error(method, "@TaskHandler method must not be private");
+            return false;
+        }
+        if (method.getModifiers().contains(Modifier.STATIC)) {
+            error(method, "@TaskHandler method must not be static");
+            return false;
+        }
+        return true;
+    }
+
+    private void generate(TypeElement owner, List<ExecutableElement> methods) {
+        String pkg = packageOf(owner);
+        String ownerSimple = owner.getSimpleName().toString();
+        String companion = ownerSimple + "Tasks";
+        String qualified = pkg.isEmpty() ? companion : pkg + "." + companion;
+
+        StringBuilder out = new StringBuilder();
+        if (!pkg.isEmpty()) {
+            out.append("package ").append(pkg).append(";\n\n");
+        }
+        out.append("import com.fasterxml.jackson.core.type.TypeReference;\n")
+                .append("import org.byteveda.taskito.task.Task;\n")
+                .append("import org.byteveda.taskito.worker.Worker;\n\n")
+                .append("/** Generated task descriptors + worker binding for {@link ")
+                .append(ownerSimple)
+                .append("}. */\n")
+                .append("public final class ")
+                .append(companion)
+                .append(" {\n")
+                .append("    private ")
+                .append(companion)
+                .append("() {}\n\n");
+
+        for (ExecutableElement method : methods) {
+            String constant = upperSnake(method.getSimpleName().toString());
+            String payloadType = method.getParameters().get(0).asType().toString();
+            String name = taskName(method);
+            out.append("    public static final Task<")
+                    .append(payloadType)
+                    .append("> ")
+                    .append(constant)
+                    .append(" = Task.of(\"")
+                    .append(escape(name))
+                    .append("\", new TypeReference<")
+                    .append(payloadType)
+                    .append(">() {})")
+                    .append(options(method))
+                    .append(";\n\n");
+        }
+
+        out.append("    public static Worker.Builder bind(Worker.Builder builder, ")
+                .append(ownerSimple)
+                .append(" impl) {\n");
+        for (ExecutableElement method : methods) {
+            String constant = upperSnake(method.getSimpleName().toString());
+            String methodName = method.getSimpleName().toString();
+            if (isVoid(method)) {
+                out.append("        builder.handle(")
+                        .append(constant)
+                        .append(", payload -> {\n            impl.")
+                        .append(methodName)
+                        .append("(payload);\n            return null;\n        });\n");
+            } else {
+                out.append("        builder.handle(")
+                        .append(constant)
+                        .append(", impl::")
+                        .append(methodName)
+                        .append(");\n");
+            }
+        }
+        out.append("        return builder;\n    }\n}\n");
+
+        write(owner, qualified, out.toString());
+    }
+
+    /** Build the chained option calls (.queue/.maxRetries/.timeoutMs/.priority) from the annotation. */
+    private String options(ExecutableElement method) {
+        AnnotationMirror mirror = mirror(method);
+        StringBuilder chain = new StringBuilder();
+        String queue = stringValue(mirror, "queue", "");
+        if (!queue.isEmpty()) {
+            chain.append(".queue(\"").append(escape(queue)).append("\")");
+        }
+        long maxRetries = longValue(mirror, "maxRetries", -1);
+        if (maxRetries >= 0) {
+            chain.append(".maxRetries(").append(maxRetries).append(")");
+        }
+        long timeoutMs = longValue(mirror, "timeoutMs", -1);
+        if (timeoutMs >= 0) {
+            chain.append(".timeoutMs(").append(timeoutMs).append("L)");
+        }
+        long priority = longValue(mirror, "priority", 0);
+        if (priority != 0) {
+            chain.append(".priority(").append(priority).append(")");
+        }
+        return chain.toString();
+    }
+
+    private String taskName(ExecutableElement method) {
+        String value = stringValue(mirror(method), "value", "");
+        return value.isEmpty() ? method.getSimpleName().toString() : value;
+    }
+
+    private AnnotationMirror mirror(ExecutableElement method) {
+        for (AnnotationMirror mirror : method.getAnnotationMirrors()) {
+            if (mirror.getAnnotationType().toString().equals(ANNOTATION)) {
+                return mirror;
+            }
+        }
+        return null;
+    }
+
+    private String stringValue(AnnotationMirror mirror, String key, String fallback) {
+        Object value = rawValue(mirror, key);
+        return value == null ? fallback : value.toString();
+    }
+
+    private long longValue(AnnotationMirror mirror, String key, long fallback) {
+        Object value = rawValue(mirror, key);
+        return value instanceof Number ? ((Number) value).longValue() : fallback;
+    }
+
+    private Object rawValue(AnnotationMirror mirror, String key) {
+        if (mirror == null) {
+            return null;
+        }
+        for (Map.Entry<? extends ExecutableElement, ? extends AnnotationValue> entry :
+                mirror.getElementValues().entrySet()) {
+            if (entry.getKey().getSimpleName().contentEquals(key)) {
+                return entry.getValue().getValue();
+            }
+        }
+        return null;
+    }
+
+    private boolean isVoid(ExecutableElement method) {
+        return method.getReturnType().getKind() == javax.lang.model.type.TypeKind.VOID;
+    }
+
+    private String packageOf(TypeElement type) {
+        return processingEnv
+                .getElementUtils()
+                .getPackageOf(type)
+                .getQualifiedName()
+                .toString();
+    }
+
+    private void write(Element origin, String qualifiedName, String source) {
+        try {
+            JavaFileObject file = processingEnv.getFiler().createSourceFile(qualifiedName, origin);
+            try (Writer writer = file.openWriter()) {
+                writer.write(source);
+            }
+        } catch (IOException e) {
+            error(origin, "failed to write " + qualifiedName + ": " + e.getMessage());
+        }
+    }
+
+    private void error(Element element, String message) {
+        processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, message, element);
+    }
+
+    /** {@code sendEmail} -> {@code SEND_EMAIL}. */
+    private static String upperSnake(String camel) {
+        StringBuilder out = new StringBuilder();
+        for (int i = 0; i < camel.length(); i++) {
+            char c = camel.charAt(i);
+            if (Character.isUpperCase(c) && i > 0) {
+                out.append('_');
+            }
+            out.append(Character.toUpperCase(c));
+        }
+        return out.toString();
+    }
+
+    private static String escape(String value) {
+        return value.replace("\\", "\\\\").replace("\"", "\\\"");
+    }
+}

--- a/sdks/java/processor/src/main/java/org/byteveda/taskito/processor/package-info.java
+++ b/sdks/java/processor/src/main/java/org/byteveda/taskito/processor/package-info.java
@@ -1,0 +1,2 @@
+/** Compile-time annotation processor that turns {@code @TaskHandler} into typed task companions. */
+package org.byteveda.taskito.processor;

--- a/sdks/java/processor/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/sdks/java/processor/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,1 @@
+org.byteveda.taskito.processor.TaskHandlerProcessor

--- a/sdks/java/settings.gradle.kts
+++ b/sdks/java/settings.gradle.kts
@@ -1,1 +1,3 @@
 rootProject.name = "taskito"
+
+include(":processor")

--- a/sdks/java/src/main/java/org/byteveda/taskito/DefaultQueue.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/DefaultQueue.java
@@ -2,6 +2,7 @@ package org.byteveda.taskito;
 
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -11,6 +12,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
+import org.byteveda.taskito.core.CoreFacade;
 import org.byteveda.taskito.locks.Lock;
 import org.byteveda.taskito.locks.LockInfo;
 import org.byteveda.taskito.middleware.EnqueueContext;
@@ -42,12 +44,16 @@ import org.byteveda.taskito.workflows.WorkflowStatus;
 final class DefaultQueue implements Queue {
     private static final ObjectMapper VIEWS = new ObjectMapper();
 
+    private static final long DEFAULT_LOCK_TTL_MS = 30_000;
+
     private final QueueBackend backend;
+    private final CoreFacade facade;
     private final Serializer serializer;
     private final List<Middleware> middleware = new CopyOnWriteArrayList<>();
 
     DefaultQueue(QueueBackend backend, Serializer serializer) {
         this.backend = backend;
+        this.facade = new CoreFacade(backend);
         this.serializer = serializer;
     }
 
@@ -100,8 +106,18 @@ final class DefaultQueue implements Queue {
     }
 
     @Override
+    public <T> List<String> enqueueAll(Task<T> task, List<T> payloads) {
+        return enqueueMany(task, payloads);
+    }
+
+    @Override
     public Optional<Job> getJob(String jobId) {
         return backend.getJobJson(jobId).map(json -> decode(json, Job.class));
+    }
+
+    @Override
+    public Optional<Job> awaitJob(String jobId, Duration timeout) {
+        return facade.awaitJobJson(jobId, timeout, Duration.ofMillis(100)).map(json -> decode(json, Job.class));
     }
 
     @Override
@@ -184,6 +200,11 @@ final class DefaultQueue implements Queue {
     }
 
     @Override
+    public String retry(String deadId) {
+        return backend.retryDead(deadId);
+    }
+
+    @Override
     public boolean deleteDead(String deadId) {
         return backend.deleteDead(deadId);
     }
@@ -256,6 +277,11 @@ final class DefaultQueue implements Queue {
     }
 
     @Override
+    public Lock lock(String name) {
+        return new Lock(backend, name, DEFAULT_LOCK_TTL_MS);
+    }
+
+    @Override
     public boolean withLock(String name, long ttlMs, Runnable body) {
         try (Lock lock = new Lock(backend, name, ttlMs)) {
             if (!lock.acquire()) {
@@ -269,6 +295,11 @@ final class DefaultQueue implements Queue {
     @Override
     public Optional<LockInfo> lockInfo(String name) {
         return backend.lockInfoJson(name).map(json -> decode(json, LockInfo.class));
+    }
+
+    @Override
+    public Optional<LockInfo> getLockInfo(String name) {
+        return lockInfo(name);
     }
 
     @Override

--- a/sdks/java/src/main/java/org/byteveda/taskito/Queue.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/Queue.java
@@ -1,5 +1,6 @@
 package org.byteveda.taskito;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -42,7 +43,13 @@ public interface Queue extends AutoCloseable {
 
     <T> List<String> enqueueMany(Task<T> task, List<T> payloads, EnqueueOptions options);
 
+    /** Alias of {@link #enqueueMany(Task, List)} in the guide's vocabulary. */
+    <T> List<String> enqueueAll(Task<T> task, List<T> payloads);
+
     Optional<Job> getJob(String jobId);
+
+    /** Block until the job reaches a terminal state (tests only); throws on timeout. */
+    Optional<Job> awaitJob(String jobId, Duration timeout);
 
     /** The job's raw serialized result, if complete. */
     Optional<byte[]> getResult(String jobId);
@@ -82,6 +89,9 @@ public interface Queue extends AutoCloseable {
     /** Re-enqueue a dead-letter entry; returns the new job id. */
     String retryDead(String deadId);
 
+    /** Alias of {@link #retryDead(String)} in the guide's vocabulary. */
+    String retry(String deadId);
+
     boolean deleteDead(String deadId);
 
     long purgeDead(long olderThanMs);
@@ -115,10 +125,16 @@ public interface Queue extends AutoCloseable {
     /** A distributed lock {@code name} with the given TTL; call {@link Lock#acquire()}. */
     Lock lock(String name, long ttlMs);
 
+    /** A distributed lock {@code name} with a default 30s TTL. */
+    Lock lock(String name);
+
     /** Acquire {@code name}, run {@code body} if obtained, then release; returns whether it ran. */
     boolean withLock(String name, long ttlMs, Runnable body);
 
     Optional<LockInfo> lockInfo(String name);
+
+    /** Alias of {@link #lockInfo(String)} in the guide's vocabulary. */
+    Optional<LockInfo> getLockInfo(String name);
 
     // ── Periodic ────────────────────────────────────────────────────
 

--- a/sdks/java/src/main/java/org/byteveda/taskito/Taskito.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/Taskito.java
@@ -34,6 +34,21 @@ public final class Taskito {
             return this;
         }
 
+        /** Shortcut for {@code backend("sqlite").url(path)}. */
+        public Builder sqlite(String path) {
+            return backend("sqlite").url(path);
+        }
+
+        /** Shortcut for {@code backend("postgres").url(url)}. */
+        public Builder postgres(String url) {
+            return backend("postgres").url(url);
+        }
+
+        /** Shortcut for {@code backend("redis").url(url)}. */
+        public Builder redis(String url) {
+            return backend("redis").url(url);
+        }
+
         public Builder poolSize(int poolSize) {
             options.put("poolSize", poolSize);
             return this;

--- a/sdks/java/src/main/java/org/byteveda/taskito/annotation/TaskHandler.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/annotation/TaskHandler.java
@@ -1,0 +1,35 @@
+package org.byteveda.taskito.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a method as a task handler. A compile-time annotation processor
+ * generates, per enclosing class {@code Foo}, a {@code FooTasks} companion that
+ * holds a typed {@link org.byteveda.taskito.task.Task} constant per handler plus
+ * a {@code bind(Worker.Builder, Foo)} method — no runtime reflection.
+ *
+ * <p>The handler method must take exactly one parameter (the payload) and may
+ * return a result or {@code void}. The generated task name is {@link #value()},
+ * or the method name when {@code value} is empty.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.SOURCE)
+public @interface TaskHandler {
+    /** Task name; defaults to the method name when empty. */
+    String value() default "";
+
+    /** Target queue; the default queue when empty. */
+    String queue() default "";
+
+    /** Max retries; core default when negative. */
+    int maxRetries() default -1;
+
+    /** Timeout in milliseconds; core default when negative. */
+    long timeoutMs() default -1;
+
+    /** Priority; 0 (default) is left unset. */
+    int priority() default 0;
+}

--- a/sdks/java/src/main/java/org/byteveda/taskito/annotation/package-info.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/annotation/package-info.java
@@ -1,0 +1,2 @@
+/** Compile-time annotations (e.g. {@code @TaskHandler}) processed into typed task companions. */
+package org.byteveda.taskito.annotation;

--- a/sdks/java/src/main/java/org/byteveda/taskito/core/CoreFacade.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/core/CoreFacade.java
@@ -1,0 +1,79 @@
+package org.byteveda.taskito.core;
+
+import java.time.Duration;
+import java.util.Optional;
+import org.byteveda.taskito.TaskitoException;
+import org.byteveda.taskito.spi.QueueBackend;
+
+/**
+ * Translation + durable-emulation layer between the typed public API and the thin
+ * native {@link QueueBackend}. It speaks the core's wire terms (JSON strings,
+ * lowercase status) and is the home for behaviours the core does not provide
+ * natively — emulated durably (state in job metadata / the settings store), never
+ * in worker memory. Today it owns job-await polling; retry-backoff and the
+ * periodic catalog join it later.
+ */
+public final class CoreFacade {
+    private final QueueBackend backend;
+
+    public CoreFacade(QueueBackend backend) {
+        this.backend = backend;
+    }
+
+    public QueueBackend backend() {
+        return backend;
+    }
+
+    /**
+     * Poll until the job reaches a terminal state or {@code timeout} elapses,
+     * returning its final JSON view. Intended for tests — production code should
+     * use worker event hooks or webhooks. Throws on timeout.
+     */
+    public Optional<String> awaitJobJson(String jobId, Duration timeout, Duration pollInterval) {
+        long deadline = System.nanoTime() + timeout.toNanos();
+        while (true) {
+            Optional<String> view = backend.getJobJson(jobId);
+            if (view.isEmpty()) {
+                return Optional.empty();
+            }
+            if (isTerminal(view.get())) {
+                return view;
+            }
+            if (System.nanoTime() >= deadline) {
+                throw new TaskitoException("job '" + jobId + "' did not finish within " + timeout);
+            }
+            sleep(pollInterval);
+        }
+    }
+
+    /** Whether a job view's wire status is terminal (complete/failed/dead/cancelled). */
+    private static boolean isTerminal(String jobJson) {
+        String status = extractStatus(jobJson);
+        return "complete".equals(status)
+                || "completed".equals(status)
+                || "failed".equals(status)
+                || "dead".equals(status)
+                || "cancelled".equals(status);
+    }
+
+    /** Read the lowercase {@code "status"} field from a job view without a full parse. */
+    private static String extractStatus(String jobJson) {
+        int key = jobJson.indexOf("\"status\"");
+        if (key < 0) {
+            return "";
+        }
+        int colon = jobJson.indexOf(':', key);
+        int open = jobJson.indexOf('"', colon + 1);
+        int close = jobJson.indexOf('"', open + 1);
+        return open < 0 || close < 0 ? "" : jobJson.substring(open + 1, close);
+    }
+
+    private static void sleep(Duration interval) {
+        try {
+            Thread.sleep(interval.toMillis());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new TaskitoException("interrupted while awaiting a job", e);
+        }
+    }
+}

--- a/sdks/java/src/main/java/org/byteveda/taskito/core/package-info.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/core/package-info.java
@@ -1,0 +1,2 @@
+/** The translation + durable-emulation facade between the public API and the native seam. */
+package org.byteveda.taskito.core;

--- a/sdks/java/src/main/java/org/byteveda/taskito/locks/Lock.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/locks/Lock.java
@@ -1,6 +1,8 @@
 package org.byteveda.taskito.locks;
 
+import java.time.Duration;
 import java.util.UUID;
+import org.byteveda.taskito.TaskitoException;
 import org.byteveda.taskito.spi.QueueBackend;
 
 /**
@@ -25,6 +27,23 @@ public final class Lock implements AutoCloseable {
     public boolean acquire() {
         held = backend.acquireLock(name, ownerId, ttlMs);
         return held;
+    }
+
+    /** Acquire, retrying every 50ms until obtained or {@code timeout} elapses. */
+    public boolean tryAcquire(Duration timeout) {
+        long deadline = System.nanoTime() + timeout.toNanos();
+        while (!acquire()) {
+            if (System.nanoTime() >= deadline) {
+                return false;
+            }
+            try {
+                Thread.sleep(50);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new TaskitoException("interrupted while acquiring lock '" + name + "'", e);
+            }
+        }
+        return true;
     }
 
     /** Extend the TTL if still held; false otherwise. A failed extend means the

--- a/sdks/java/src/main/java/org/byteveda/taskito/serialization/EncryptedSerializer.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/serialization/EncryptedSerializer.java
@@ -1,5 +1,6 @@
 package org.byteveda.taskito.serialization;
 
+import java.lang.reflect.Type;
 import java.security.SecureRandom;
 import java.util.Arrays;
 import javax.crypto.Cipher;
@@ -45,6 +46,16 @@ public final class EncryptedSerializer implements Serializer {
 
     @Override
     public <T> T deserialize(byte[] bytes, Class<T> type) {
+        return delegate.deserialize(decrypt(bytes), type);
+    }
+
+    @Override
+    public Object deserialize(byte[] bytes, Type type) {
+        return delegate.deserialize(decrypt(bytes), type);
+    }
+
+    /** Strip the IV, decrypt + authenticate (GCM), and return the plaintext. */
+    private byte[] decrypt(byte[] bytes) {
         if (bytes.length < IV_LENGTH) {
             throw new TaskitoException("encrypted payload is too short");
         }
@@ -53,7 +64,7 @@ public final class EncryptedSerializer implements Serializer {
             byte[] ciphertext = Arrays.copyOfRange(bytes, IV_LENGTH, bytes.length);
             Cipher cipher = Cipher.getInstance(TRANSFORMATION);
             cipher.init(Cipher.DECRYPT_MODE, key, new GCMParameterSpec(TAG_BITS, iv));
-            return delegate.deserialize(cipher.doFinal(ciphertext), type);
+            return cipher.doFinal(ciphertext);
         } catch (Exception e) {
             throw new TaskitoException("decryption failed", e);
         }

--- a/sdks/java/src/main/java/org/byteveda/taskito/serialization/JsonSerializer.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/serialization/JsonSerializer.java
@@ -1,6 +1,7 @@
 package org.byteveda.taskito.serialization;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.lang.reflect.Type;
 import org.byteveda.taskito.TaskitoException;
 
 /** Default {@link Serializer}: JSON via Jackson. */
@@ -28,6 +29,15 @@ public final class JsonSerializer implements Serializer {
     public <T> T deserialize(byte[] bytes, Class<T> type) {
         try {
             return mapper.readValue(bytes, type);
+        } catch (Exception e) {
+            throw new TaskitoException("failed to deserialize payload", e);
+        }
+    }
+
+    @Override
+    public Object deserialize(byte[] bytes, Type type) {
+        try {
+            return mapper.readValue(bytes, mapper.getTypeFactory().constructType(type));
         } catch (Exception e) {
             throw new TaskitoException("failed to deserialize payload", e);
         }

--- a/sdks/java/src/main/java/org/byteveda/taskito/serialization/Serializer.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/serialization/Serializer.java
@@ -1,8 +1,25 @@
 package org.byteveda.taskito.serialization;
 
+import java.lang.reflect.Type;
+
 /** Converts task payloads and results to and from the opaque bytes the core stores. */
 public interface Serializer {
     byte[] serialize(Object value);
 
     <T> T deserialize(byte[] bytes, Class<T> type);
+
+    /**
+     * Deserialize to a possibly-generic {@link Type} (from a
+     * {@code TypeReference}). The default handles plain {@code Class} types and
+     * rejects generic ones; a generics-aware serializer (e.g. {@link JsonSerializer})
+     * overrides this.
+     */
+    default Object deserialize(byte[] bytes, Type type) {
+        if (type instanceof Class) {
+            return deserialize(bytes, (Class<?>) type);
+        }
+        throw new UnsupportedOperationException(getClass().getSimpleName()
+                + " does not support the generic payload type " + type
+                + "; use a Jackson-based serializer or a non-generic Task payload type");
+    }
 }

--- a/sdks/java/src/main/java/org/byteveda/taskito/serialization/SignedSerializer.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/serialization/SignedSerializer.java
@@ -1,5 +1,6 @@
 package org.byteveda.taskito.serialization;
 
+import java.lang.reflect.Type;
 import java.security.MessageDigest;
 import java.util.Arrays;
 import javax.crypto.Mac;
@@ -34,6 +35,16 @@ public final class SignedSerializer implements Serializer {
 
     @Override
     public <T> T deserialize(byte[] bytes, Class<T> type) {
+        return delegate.deserialize(verify(bytes), type);
+    }
+
+    @Override
+    public Object deserialize(byte[] bytes, Type type) {
+        return delegate.deserialize(verify(bytes), type);
+    }
+
+    /** Verify the HMAC tag (constant-time) and return the signed body. */
+    private byte[] verify(byte[] bytes) {
         if (bytes.length < MAC_LENGTH) {
             throw new TaskitoException("signed payload is too short");
         }
@@ -42,7 +53,7 @@ public final class SignedSerializer implements Serializer {
         if (!MessageDigest.isEqual(mac, mac(body))) {
             throw new TaskitoException("signature mismatch");
         }
-        return delegate.deserialize(body, type);
+        return body;
     }
 
     private byte[] mac(byte[] body) {

--- a/sdks/java/src/main/java/org/byteveda/taskito/task/EnqueueOptions.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/task/EnqueueOptions.java
@@ -49,6 +49,20 @@ public final class EnqueueOptions {
         return new Builder();
     }
 
+    /** A builder seeded with this instance's values, for deriving a modified copy. */
+    public Builder toBuilder() {
+        Builder b = new Builder();
+        b.queue = queue;
+        b.priority = priority;
+        b.maxRetries = maxRetries;
+        b.timeoutMs = timeoutMs;
+        b.delayMs = delayMs;
+        b.uniqueKey = uniqueKey;
+        b.metadata = metadata;
+        b.namespace = namespace;
+        return b;
+    }
+
     public static final class Builder {
         private String queue;
         private Integer priority;

--- a/sdks/java/src/main/java/org/byteveda/taskito/task/EnqueueOptions.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/task/EnqueueOptions.java
@@ -2,6 +2,7 @@ package org.byteveda.taskito.task;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Duration;
 
 /** Immutable per-enqueue options. Unset fields take core defaults. */
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -104,6 +105,24 @@ public final class EnqueueOptions {
                 throw new IllegalArgumentException("delayMs must be >= 0");
             }
             this.delayMs = delayMs;
+            return this;
+        }
+
+        /** Schedule the job after {@code delay} (Duration form of {@link #delayMs}). */
+        public Builder delay(Duration delay) {
+            this.delayMs = delay.toMillis();
+            return this;
+        }
+
+        /** Per-job timeout (Duration form of {@link #timeoutMs}). */
+        public Builder timeout(Duration timeout) {
+            this.timeoutMs = timeout.toMillis();
+            return this;
+        }
+
+        /** Idempotency key — alias of {@link #uniqueKey} in the guide's vocabulary. */
+        public Builder jobId(String jobId) {
+            this.uniqueKey = jobId;
             return this;
         }
 

--- a/sdks/java/src/main/java/org/byteveda/taskito/task/Task.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/task/Task.java
@@ -2,6 +2,7 @@ package org.byteveda.taskito.task;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.lang.reflect.Type;
+import java.time.Duration;
 import java.util.Objects;
 
 /**
@@ -52,12 +53,25 @@ public final class Task<T> {
         return withOptions(options.toBuilder().maxRetries(maxRetries).build());
     }
 
+    /** Alias of {@link #maxRetries} in the guide's vocabulary. */
+    public Task<T> retries(int retries) {
+        return maxRetries(retries);
+    }
+
     public Task<T> timeoutMs(long timeoutMs) {
         return withOptions(options.toBuilder().timeoutMs(timeoutMs).build());
     }
 
+    public Task<T> timeout(Duration timeout) {
+        return timeoutMs(timeout.toMillis());
+    }
+
     public Task<T> delayMs(long delayMs) {
         return withOptions(options.toBuilder().delayMs(delayMs).build());
+    }
+
+    public Task<T> delay(Duration delay) {
+        return delayMs(delay.toMillis());
     }
 
     public String name() {

--- a/sdks/java/src/main/java/org/byteveda/taskito/task/Task.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/task/Task.java
@@ -1,14 +1,22 @@
 package org.byteveda.taskito.task;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.lang.reflect.Type;
 import java.util.Objects;
 
-/** Typed task descriptor: a name, its payload type, and default enqueue options. */
+/**
+ * Typed task descriptor: a name, its payload type, and default enqueue options.
+ *
+ * <p>For generic payloads (e.g. {@code Map<String, Object>}) use the
+ * {@link TypeReference} factory, which {@code Class} tokens cannot express.
+ * The fluent option methods each return a new descriptor (the type is immutable).
+ */
 public final class Task<T> {
     private final String name;
-    private final Class<T> payloadType;
+    private final Type payloadType;
     private final EnqueueOptions options;
 
-    private Task(String name, Class<T> payloadType, EnqueueOptions options) {
+    private Task(String name, Type payloadType, EnqueueOptions options) {
         this.name = Objects.requireNonNull(name, "task name must not be null");
         if (name.trim().isEmpty()) {
             throw new IllegalArgumentException("task name must not be blank");
@@ -17,8 +25,14 @@ public final class Task<T> {
         this.options = Objects.requireNonNull(options, "options must not be null");
     }
 
+    /** A task whose payload deserializes to {@code payloadType}. */
     public static <T> Task<T> of(String name, Class<T> payloadType) {
         return new Task<>(name, payloadType, EnqueueOptions.none());
+    }
+
+    /** A task whose payload deserializes to a generic type, e.g. {@code new TypeReference<List<Foo>>(){}}. */
+    public static <T> Task<T> of(String name, TypeReference<T> payloadType) {
+        return new Task<>(name, payloadType.getType(), EnqueueOptions.none());
     }
 
     /** A copy of this task with the given default options. */
@@ -26,11 +40,32 @@ public final class Task<T> {
         return new Task<>(name, payloadType, options);
     }
 
+    public Task<T> queue(String queue) {
+        return withOptions(options.toBuilder().queue(queue).build());
+    }
+
+    public Task<T> priority(int priority) {
+        return withOptions(options.toBuilder().priority(priority).build());
+    }
+
+    public Task<T> maxRetries(int maxRetries) {
+        return withOptions(options.toBuilder().maxRetries(maxRetries).build());
+    }
+
+    public Task<T> timeoutMs(long timeoutMs) {
+        return withOptions(options.toBuilder().timeoutMs(timeoutMs).build());
+    }
+
+    public Task<T> delayMs(long delayMs) {
+        return withOptions(options.toBuilder().delayMs(delayMs).build());
+    }
+
     public String name() {
         return name;
     }
 
-    public Class<T> payloadType() {
+    /** The payload type — a {@code Class} or a generic {@code Type} from a {@link TypeReference}. */
+    public Type payloadType() {
         return payloadType;
     }
 

--- a/sdks/java/src/main/java/org/byteveda/taskito/worker/RegisteredTask.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/worker/RegisteredTask.java
@@ -1,13 +1,14 @@
 package org.byteveda.taskito.worker;
 
+import java.lang.reflect.Type;
 import org.byteveda.taskito.task.TaskFunction;
 
 /** A worker-registered handler: payload type plus the function to run. */
 final class RegisteredTask {
-    final Class<?> payloadType;
+    final Type payloadType;
     final TaskFunction<Object, Object> handler;
 
-    RegisteredTask(Class<?> payloadType, TaskFunction<Object, Object> handler) {
+    RegisteredTask(Type payloadType, TaskFunction<Object, Object> handler) {
         this.payloadType = payloadType;
         this.handler = handler;
     }

--- a/sdks/java/src/main/java/org/byteveda/taskito/worker/Worker.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/worker/Worker.java
@@ -110,7 +110,14 @@ public final class Worker implements AutoCloseable {
         }
 
         public <T, R> Builder handle(Task<T> task, TaskFunction<T, R> handler) {
-            return handle(task.name(), task.payloadType(), handler);
+            handlers.put(task.name(), new RegisteredTask(task.payloadType(), cast(handler)));
+            return this;
+        }
+
+        /** Apply a customizer to this builder (e.g. a generated {@code XxxTasks.bind}). */
+        public Builder apply(Consumer<Builder> customizer) {
+            customizer.accept(this);
+            return this;
         }
 
         public Builder queues(String... queues) {

--- a/sdks/java/src/main/java/org/byteveda/taskito/workflows/FanMode.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/workflows/FanMode.java
@@ -1,0 +1,14 @@
+package org.byteveda.taskito.workflows;
+
+/** Fan-out / fan-in strategy. The wire form is the lowercase name. */
+public enum FanMode {
+    /** Fan-out: run the step once per item of the predecessor's result list. */
+    EACH,
+    /** Fan-in: collect every fan-out child's result into one list. */
+    ALL;
+
+    /** Lowercase wire strategy string passed to the native layer. */
+    public String wire() {
+        return name().toLowerCase(java.util.Locale.ROOT);
+    }
+}

--- a/sdks/java/src/main/java/org/byteveda/taskito/workflows/Step.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/workflows/Step.java
@@ -98,10 +98,20 @@ public final class Step {
             return this;
         }
 
+        /** Run this step once per predecessor item using a {@link FanMode}. */
+        public Builder fanOut(FanMode mode) {
+            return fanOut(mode.wire());
+        }
+
         /** Collect a fan-out predecessor's child results into one list (strategy {@code "all"}). */
         public Builder fanIn(String strategy) {
             this.fanIn = strategy;
             return this;
+        }
+
+        /** Collect a fan-out predecessor's results using a {@link FanMode}. */
+        public Builder fanIn(FanMode mode) {
+            return fanIn(mode.wire());
         }
 
         public Step build() {

--- a/sdks/java/src/main/java/org/byteveda/taskito/workflows/Workflow.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/workflows/Workflow.java
@@ -50,6 +50,11 @@ public final class Workflow {
         return step(Step.of(name, task).fanOut(strategy).after(after).build());
     }
 
+    /** Fan-out with a {@link FanMode} (typically {@link FanMode#EACH}). */
+    public <T> Workflow fanOut(String name, Task<T> task, FanMode mode, String... after) {
+        return fanOut(name, task, mode.wire(), after);
+    }
+
     /**
      * Add a fan-in step that collects its fan-out predecessor's child results
      * into one list and passes it to {@code task}.
@@ -57,6 +62,11 @@ public final class Workflow {
     public <T> Workflow fanIn(String name, Task<T> task, String strategy, String... after) {
         requireSinglePredecessor("fan-in", name, after);
         return step(Step.of(name, task).fanIn(strategy).after(after).build());
+    }
+
+    /** Fan-in with a {@link FanMode} (typically {@link FanMode#ALL}). */
+    public <T> Workflow fanIn(String name, Task<T> task, FanMode mode, String... after) {
+        return fanIn(name, task, mode.wire(), after);
     }
 
     // A fan-out/fan-in node has exactly one runtime trigger — its single producer.

--- a/sdks/java/src/main/java/org/byteveda/taskito/workflows/WorkflowRun.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/workflows/WorkflowRun.java
@@ -7,7 +7,7 @@ import org.byteveda.taskito.TaskitoException;
 import org.byteveda.taskito.spi.QueueBackend;
 
 /** A submitted workflow run. Query {@link #status()}, block on {@link #await}, or {@link #cancel()}. */
-public final class WorkflowRun {
+public final class WorkflowRun implements AutoCloseable {
     private final QueueBackend backend;
     private final ObjectMapper json;
     private final String id;
@@ -21,6 +21,11 @@ public final class WorkflowRun {
     }
 
     public String id() {
+        return id;
+    }
+
+    /** Alias of {@link #id()} in the guide's vocabulary. */
+    public String runId() {
         return id;
     }
 
@@ -61,6 +66,12 @@ public final class WorkflowRun {
     /** Cancel the run: skip its pending nodes and mark it cancelled. */
     public void cancel() {
         backend.cancelWorkflowRun(id);
+    }
+
+    /** No native resources are held; provided so a run can be used in try-with-resources. */
+    @Override
+    public void close() {
+        // Intentionally empty — keeps the API consistent and future-proof.
     }
 
     private WorkflowStatus decode(String raw) {

--- a/sdks/java/src/main/java/org/byteveda/taskito/workflows/WorkflowStatus.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/workflows/WorkflowStatus.java
@@ -42,4 +42,12 @@ public final class WorkflowStatus {
     public Optional<NodeSnapshot> node(String nodeName) {
         return nodes.stream().filter(n -> n.nodeName.equals(nodeName)).findFirst();
     }
+
+    /** The name of the first failed node, if any (helps explain a {@code FAILED} run). */
+    public Optional<String> failedStep() {
+        return nodes.stream()
+                .filter(n -> n.status == NodeStatus.FAILED)
+                .map(n -> n.nodeName)
+                .findFirst();
+    }
 }

--- a/sdks/java/src/test/java/org/byteveda/taskito/AnnotationProcessorTest.java
+++ b/sdks/java/src/test/java/org/byteveda/taskito/AnnotationProcessorTest.java
@@ -1,0 +1,39 @@
+package org.byteveda.taskito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.byteveda.taskito.events.EventName;
+import org.byteveda.taskito.worker.Worker;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+class AnnotationProcessorTest {
+
+    @Test
+    @Timeout(30)
+    void generatedCompanionEnqueuesAndHandles(@TempDir Path dir) throws Exception {
+        try (Queue queue =
+                Taskito.builder().sqlite(dir.resolve("ap.db").toString()).open()) {
+            // GreeterTasks is generated from @TaskHandler on Greeter; GREET/TOTAL
+            // are typed Task constants (TOTAL carries the generic List<Integer>).
+            String greetId = queue.enqueue(GreeterTasks.GREET, "ada");
+            String totalId = queue.enqueue(GreeterTasks.TOTAL, List.of(1, 2, 3, 4));
+
+            CountDownLatch done = new CountDownLatch(2);
+            try (Worker worker = queue.worker()
+                    .apply(builder -> GreeterTasks.bind(builder, new Greeter()))
+                    .on(EventName.SUCCESS, event -> done.countDown())
+                    .start()) {
+                assertTrue(done.await(20, TimeUnit.SECONDS), "both tasks should complete");
+                assertEquals("hello ada", queue.getResult(greetId, String.class).orElseThrow());
+                assertEquals(10, queue.getResult(totalId, Integer.class).orElseThrow());
+            }
+        }
+    }
+}

--- a/sdks/java/src/test/java/org/byteveda/taskito/ErgonomicsTest.java
+++ b/sdks/java/src/test/java/org/byteveda/taskito/ErgonomicsTest.java
@@ -1,0 +1,58 @@
+package org.byteveda.taskito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import org.byteveda.taskito.locks.Lock;
+import org.byteveda.taskito.model.Job;
+import org.byteveda.taskito.model.JobStatus;
+import org.byteveda.taskito.task.Task;
+import org.byteveda.taskito.worker.Worker;
+import org.byteveda.taskito.workflows.FanMode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+class ErgonomicsTest {
+
+    @Test
+    @Timeout(30)
+    void awaitJobReturnsTerminalState(@TempDir Path dir) throws Exception {
+        Task<Integer> echo = Task.of("erg.echo", Integer.class).retries(0).timeout(Duration.ofSeconds(10));
+        try (Queue queue =
+                Taskito.builder().sqlite(dir.resolve("erg.db").toString()).open()) {
+            String id = queue.enqueue(echo, 42);
+            try (Worker worker = queue.worker().handle(echo, p -> p).start()) {
+                Job job = queue.awaitJob(id, Duration.ofSeconds(20)).orElseThrow();
+                assertEquals(JobStatus.COMPLETE, job.status);
+                assertEquals(42, queue.getResult(id, Integer.class).orElseThrow());
+            }
+        }
+    }
+
+    @Test
+    void fanModeWireStrings() {
+        assertEquals("each", FanMode.EACH.wire());
+        assertEquals("all", FanMode.ALL.wire());
+    }
+
+    @Test
+    @Timeout(30)
+    void lockSugar(@TempDir Path dir) {
+        try (Queue queue =
+                Taskito.builder().sqlite(dir.resolve("lock.db").toString()).open()) {
+            try (Lock lock = queue.lock("erg-lock")) { // default-TTL overload
+                assertTrue(lock.tryAcquire(Duration.ofSeconds(1)));
+                assertTrue(queue.getLockInfo("erg-lock").isPresent());
+            }
+            // released by close(); a fresh holder can re-acquire immediately
+            try (Lock again = queue.lock("erg-lock", 5_000)) {
+                assertTrue(again.acquire());
+            }
+            assertFalse(queue.getLockInfo("erg-lock").isPresent());
+        }
+    }
+}

--- a/sdks/java/src/test/java/org/byteveda/taskito/Greeter.java
+++ b/sdks/java/src/test/java/org/byteveda/taskito/Greeter.java
@@ -1,0 +1,18 @@
+package org.byteveda.taskito;
+
+import java.util.List;
+import org.byteveda.taskito.annotation.TaskHandler;
+
+/** Test fixture: the {@code @TaskHandler} processor turns this into a generated {@code GreeterTasks}. */
+class Greeter {
+
+    @TaskHandler("greet")
+    String greet(String name) {
+        return "hello " + name;
+    }
+
+    @TaskHandler
+    Integer total(List<Integer> numbers) {
+        return numbers.stream().mapToInt(Integer::intValue).sum();
+    }
+}


### PR DESCRIPTION
Eighth of the Java SDK split series (follows #306). Producer-API ergonomics, a compile-time `@TaskHandler` processor, and the `CoreFacade` translation seam.

## What's here

- **Type-carrying tasks**: `Task<T>` now holds a `java.lang.reflect.Type` — `Task.of(name, Class)` for simple payloads and `Task.of(name, TypeReference)` for generics like `Map<String,Object>` that a `Class` token can't express. `Serializer.deserialize(byte[], Type)` added; `JsonSerializer` resolves it via the Jackson `TypeFactory`.
- **Fluent options on the task**: `task.queue(...).priority(...).maxRetries(...)/.retries(...).timeout(Duration)/.timeoutMs(...).delay(Duration)/.delayMs(...)` — each returns a new immutable descriptor. `FanMode` enum for fan-out/fan-in; `Lock.tryAcquire(Duration)`; `WorkflowRun` is `AutoCloseable` with `runId()`/`failedStep()`.
- **`@TaskHandler` compile-time processor**: a SOURCE-retention annotation + a standalone `:processor` Gradle subproject (an `AbstractProcessor` reading the `AnnotationMirror` structurally, so no dependency cycle). It generates a `<Class>Tasks` companion with typed `Task` constants + a `bind(Worker.Builder, impl)` — zero runtime reflection, GraalVM-clean.
- **`CoreFacade`**: a translation seam between `DefaultQueue` and the `QueueBackend`, with `awaitJob(...)` polling helpers — the foundation for later durable emulation.

## Verification

Full `./gradlew build --no-daemon` passes for both the root project and the new `:processor` subproject: compile + Spotless + Checkstyle + tests (`ErgonomicsTest`, `AnnotationProcessorTest`).

> Conflict notes: resolved cherry-pick conflicts by keeping BOTH the prior review fixes and the new features — `Task.java` (#299 validation + the `Type` rewrite + `Duration` overloads), `Workflow.java` (#306 `requireSinglePredecessor` + `FanMode` overloads), `Lock.java` (#303 `extend` semantics + `tryAcquire`).
