### PR TITLE
ci: verify the Java SDK under GraalVM native-image

### DIFF
--- a/.github/workflows/ci-java.yml
+++ b/.github/workflows/ci-java.yml
@@ -101,3 +101,31 @@ jobs:
         working-directory: sdks/java
         shell: bash
         run: ./gradlew build --no-daemon
+
+  # Prove the SDK works under GraalVM native-image: run the smoke under the
+  # tracing agent to collect JNI/reflection/resource metadata, then build a
+  # native image with it and run the binary.
+  graalvm:
+    name: Java SDK GraalVM native-image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Rust
+        uses: ./.github/actions/setup-rust
+
+      - name: Set up GraalVM
+        uses: graalvm/setup-graalvm@v1
+        with:
+          java-version: "21"
+          distribution: graalvm
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Collect metadata, build, and run the native image
+        working-directory: sdks/java
+        run: |
+          ./gradlew -Pagent :graalvm-smoke:run --no-daemon
+          ./gradlew :graalvm-smoke:metadataCopy --no-daemon
+          ./gradlew :graalvm-smoke:nativeCompile --no-daemon
+          ./graalvm-smoke/build/native/nativeCompile/graalvm-smoke

--- a/sdks/java/.gitignore
+++ b/sdks/java/.gitignore
@@ -1,3 +1,6 @@
 .gradle/
 build/
 bin/
+
+# Agent-generated GraalVM metadata for the smoke (regenerated in CI).
+graalvm-smoke/src/main/resources/META-INF/native-image/

--- a/sdks/java/graalvm-smoke/build.gradle.kts
+++ b/sdks/java/graalvm-smoke/build.gradle.kts
@@ -1,0 +1,57 @@
+// A throwaway consumer that drives the SDK's JNI + Jackson paths end to end.
+// CI builds it into a GraalVM native image to verify the reachability metadata
+// the runtime ships. Not published; not part of the SDK artifact.
+plugins {
+    application
+    checkstyle
+    id("com.diffplug.spotless") version "6.25.0"
+    id("org.graalvm.buildtools.native") version "0.10.6"
+}
+
+group = "org.byteveda"
+version = "0.16.4"
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation(project(":"))
+}
+
+application {
+    mainClass.set("org.byteveda.taskito.graalvm.Smoke")
+}
+
+graalvmNative {
+    binaries.named("main") {
+        // Fail the build on missing metadata rather than emitting a fallback image.
+        buildArgs.add("--no-fallback")
+    }
+    // CI runs the smoke under the tracing agent (`-Pagent :graalvm-smoke:run`)
+    // then `metadataCopy` to populate this module's resources, so `nativeCompile`
+    // sees the JNI/reflection metadata the SDK's JNI + Jackson paths require.
+    agent {
+        metadataCopy {
+            inputTaskNames.add("run")
+            outputDirectories.add("src/main/resources/META-INF/native-image")
+            mergeWithExisting.set(true)
+        }
+    }
+}
+
+spotless {
+    java {
+        target("src/**/*.java")
+        palantirJavaFormat("2.50.0")
+        removeUnusedImports()
+        trimTrailingWhitespace()
+        endWithNewline()
+    }
+}
+
+checkstyle {
+    toolVersion = "10.21.4"
+    configFile = file("../config/checkstyle/checkstyle.xml")
+    isIgnoreFailures = false
+}

--- a/sdks/java/graalvm-smoke/src/main/java/org/byteveda/taskito/graalvm/Smoke.java
+++ b/sdks/java/graalvm-smoke/src/main/java/org/byteveda/taskito/graalvm/Smoke.java
@@ -1,0 +1,61 @@
+package org.byteveda.taskito.graalvm;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.byteveda.taskito.Queue;
+import org.byteveda.taskito.Taskito;
+import org.byteveda.taskito.events.EventName;
+import org.byteveda.taskito.scheduling.PeriodicTask;
+import org.byteveda.taskito.task.Task;
+import org.byteveda.taskito.worker.Worker;
+
+/**
+ * Drives the SDK's JNI dispatch and Jackson (de)serialization end to end so a
+ * GraalVM native image of this class proves the shipped reachability metadata is
+ * complete. Exits non-zero on any failure.
+ */
+public final class Smoke {
+
+    private Smoke() {}
+
+    public static void main(String[] args) throws Exception {
+        Path dir = Files.createTempDirectory("taskito-graalvm-smoke");
+        Task<String> echo = Task.of("echo", String.class);
+
+        try (Queue queue = Taskito.builder()
+                .backend("sqlite")
+                .url(dir.resolve("smoke.db").toString())
+                .open()) {
+            String id = queue.enqueue(echo, "graalvm");
+
+            CountDownLatch done = new CountDownLatch(1);
+            try (Worker worker = queue.worker()
+                    .handle(echo, (String payload) -> payload.length())
+                    .on(EventName.SUCCESS, event -> done.countDown())
+                    .start()) {
+                if (!done.await(20, TimeUnit.SECONDS)) {
+                    throw new IllegalStateException("task did not complete");
+                }
+            }
+
+            byte[] result = queue.getResult(id).orElseThrow(() -> new IllegalStateException("no result persisted"));
+            String value = new String(result, StandardCharsets.UTF_8);
+            if (!"7".equals(value)) {
+                throw new IllegalStateException("unexpected result: " + value);
+            }
+
+            // Exercise the Jackson DTO paths (PeriodicInfo + DeadJob deserialization).
+            queue.registerPeriodic(
+                    PeriodicTask.builder("nightly", "echo", "0 0 0 * * *").build());
+            if (queue.listPeriodic().isEmpty()) {
+                throw new IllegalStateException("listPeriodic returned empty");
+            }
+            queue.listDead(10, 0);
+
+            System.out.println("taskito graalvm smoke ok");
+        }
+    }
+}

--- a/sdks/java/settings.gradle.kts
+++ b/sdks/java/settings.gradle.kts
@@ -2,3 +2,4 @@ rootProject.name = "taskito"
 
 include(":processor")
 include(":test-support")
+include(":graalvm-smoke")


### PR DESCRIPTION
## What

P15 (GraalVM): prove the Java SDK builds and runs under GraalVM `native-image`. The SDK uses JNI + Jackson reflection that native-image can't infer statically, so this adds a CI job that generates the reachability metadata with the tracing agent and verifies it against a real native binary.

## How (web-backed library flow)

Per the [native-build-tools docs](https://graalvm.github.io/native-build-tools/latest/gradle-plugin.html), metadata is collected with the tracing agent and a smoke consumer verifies it:

- **`:graalvm-smoke`** — a non-published subproject with a `Smoke` main that drives the SDK end to end (open SQLite queue → enqueue → run a worker → `getResult` → `registerPeriodic`/`listPeriodic` → `listDead`), exercising the JNI dispatch and every Jackson DTO path.
- **CI `graalvm` job** — `setup-graalvm`, then `-Pagent :graalvm-smoke:run` (collect JNI/reflection/resource metadata) → `metadataCopy` → `nativeCompile --no-fallback` → run the native binary, which prints `taskito graalvm smoke ok`.

The agent/native-image tasks live in the smoke subproject, **not** the published root — applying the plugin to the root collided with the `maven-publish` `sourcesJar` task.

## Verification

- `:graalvm-smoke:run` is green **on the JVM locally** (real JNI + Jackson) — proves the smoke logic; only `nativeCompile` needs the GraalVM toolchain, which runs in CI.
- Full `./gradlew build` green with the new subproject (compile + Spotless + Checkstyle).
- No local GraalVM toolchain here, so the native-image build itself is verified by this PR's CI run.

## Notes / follow-ups

- Shipping the conditional metadata inside the **published SDK jar** (so consumers get it automatically) is a follow-up once the generated metadata is reviewed from a green CI run.
- Maven Central publish (the other half of P15) is a separate, user-gated release action (`publish-java.yml` already wired).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Java smoke-test build for GraalVM native image support.
  * Included a new native executable check that runs end-to-end in CI.

* **Bug Fixes**
  * Improved native-image compatibility by generating and reusing required metadata during the build.
  * Ensured the Java SDK smoke flow validates task execution, persistence, and periodic task handling.

* **Chores**
  * Updated project configuration to include the new Java smoke-test module and ignore generated build artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->