### PR TITLE
ci: test Java SDK across JDK matrix + platforms

### DIFF
--- a/.github/actions/setup-java/action.yml
+++ b/.github/actions/setup-java/action.yml
@@ -15,7 +15,7 @@ runs:
   using: composite
   steps:
     - name: Install JDK + Gradle cache
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: temurin
         java-version: ${{ inputs.java-version }}

--- a/.github/workflows/ci-java.yml
+++ b/.github/workflows/ci-java.yml
@@ -1,9 +1,9 @@
 name: CI Java
 
-# Reusable workflow: build the JNI cdylib (via Gradle's cargoBuild) and run the
-# Java SDK's full `gradle build` — compile, Spotless + Checkstyle, and the JUnit
-# suite across the runtime, processor, and test-support subprojects. Called by
-# ci.yml when Java-relevant paths change.
+# Reusable workflow for the Java SDK. The JNI cdylib is built once (it's
+# identical for every consumer JDK), then the full `gradle build` — compile
+# (`--release 11`), Spotless + Checkstyle, and the JUnit suite — runs against
+# each supported JDK runtime. Called by ci.yml when Java-relevant paths change.
 on:
   workflow_call:
 
@@ -15,8 +15,11 @@ env:
   CARGO_NET_RETRY: "10"
 
 jobs:
-  java-test:
-    name: Java SDK Tests
+  # Compile the native library once and hand it to every test leg as an
+  # artifact. The .so does not depend on the JDK, so rebuilding it per matrix
+  # entry would only burn runner minutes.
+  native:
+    name: Build native library
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
@@ -25,12 +28,49 @@ jobs:
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
 
+      - name: Build the JNI cdylib
+        run: cargo build --release --features postgres,redis,workflows -p taskito-java
+
+      - name: Upload the cdylib
+        uses: actions/upload-artifact@v7
+        with:
+          name: taskito-java-native
+          path: target/release/libtaskito_java.so
+          if-no-files-found: error
+          retention-days: 1
+
+  # Run compile + lint + the JUnit suite on every supported JDK runtime. The
+  # SDK targets Java 11 but is consumed on 11/17/21 and loads a native .so, so
+  # JVM behaviour is runtime-sensitive — green on one JDK is not green on all.
+  # fail-fast is off so one JDK's failures don't mask another's.
+  test:
+    name: Java SDK Tests (JDK ${{ matrix.java }})
+    needs: native
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java: ["11", "17", "21"]
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
       - name: Set up Java + Gradle
         uses: ./.github/actions/setup-java
+        with:
+          java-version: ${{ matrix.java }}
 
-      # `gradle build` runs cargoBuild (the JNI cdylib), staging the native
-      # library into the jar, then compile + Spotless + Checkstyle + tests for
-      # every subproject. --no-daemon keeps the runner clean.
+      # Stage the prebuilt library where Gradle's copyNative expects it
+      # (../../target/release from sdks/java), so the build needs no Rust.
+      - name: Download the cdylib
+        uses: actions/download-artifact@v8
+        with:
+          name: taskito-java-native
+          path: target/release
+
+      # `-x cargoBuild` skips the Rust compile; copyNative still stages the
+      # downloaded .so into the jar before compile + Spotless + Checkstyle +
+      # tests run. --no-daemon keeps the runner clean.
       - name: Build and test the Java SDK
         working-directory: sdks/java
-        run: ./gradlew build --no-daemon
+        run: ./gradlew build -x cargoBuild --no-daemon

--- a/.github/workflows/ci-java.yml
+++ b/.github/workflows/ci-java.yml
@@ -1,9 +1,8 @@
 name: CI Java
 
-# Reusable workflow for the Java SDK. The JNI cdylib is built once (it's
-# identical for every consumer JDK), then the full `gradle build` — compile
-# (`--release 11`), Spotless + Checkstyle, and the JUnit suite — runs against
-# each supported JDK runtime. Called by ci.yml when Java-relevant paths change.
+# Reusable Java SDK workflow: Linux runs the full `gradle build` across every
+# JDK (sharing one prebuilt cdylib); a smoke build covers the other published
+# platforms. Called by ci.yml when Java-relevant paths change.
 on:
   workflow_call:
 
@@ -15,9 +14,7 @@ env:
   CARGO_NET_RETRY: "10"
 
 jobs:
-  # Compile the native library once and hand it to every test leg as an
-  # artifact. The .so does not depend on the JDK, so rebuilding it per matrix
-  # entry would only burn runner minutes.
+  # Build the JDK-independent cdylib once; test legs reuse it as an artifact.
   native:
     name: Build native library
     runs-on: ubuntu-latest
@@ -39,10 +36,8 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  # Run compile + lint + the JUnit suite on every supported JDK runtime. The
-  # SDK targets Java 11 but is consumed on 11/17/21 and loads a native .so, so
-  # JVM behaviour is runtime-sensitive — green on one JDK is not green on all.
-  # fail-fast is off so one JDK's failures don't mask another's.
+  # Build + test on every supported JDK; the SDK targets 11 but runs on 11/17/21
+  # over a native .so, so JVM behaviour is runtime-sensitive.
   test:
     name: Java SDK Tests (JDK ${{ matrix.java }})
     needs: native
@@ -60,17 +55,49 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
 
-      # Stage the prebuilt library where Gradle's copyNative expects it
-      # (../../target/release from sdks/java), so the build needs no Rust.
+      # Stage the prebuilt .so where copyNative expects it, so no Rust is needed.
       - name: Download the cdylib
         uses: actions/download-artifact@v8
         with:
           name: taskito-java-native
           path: target/release
 
-      # `-x cargoBuild` skips the Rust compile; copyNative still stages the
-      # downloaded .so into the jar before compile + Spotless + Checkstyle +
-      # tests run. --no-daemon keeps the runner clean.
+      # -x cargoBuild skips the Rust compile; copyNative still stages the .so.
       - name: Build and test the Java SDK
         working-directory: sdks/java
         run: ./gradlew build -x cargoBuild --no-daemon
+
+  # Smoke the other published platforms on one JDK: their native binary differs,
+  # so they rebuild it (cargoBuild) instead of reusing the Linux artifact.
+  smoke:
+    name: Java SDK Smoke (${{ matrix.classifier }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - classifier: osx-aarch64
+            runner: macos-15
+          - classifier: windows-x86_64
+            runner: windows-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      # Vendored OpenSSL needs Perl; point openssl-sys at Strawberry Perl.
+      - name: Point vendored OpenSSL at Strawberry Perl (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: echo "OPENSSL_SRC_PERL=C:/Strawberry/perl/bin/perl.exe" >> "$GITHUB_ENV"
+
+      - name: Set up Rust
+        uses: ./.github/actions/setup-rust
+
+      - name: Set up Java + Gradle
+        uses: ./.github/actions/setup-java
+
+      # bash so `./gradlew` runs uniformly on the Windows runner too.
+      - name: Build and test the Java SDK
+        working-directory: sdks/java
+        shell: bash
+        run: ./gradlew build --no-daemon

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -10,14 +10,15 @@ jobs:
     permissions:
       actions: write
     steps:
-      - uses: actions/checkout@v7
-
+      # Delete every cache scoped to the PR's merge ref in one call. --all avoids
+      # `gh cache list`'s 30-entry cap; --succeed-on-no-caches exits 0 when the
+      # PR left none, without masking real failures the way `|| true` would.
       - name: Delete PR branch caches
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: refs/pull/${{ github.event.pull_request.number }}/merge
-        run: |
-          echo "Deleting caches for branch: $BRANCH"
-          gh cache list --ref "$BRANCH" --json id --jq '.[].id' |
-            xargs -I {} gh cache delete {} --repo "${{ github.repository }}" || true
-          echo "Done"
+        run: >-
+          gh cache delete --all
+          --ref "$BRANCH"
+          --repo "${{ github.repository }}"
+          --succeed-on-no-caches

--- a/.github/workflows/publish-java.yml
+++ b/.github/workflows/publish-java.yml
@@ -126,7 +126,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "21"


### PR DESCRIPTION
## What

- Bump `actions/setup-java@v4` → `v5` (Node 24; clears the Node 20 deprecation warning).
- Run the Java SDK CI across **JDK 11/17/21** instead of only 21.
- Smoke-build the other published platforms (**macOS arm64**, **Windows x86_64**).

## Why

SDK targets Java 11 but is consumed on 11/17/21 and loads a native JNI binary — JVM behaviour is runtime-sensitive (JPMS encapsulation, `SecurityManager` removal in 21+, reflection). Green on one JDK/platform is not green on all.

## Design (optimized)

The cdylib is JDK-independent, so on Linux it's built **once** and handed to every JDK leg as an artifact — no per-leg cargo rebuild:

- `native` job: `cargo build -p taskito-java --features postgres,redis,workflows` → uploads `libtaskito_java.so`.
- `test` matrix `[11, 17, 21]`, `fail-fast: false`: downloads the `.so`, runs `./gradlew build -x cargoBuild`. No Rust on test legs; `copyNative` still stages the prebuilt library.
- `smoke` matrix `[osx-aarch64, windows-x86_64]` on JDK 21: native binary is platform-specific (`.dylib`/`.dll`), so these legs run the **real** `cargoBuild` + full suite. Windows points `OPENSSL_SRC_PERL` at Strawberry Perl for vendored OpenSSL.

Feature flags match: the `native` job's `--features postgres,redis,workflows` mirrors Gradle's `cargoBuild` (`build.gradle.kts:103`) exactly, so the artifact reused on Linux is what a real `gradle build` / the publish pipeline ships.

## Verification (live in this PR's checks)

- `Java / Build native library` ✅
- `Java / Java SDK Tests (JDK 11 | 17 | 21)` ✅ — artifact upload → download round-trip exercised; downloaded `.so` resolved where `copyNative` expects (repo-root `target/release`).
- `Java / Java SDK Smoke (osx-aarch64)` ✅
- `Java / Java SDK Smoke (windows-x86_64)` ✅ — real cargoBuild + vendored OpenSSL on Windows.

## Notes

- **Branch protection**: required-check names change. Add:
  - `Java / Build native library`
  - `Java / Java SDK Tests (JDK 11)`, `(JDK 17)`, `(JDK 21)`
  - `Java / Java SDK Smoke (osx-aarch64)`, `(windows-x86_64)`
  - Drop the old `Java / Java SDK Tests`.
- **Coverage**: linux-x86_64 (×3 JDK) + osx-aarch64 + windows-x86_64 tested. `linux-aarch64` + `osx-x86_64` remain publish-only (built in `publish-java.yml`, not CI-gated).
- **JDK 25 omitted** — Gradle 8.12 can't run on it; needs a wrapper bump first.
- **`smoke` is the heavy leg** (full build + Rust-from-scratch + Windows OpenSSL-from-source, a known flakiness source). Intentional; worth watching.