### PR TITLE
ci: scope composite-action path filters to their suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,29 +41,36 @@ jobs:
         uses: dorny/paths-filter@v4
         with:
           # Each suite reruns when its own sources, the shared Rust core, the
-          # composite actions, or its workflow (orchestrator + reusable) change.
+          # composite actions it actually uses, or its workflow change. Only
+          # setup-rust is shared by every suite; the other actions map to a
+          # single suite, so they no longer rerun all four.
           filters: |
             shared: &shared
               - 'crates/**'
               - 'Cargo.toml'
               - 'Cargo.lock'
-              - '.github/actions/**'
+              - '.github/actions/setup-rust/**'
               - '.github/workflows/ci.yml'
             rust:
               - *shared
+              - '.github/actions/rust-prelude/**'
+              - '.github/actions/setup-python/**'
               - 'rust-toolchain.toml'
               - '.github/workflows/ci-rust.yml'
             python:
               - *shared
+              - '.github/actions/setup-python/**'
               - 'sdks/python/**'
               - '.github/workflows/ci-python.yml'
             node:
               - *shared
+              - '.github/actions/setup-node/**'
               - 'sdks/node/**'
               - 'dashboard/**'
               - '.github/workflows/ci-node.yml'
             java:
               - *shared
+              - '.github/actions/setup-java/**'
               - 'sdks/java/**'
               - '.github/workflows/ci-java.yml'
 


### PR DESCRIPTION
## What

Narrow the `changes` job's path filters so a composite-action edit only reruns the suites that actually use it.

## Why

`shared` matched `.github/actions/**`, and every suite includes `*shared` — so editing **any** composite action (e.g. `setup-java`) reran rust + python + node + java. The `setup-java@v5` bump in #309 fired the whole Python/Node matrix for nothing.

Research consensus: over-triggering wastes minutes, under-triggering ships untested bugs. Narrowing is safe **only** for single-consumer actions; the map was grep-verified:

| action | consumers |
|---|---|
| `setup-rust` | rust, python, node, java → stays in `shared` |
| `setup-python` | rust, python |
| `rust-prelude` | rust |
| `setup-node` | node |
| `setup-java` | java |

## Change

`shared` keeps only `setup-rust`; each suite lists the actions it consumes. No suite loses a dependency it had (no under-trigger), single-consumer actions stop fanning out to all four (no over-trigger).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI change-detection so jobs run only for the suites and workflow files they actually relate to.
  * Reduced unnecessary CI reruns by narrowing shared triggers and adding suite-specific workflow/action paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->