### PR TITLE
fix: harden Java SDK publish + javadoc links

### DIFF
--- a/.github/workflows/publish-java.yml
+++ b/.github/workflows/publish-java.yml
@@ -169,9 +169,15 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          git tag "java-v${VERSION}"
-          git -c http.https://github.com/.extraheader="AUTHORIZATION: bearer ${GH_TOKEN}" \
-            push origin "java-v${VERSION}"
+          # Idempotent: a re-publish (e.g. after fixing the keyserver) reuses the
+          # same version, so skip if the tag is already on the remote.
+          if git ls-remote --exit-code --tags origin "java-v${VERSION}" >/dev/null 2>&1; then
+            echo "::notice::Tag java-v${VERSION} already exists — skipping"
+          else
+            git tag "java-v${VERSION}"
+            git -c http.https://github.com/.extraheader="AUTHORIZATION: bearer ${GH_TOKEN}" \
+              push origin "java-v${VERSION}"
+          fi
 
       - name: Create GitHub release
         if: ${{ !inputs.dry-run }}

--- a/sdks/java/src/main/java/org/byteveda/taskito/model/JobFilter.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/model/JobFilter.java
@@ -3,7 +3,7 @@ package org.byteveda.taskito.model;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-/** Immutable filter for {@link Queue#listJobs(JobFilter)}. Unset fields are ignored. */
+/** Immutable filter for {@link org.byteveda.taskito.Queue#listJobs(JobFilter)}. Unset fields are ignored. */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public final class JobFilter {
     @JsonProperty("status")

--- a/sdks/java/src/main/java/org/byteveda/taskito/worker/Worker.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/worker/Worker.java
@@ -27,7 +27,7 @@ import org.byteveda.taskito.task.TaskFunction;
 import org.byteveda.taskito.workflows.WorkflowTracker;
 
 /**
- * A running worker. Build one with {@link Queue#worker()}, register handlers,
+ * A running worker. Build one with {@link org.byteveda.taskito.Queue#worker()}, register handlers,
  * then {@link Builder#start()}. {@link #close()} stops it and drains in-flight
  * jobs.
  */


### PR DESCRIPTION
Two fixes surfaced by the 0.17.0 Maven Central publish attempt.

- **Javadoc links**: `{@link Queue#listJobs(JobFilter)}` / `{@link Queue#worker()}` could not resolve `Queue` from the `model`/`worker` packages (no import). Fully-qualified both refs — clears the javadoc warnings in the publish run.
- **Idempotent tag step**: a `workflow_dispatch` re-publish of the same version died on `git tag java-v0.17.0` (tag already on remote). Guarded with `git ls-remote`, mirroring the existing GitHub-release step.

Note: neither caused the FAILED deployment — that was the GPG public key missing from keyservers (operational, fixed separately by uploading the key).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Java release publishing so tag creation is skipped when the tag already exists, helping workflow re-runs complete more reliably.

* **Documentation**
  * Updated Java API documentation links for clearer navigation between related classes and methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->