### PR TITLE
chore: release 0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,35 @@
 
 All notable changes to taskito are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the project follows
-[Semantic Versioning](https://semver.org/spec/v2.0.0.html). All SDKs (Python, Node) and the
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html). All SDKs (Python, Node, Java) and the
 underlying Rust crates are released together, in lock-step.
+
+## 0.17.0
+
+Feature release across the SDKs: periodic-task management, task-scoped dead-letter queries, and
+the first **Java SDK** release.
+
+### Added
+
+- **Java SDK.** First release, published to Maven Central as `org.byteveda:taskito`. A JNI binding
+  over the Taskito core with the full producer / worker / inspection / admin surface, workflows,
+  distributed locks, periodic tasks, an in-memory `taskito-test` backend, and a `@TaskHandler`
+  annotation processor. Verified under GraalVM `native-image`.
+- **Periodic task management.** List, unschedule, pause, and resume registered cron tasks —
+  `listPeriodic` / `deletePeriodic` / `pausePeriodic` / `resumePeriodic` (Java, Node) and the
+  equivalent native bindings (Python). Pause toggles the task's `enabled` flag without removing it
+  (#313).
+- **Per-task dead-letter queries.** List and purge dead-letter entries scoped to a single task —
+  `listDeadByTask` / `purgeDeadByTask` (Java), `deadLettersByTask` / `purgeDeadByTask` (Node), and
+  native bindings (Python). Filtering happens server-side so pagination stays correct (#314).
+- **Per-task retry backoff (Java).** `Task.retryPolicy(...)` surfaces the core retry engine's
+  backoff curve — exponential with jitter, or exact explicit delays — with the retry budget still
+  set per enqueue (#311).
+
+### Changed
+
+- **Node now requires Node.js 20+.** Node 18 reached end-of-life; the test toolchain (vitest 4)
+  requires Node 20.12+. The `engines` floor and tsup target were raised accordingly (#312).
 
 ## 0.16.4
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1481,7 +1481,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "taskito-core"
-version = "0.16.4"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1505,7 +1505,7 @@ dependencies = [
 
 [[package]]
 name = "taskito-java"
-version = "0.16.4"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
@@ -1523,7 +1523,7 @@ dependencies = [
 
 [[package]]
 name = "taskito-mesh"
-version = "0.16.4"
+version = "0.17.0"
 dependencies = [
  "base64",
  "bincode",
@@ -1538,7 +1538,7 @@ dependencies = [
 
 [[package]]
 name = "taskito-node"
-version = "0.16.4"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
@@ -1557,7 +1557,7 @@ dependencies = [
 
 [[package]]
 name = "taskito-python"
-version = "0.16.4"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -1577,7 +1577,7 @@ dependencies = [
 
 [[package]]
 name = "taskito-workflows"
-version = "0.16.4"
+version = "0.17.0"
 dependencies = [
  "dagron-core",
  "diesel",

--- a/crates/taskito-core/Cargo.toml
+++ b/crates/taskito-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-core"
-version = "0.16.4"
+version = "0.17.0"
 edition = "2021"
 
 [features]

--- a/crates/taskito-java/Cargo.toml
+++ b/crates/taskito-java/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-java"
-version = "0.16.4"
+version = "0.17.0"
 edition = "2021"
 description = "Java (JNI) bindings for the Taskito task-queue core"
 license = "MIT"

--- a/crates/taskito-mesh/Cargo.toml
+++ b/crates/taskito-mesh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-mesh"
-version = "0.16.4"
+version = "0.17.0"
 edition = "2021"
 
 [dependencies]

--- a/crates/taskito-node/Cargo.toml
+++ b/crates/taskito-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-node"
-version = "0.16.4"
+version = "0.17.0"
 edition = "2021"
 description = "Node.js (napi-rs) bindings for the Taskito task-queue core"
 license = "MIT"

--- a/crates/taskito-python/Cargo.toml
+++ b/crates/taskito-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-python"
-version = "0.16.4"
+version = "0.17.0"
 edition = "2021"
 
 [features]

--- a/crates/taskito-workflows/Cargo.toml
+++ b/crates/taskito-workflows/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-workflows"
-version = "0.16.4"
+version = "0.17.0"
 edition = "2021"
 
 [features]

--- a/docs/app/components/landing/hero.tsx
+++ b/docs/app/components/landing/hero.tsx
@@ -92,9 +92,12 @@ export function Hero() {
                 onClick={() => setSdk(p.id === "ts" ? "node" : "python")}
               >
                 {p.label}
-                {p.id === "ts" ? <span className="tag beta">Beta</span> : null}
               </button>
             ))}
+            <button type="button" className="langtab" disabled>
+              Java
+              <span className="tag soon">Soon</span>
+            </button>
             <CopyButton text={active.code} />
           </div>
           <div id="hero-panes">

--- a/docs/app/styles/landing.css
+++ b/docs/app/styles/landing.css
@@ -375,6 +375,13 @@ main {
 .langtab:hover {
   color: var(--txt2);
 }
+.langtab:disabled {
+  cursor: default;
+  opacity: 0.65;
+}
+.langtab:disabled:hover {
+  color: var(--dim);
+}
 .langtab.active {
   color: var(--txt);
   background: var(--panel3);

--- a/docs/app/styles/landing.css
+++ b/docs/app/styles/landing.css
@@ -372,15 +372,12 @@ main {
     background 0.15s,
     border-color 0.15s;
 }
-.langtab:hover {
+.langtab:not(:disabled):hover {
   color: var(--txt2);
 }
 .langtab:disabled {
   cursor: default;
   opacity: 0.65;
-}
-.langtab:disabled:hover {
-  color: var(--dim);
 }
 .langtab.active {
   color: var(--txt);

--- a/docs/content/docs/resources/changelog.mdx
+++ b/docs/content/docs/resources/changelog.mdx
@@ -7,8 +7,35 @@ description: "Release history for taskito — every notable change, fix, and fea
 
 All notable changes to taskito are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the project follows
-[Semantic Versioning](https://semver.org/spec/v2.0.0.html). All SDKs (Python, Node) and the
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html). All SDKs (Python, Node, Java) and the
 underlying Rust crates are released together, in lock-step.
+
+## 0.17.0
+
+Feature release across the SDKs: periodic-task management, task-scoped dead-letter queries, and
+the first **Java SDK** release.
+
+### Added
+
+- **Java SDK.** First release, published to Maven Central as `org.byteveda:taskito`. A JNI binding
+  over the Taskito core with the full producer / worker / inspection / admin surface, workflows,
+  distributed locks, periodic tasks, an in-memory `taskito-test` backend, and a `@TaskHandler`
+  annotation processor. Verified under GraalVM `native-image`.
+- **Periodic task management.** List, unschedule, pause, and resume registered cron tasks —
+  `listPeriodic` / `deletePeriodic` / `pausePeriodic` / `resumePeriodic` (Java, Node) and the
+  equivalent native bindings (Python). Pause toggles the task's `enabled` flag without removing it
+  (#313).
+- **Per-task dead-letter queries.** List and purge dead-letter entries scoped to a single task —
+  `listDeadByTask` / `purgeDeadByTask` (Java), `deadLettersByTask` / `purgeDeadByTask` (Node), and
+  native bindings (Python). Filtering happens server-side so pagination stays correct (#314).
+- **Per-task retry backoff (Java).** `Task.retryPolicy(...)` surfaces the core retry engine's
+  backoff curve — exponential with jitter, or exact explicit delays — with the retry budget still
+  set per enqueue (#311).
+
+### Changed
+
+- **Node now requires Node.js 20+.** Node 18 reached end-of-life; the test toolchain (vitest 4)
+  requires Node 20.12+. The `engines` floor and tsup target were raised accordingly (#312).
 
 ## 0.16.4
 
@@ -478,6 +505,9 @@ migration steps, rolling-upgrade notes, and the downgrade floor.
 
 ---
 
+<details>
+<summary>Older releases (0.1.0 – 0.10.0)</summary>
+
 ## 0.10.0
 
 ### Features
@@ -590,8 +620,6 @@ migration steps, rolling-upgrade notes, and the downgrade floor.
 
 ---
 
-<details>
-<summary>Older releases (0.1.0 – 0.5.0)</summary>
 
 ## 0.5.0
 

--- a/sdks/java/build.gradle.kts
+++ b/sdks/java/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "org.byteveda"
-version = "0.16.4"
+version = "0.17.0"
 
 java {
     // Sources + javadoc jars are added by the maven-publish plugin below.

--- a/sdks/java/graalvm-smoke/build.gradle.kts
+++ b/sdks/java/graalvm-smoke/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "org.byteveda"
-version = "0.16.4"
+version = "0.17.0"
 
 repositories {
     mavenCentral()

--- a/sdks/java/processor/build.gradle.kts
+++ b/sdks/java/processor/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "org.byteveda"
-version = "0.16.4"
+version = "0.17.0"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_11

--- a/sdks/java/test-support/build.gradle.kts
+++ b/sdks/java/test-support/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "org.byteveda"
-version = "0.16.4"
+version = "0.17.0"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_11

--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byteveda/taskito",
-  "version": "0.16.4",
+  "version": "0.17.0",
   "description": "Rust-powered task queue for Node.js — no broker required.",
   "license": "MIT",
   "type": "module",

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "taskito"
-version = "0.16.4"
+version = "0.17.0"
 description = "Rust-powered task queue for Python. No broker required."
 requires-python = ">=3.10"
 license = { file = "LICENSE" }

--- a/sdks/python/taskito/__init__.py
+++ b/sdks/python/taskito/__init__.py
@@ -122,4 +122,4 @@ try:
 
     __version__ = _get_version("taskito")
 except PackageNotFoundError:
-    __version__ = "0.16.4"
+    __version__ = "0.17.0"


### PR DESCRIPTION
Release 0.17.0 — lock-step across all crates + SDKs (Python, Node, Java).

## Highlights

- **Java SDK** — first release (`org.byteveda:taskito`, Maven Central).
- **Periodic task management** — list / unschedule / pause / resume (#313).
- **Per-task dead-letter queries** — list + purge by task (#314).
- **Per-task retry backoff (Java)** (#311).
- **Node requires Node 20+** — Node 18 EOL (#312).

## Bumped (12 locations → 0.17.0)

5 crates + `Cargo.lock`, `sdks/python/{pyproject.toml,taskito/__init__.py}`, `sdks/node/package.json`, `sdks/java/build.gradle.kts` + 3 java subprojects (root/processor/test-support/graalvm-smoke).

CHANGELOG.md updated; `docs/.../changelog.mdx` regenerated via `scripts/sync-changelog.mjs`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added release notes for version 0.17.0, including Java SDK availability and new task management capabilities.
  * The docs site now shows a Java language tab marked as coming soon.

* **Changed**
  * Updated the minimum supported Node.js version to 20+ and aligned related tooling versions.
  * Bumped package and SDK versions across the project to 0.17.0.

* **Documentation**
  * Expanded the changelog with the latest release details and refreshed the older releases section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->