### PR TITLE
feat(java): named-queue handle + dashboard autoload + default store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,5 +51,10 @@ node_modules/
 # bundled into wheels by CI. Not tracked so every rebuild doesn't churn git.
 sdks/python/taskito/static/
 
+# Java SDK: native libs + dashboard SPA staged into resources by CI at publish
+# time (see publish-java.yml). Generated, not tracked.
+sdks/java/src/main/resources/org/byteveda/taskito/native/
+sdks/java/src/main/resources/org/byteveda/taskito/dashboard/
+
 # Docs
 site/

--- a/sdks/java/README.md
+++ b/sdks/java/README.md
@@ -8,6 +8,19 @@ A typed Java 11+ client over the Taskito Rust core, via a hand-written JNI shell
 > distributed locks, periodic/cron, and static-DAG workflows are implemented and
 > verified end-to-end.
 
+## Migration
+
+**0.18 — source-breaking (pre-1.0):** the client interface was renamed and the
+name `Queue` now denotes a single named queue.
+
+- The client you open is now `Taskito`, not `Queue`:
+  `Taskito client = Taskito.builder()…open();` (was `Queue queue = …`).
+  `Taskito.builder()` is unchanged.
+- `Queue` is a per-queue handle from `Taskito.queue(name)`, exposing
+  `pause()` / `resume()` / `isPaused()`.
+- `client.pauseQueue("emails")` → `client.queue("emails").pause()` (likewise
+  `resume`). `listPausedQueues()` stays on the client as the global view.
+
 ## Usage
 
 ### Enqueue

--- a/sdks/java/README.md
+++ b/sdks/java/README.md
@@ -14,7 +14,6 @@ A typed Java 11+ client over the Taskito Rust core, via a hand-written JNI shell
 
 ```java
 import com.fasterxml.jackson.core.type.TypeReference;
-import org.byteveda.taskito.Queue;
 import org.byteveda.taskito.Taskito;
 import org.byteveda.taskito.model.Job;
 import org.byteveda.taskito.model.JobStatus;
@@ -29,11 +28,15 @@ Task<Map<String, Object>> sendEmail =
                 .queue("emails")
                 .priority(5);
 
-try (Queue queue = Taskito.builder().sqlite("taskito.db").open()) {
-    String id = queue.enqueue(sendEmail, Map.of("to", "a@b.c"));
-    Job job = queue.getJob(id).orElseThrow();   // job.status == JobStatus.PENDING
-    QueueStats stats = queue.stats();
-    queue.cancel(id);
+try (Taskito taskito = Taskito.builder().sqlite("taskito.db").open()) {
+    String id = taskito.enqueue(sendEmail, Map.of("to", "a@b.c"));
+    Job job = taskito.getJob(id).orElseThrow();   // job.status == JobStatus.PENDING
+    QueueStats stats = taskito.stats();
+    taskito.cancel(id);
+
+    // Pause/resume are scoped to one named queue:
+    taskito.queue("emails").pause();
+    taskito.queue("emails").resume();
 }
 ```
 
@@ -48,8 +51,8 @@ import org.byteveda.taskito.worker.Worker;
 
 Task<Map> add = Task.of("add", Map.class);
 
-Queue queue = Taskito.builder().backend("sqlite").url("taskito.db").open();
-Worker worker = queue.worker()
+Taskito taskito = Taskito.builder().backend("sqlite").url("taskito.db").open();
+Worker worker = taskito.worker()
         .handle(add, p -> ((Number) p.get("a")).intValue() + ((Number) p.get("b")).intValue())
         .concurrency(4)
         .on(EventName.SUCCESS, e -> System.out.println("done: " + e.jobId))
@@ -60,7 +63,7 @@ Worker worker = queue.worker()
 // exit to trigger close(), so it would deadlock.)
 Runtime.getRuntime().addShutdownHook(new Thread(() -> {
     worker.close();
-    queue.close();
+    taskito.close();
 }));
 worker.awaitShutdown();
 ```
@@ -82,9 +85,9 @@ class EmailTasks {
 }
 
 // generated EmailTasksTasks:
-String id = queue.enqueue(EmailTasksTasks.SEND, payload);
+String id = taskito.enqueue(EmailTasksTasks.SEND, payload);
 
-queue.worker()
+taskito.worker()
         .apply(b -> EmailTasksTasks.bind(b, new EmailTasks()))
         .start();
 ```
@@ -114,9 +117,9 @@ Workflow wf = Workflow.named("etl")
         .step("transform", transform, 2, "extract")
         .step("load", load, 3, "transform");
 
-WorkflowRun run = queue.submitWorkflow(wf);
+WorkflowRun run = taskito.submitWorkflow(wf);
 
-try (Worker worker = queue.worker()
+try (Worker worker = taskito.worker()
         .handle(extract, p -> p * 10)
         .handle(transform, p -> p + 1)
         .handle(load, p -> p)
@@ -139,7 +142,7 @@ Workflow etl = Workflow.named("etl")
         .stepAfter("transform", transform, "extract")
         .stepAfter("load", load, "transform");
 
-queue.submitWorkflow(etl, Map.of("extract", 5, "transform", 6, "load", 7));
+taskito.submitWorkflow(etl, Map.of("extract", 5, "transform", 6, "load", 7));
 ```
 
 A step's effective payload is `map.get(name)` when present, else the one baked
@@ -163,7 +166,7 @@ gates, and sagas are not yet exposed.
 ### Middleware
 
 ```java
-queue.use(new Middleware() {
+taskito.use(new Middleware() {
     @Override public void onEnqueue(EnqueueContext ctx) { /* validate / rewrite */ }
     @Override public void before(TaskContext ctx) { /* trace */ }
     @Override public void onDeadLetter(OutcomeEvent e) { /* alert */ }
@@ -183,7 +186,7 @@ try (DashboardServer dashboard = DashboardServer.start(queue, 8080, token, stati
 
 ```java
 byte[] key = ...; // 16/24/32 bytes for AES
-Queue secure = Taskito.builder()
+Taskito secure = Taskito.builder()
         .backend("sqlite").url("taskito.db")
         .serializer(new EncryptedSerializer(new JsonSerializer(), key))
         .open();
@@ -195,9 +198,10 @@ Packages are organized by feature; the root holds only the front door.
 
 ```text
 org.byteveda.taskito
-├── Taskito            entry point — Taskito.builder()...open()
-├── Queue              public interface
-├── DefaultQueue       package-private impl (not exported)
+├── Taskito            client interface + entry — Taskito.builder()...open()
+├── Queue              named-queue handle (pause/resume) — Taskito.queue(name)
+├── DefaultTaskito     package-private client impl (not exported)
+├── NamedQueue         package-private Queue impl (not exported)
 ├── TaskitoException   unchecked error type
 ├── task/              Task, TaskFunction, EnqueueOptions
 ├── model/             Job, JobStatus, QueueStats, DeadJob, JobError,

--- a/sdks/java/graalvm-smoke/src/main/java/org/byteveda/taskito/graalvm/Smoke.java
+++ b/sdks/java/graalvm-smoke/src/main/java/org/byteveda/taskito/graalvm/Smoke.java
@@ -5,7 +5,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import org.byteveda.taskito.Queue;
 import org.byteveda.taskito.Taskito;
 import org.byteveda.taskito.events.EventName;
 import org.byteveda.taskito.scheduling.PeriodicTask;
@@ -25,7 +24,7 @@ public final class Smoke {
         Path dir = Files.createTempDirectory("taskito-graalvm-smoke");
         Task<String> echo = Task.of("echo", String.class);
 
-        try (Queue queue = Taskito.builder()
+        try (Taskito queue = Taskito.builder()
                 .backend("sqlite")
                 .url(dir.resolve("smoke.db").toString())
                 .open()) {

--- a/sdks/java/src/main/java/org/byteveda/taskito/DefaultTaskito.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/DefaultTaskito.java
@@ -38,11 +38,11 @@ import org.byteveda.taskito.workflows.WorkflowRun;
 import org.byteveda.taskito.workflows.WorkflowStatus;
 
 /**
- * Default {@link Queue}: maps the typed public API onto a {@link QueueBackend},
+ * Default {@link Taskito}: maps the typed public API onto a {@link QueueBackend},
  * serializing payloads with the configured {@link Serializer} and decoding
  * native JSON views with a private mapper.
  */
-final class DefaultQueue implements Queue {
+final class DefaultTaskito implements Taskito {
     private static final ObjectMapper VIEWS = new ObjectMapper();
 
     private static final long DEFAULT_LOCK_TTL_MS = 30_000;
@@ -52,14 +52,19 @@ final class DefaultQueue implements Queue {
     private final Serializer serializer;
     private final List<Middleware> middleware = new CopyOnWriteArrayList<>();
 
-    DefaultQueue(QueueBackend backend, Serializer serializer) {
+    DefaultTaskito(QueueBackend backend, Serializer serializer) {
         this.backend = backend;
         this.facade = new CoreFacade(backend);
         this.serializer = serializer;
     }
 
     @Override
-    public Queue use(Middleware middleware) {
+    public Queue queue(String name) {
+        return new NamedQueue(this, name);
+    }
+
+    @Override
+    public Taskito use(Middleware middleware) {
         this.middleware.add(middleware);
         return this;
     }
@@ -236,13 +241,13 @@ final class DefaultQueue implements Queue {
         return backend.purgeCompleted(olderThanMs);
     }
 
-    @Override
-    public void pauseQueue(String queue) {
+    /** Pause one named queue; backs {@link NamedQueue#pause()}. */
+    void pauseLane(String queue) {
         backend.pauseQueue(queue);
     }
 
-    @Override
-    public void resumeQueue(String queue) {
+    /** Resume one named queue; backs {@link NamedQueue#resume()}. */
+    void resumeLane(String queue) {
         backend.resumeQueue(queue);
     }
 

--- a/sdks/java/src/main/java/org/byteveda/taskito/NamedQueue.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/NamedQueue.java
@@ -1,0 +1,32 @@
+package org.byteveda.taskito;
+
+/** Default {@link Queue}: scopes pause/resume to one named queue via its owning client. */
+final class NamedQueue implements Queue {
+    private final DefaultTaskito owner;
+    private final String name;
+
+    NamedQueue(DefaultTaskito owner, String name) {
+        this.owner = owner;
+        this.name = name;
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public void pause() {
+        owner.pauseLane(name);
+    }
+
+    @Override
+    public void resume() {
+        owner.resumeLane(name);
+    }
+
+    @Override
+    public boolean isPaused() {
+        return owner.listPausedQueues().contains(name);
+    }
+}

--- a/sdks/java/src/main/java/org/byteveda/taskito/Queue.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/Queue.java
@@ -1,189 +1,21 @@
 package org.byteveda.taskito;
 
-import java.time.Duration;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import org.byteveda.taskito.locks.Lock;
-import org.byteveda.taskito.locks.LockInfo;
-import org.byteveda.taskito.middleware.Middleware;
-import org.byteveda.taskito.model.DeadJob;
-import org.byteveda.taskito.model.Job;
-import org.byteveda.taskito.model.JobError;
-import org.byteveda.taskito.model.JobFilter;
-import org.byteveda.taskito.model.PeriodicInfo;
-import org.byteveda.taskito.model.QueueStats;
-import org.byteveda.taskito.model.TaskLog;
-import org.byteveda.taskito.model.TaskMetric;
-import org.byteveda.taskito.model.WorkerInfo;
-import org.byteveda.taskito.scheduling.PeriodicTask;
-import org.byteveda.taskito.task.EnqueueOptions;
-import org.byteveda.taskito.task.Task;
-import org.byteveda.taskito.worker.Worker;
-import org.byteveda.taskito.workflows.Workflow;
-import org.byteveda.taskito.workflows.WorkflowRun;
-import org.byteveda.taskito.workflows.WorkflowStatus;
-
-/** A Taskito queue. Obtain one from {@link Taskito#builder()}. */
-public interface Queue extends AutoCloseable {
-    /** Register cross-cutting middleware (enqueue + worker hooks); returns {@code this}. */
-    Queue use(Middleware middleware);
-
-    // ── Producer ────────────────────────────────────────────────────
-
-    /** Enqueue a typed payload using the task's default options; returns the job id. */
-    <T> String enqueue(Task<T> task, T payload);
-
-    <T> String enqueue(Task<T> task, T payload, EnqueueOptions options);
-
-    /** Enqueue by task name with an arbitrary payload and default options. */
-    String enqueue(String taskName, Object payload);
-
-    /** Enqueue a batch in one storage call; returns ids in input order. */
-    <T> List<String> enqueueMany(Task<T> task, List<T> payloads);
-
-    <T> List<String> enqueueMany(Task<T> task, List<T> payloads, EnqueueOptions options);
-
-    /** Alias of {@link #enqueueMany(Task, List)} in the guide's vocabulary. */
-    <T> List<String> enqueueAll(Task<T> task, List<T> payloads);
-
-    Optional<Job> getJob(String jobId);
-
-    /** Block until the job reaches a terminal state (tests only); throws on timeout. */
-    Optional<Job> awaitJob(String jobId, Duration timeout);
-
-    /** The job's raw serialized result, if complete. */
-    Optional<byte[]> getResult(String jobId);
-
-    /** The job's result deserialized to {@code type}, if complete. */
-    <R> Optional<R> getResult(String jobId, Class<R> type);
-
-    boolean cancel(String jobId);
-
-    boolean requestCancel(String jobId);
-
-    boolean isCancelRequested(String jobId);
-
-    void setProgress(String jobId, int progress);
-
-    // ── Inspection ──────────────────────────────────────────────────
-
-    QueueStats stats();
-
-    QueueStats statsByQueue(String queue);
-
-    Map<String, QueueStats> statsAllQueues();
-
-    List<Job> listJobs(JobFilter filter);
-
-    List<JobError> jobErrors(String jobId);
-
-    /** Per-execution metrics within the last {@code sinceMs}; null task = all. */
-    List<TaskMetric> metrics(String taskName, long sinceMs);
-
-    List<WorkerInfo> listWorkers();
-
-    // ── Admin ───────────────────────────────────────────────────────
-
-    List<DeadJob> listDead(long limit, long offset);
-
-    /** Dead-letter entries for a single task, newest first. */
-    List<DeadJob> listDeadByTask(String taskName, long limit, long offset);
-
-    /** Delete every dead-letter entry for a task; returns the number removed. */
-    long purgeDeadByTask(String taskName);
-
-    /** Re-enqueue a dead-letter entry; returns the new job id. */
-    String retryDead(String deadId);
-
-    /** Alias of {@link #retryDead(String)} in the guide's vocabulary. */
-    String retry(String deadId);
-
-    boolean deleteDead(String deadId);
-
-    long purgeDead(long olderThanMs);
-
-    long purgeCompleted(long olderThanMs);
-
-    void pauseQueue(String queue);
-
-    void resumeQueue(String queue);
-
-    List<String> listPausedQueues();
-
-    Optional<String> getSetting(String key);
-
-    void setSetting(String key, String value);
-
-    boolean deleteSetting(String key);
-
-    Map<String, String> listSettings();
-
-    // ── Logs ────────────────────────────────────────────────────────
-
-    void writeTaskLog(String jobId, String taskName, String level, String message);
-
-    void writeTaskLog(String jobId, String taskName, String level, String message, String extra);
-
-    List<TaskLog> getTaskLogs(String jobId);
-
-    // ── Locks ───────────────────────────────────────────────────────
-
-    /** A distributed lock {@code name} with the given TTL; call {@link Lock#acquire()}. */
-    Lock lock(String name, long ttlMs);
-
-    /** A distributed lock {@code name} with a default 30s TTL. */
-    Lock lock(String name);
-
-    /** Acquire {@code name}, run {@code body} if obtained, then release; returns whether it ran. */
-    boolean withLock(String name, long ttlMs, Runnable body);
-
-    Optional<LockInfo> lockInfo(String name);
-
-    /** Alias of {@link #lockInfo(String)} in the guide's vocabulary. */
-    Optional<LockInfo> getLockInfo(String name);
-
-    // ── Periodic ────────────────────────────────────────────────────
-
-    /** Register (or replace) a cron task; returns the next fire time (Unix ms). */
-    long registerPeriodic(PeriodicTask task);
-
-    /** Every registered periodic task, enabled or paused. */
-    List<PeriodicInfo> listPeriodic();
-
-    /** Unschedule a periodic task; false if none had that name. */
-    boolean deletePeriodic(String name);
-
-    /** Stop a periodic task from firing without removing it; false if none had that name. */
-    boolean pausePeriodic(String name);
-
-    /** Resume a paused periodic task; false if none had that name. */
-    boolean resumePeriodic(String name);
-
-    // ── Workflows ───────────────────────────────────────────────────
-
-    /** Submit a workflow DAG; returns a handle to the run. */
-    WorkflowRun submitWorkflow(Workflow workflow);
-
-    /**
-     * Submit a workflow, supplying per-step payloads keyed by step name. A step's
-     * effective payload is {@code payloads.get(name)} when present, else the
-     * payload baked into the step. Pairs with the structural
-     * {@code Workflow.stepAfter(name, task, deps...)} form.
-     */
-    WorkflowRun submitWorkflow(Workflow workflow, Map<String, Object> payloads);
-
-    /** Current status of a workflow run, or empty if it no longer exists. */
-    Optional<WorkflowStatus> workflowStatus(String runId);
-
-    /** Cancel a workflow run: skip its pending nodes and mark it cancelled. */
-    void cancelWorkflow(String runId);
-
-    // ── Worker ──────────────────────────────────────────────────────
-
-    /** Begin building a worker over this queue. */
-    Worker.Builder worker();
-
-    @Override
-    void close();
+/**
+ * A handle to one named queue. Obtain it from {@link Taskito#queue(String)}.
+ * Pausing stops workers from dispatching this queue's jobs until resumed;
+ * in-flight jobs run to completion.
+ */
+public interface Queue {
+
+    /** This queue's name. */
+    String name();
+
+    /** Stop workers from dispatching jobs on this queue. */
+    void pause();
+
+    /** Resume dispatching after a {@link #pause()}. */
+    void resume();
+
+    /** Whether this queue is currently paused. */
+    boolean isPaused();
 }

--- a/sdks/java/src/main/java/org/byteveda/taskito/Taskito.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/Taskito.java
@@ -5,23 +5,211 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.byteveda.taskito.internal.JniQueueBackend;
+import org.byteveda.taskito.locks.Lock;
+import org.byteveda.taskito.locks.LockInfo;
+import org.byteveda.taskito.middleware.Middleware;
+import org.byteveda.taskito.model.DeadJob;
+import org.byteveda.taskito.model.Job;
+import org.byteveda.taskito.model.JobError;
+import org.byteveda.taskito.model.JobFilter;
+import org.byteveda.taskito.model.PeriodicInfo;
+import org.byteveda.taskito.model.QueueStats;
+import org.byteveda.taskito.model.TaskLog;
+import org.byteveda.taskito.model.TaskMetric;
+import org.byteveda.taskito.model.WorkerInfo;
+import org.byteveda.taskito.scheduling.PeriodicTask;
 import org.byteveda.taskito.serialization.JsonSerializer;
 import org.byteveda.taskito.serialization.Serializer;
 import org.byteveda.taskito.spi.QueueBackend;
+import org.byteveda.taskito.task.EnqueueOptions;
+import org.byteveda.taskito.task.Task;
+import org.byteveda.taskito.worker.Worker;
+import org.byteveda.taskito.workflows.Workflow;
+import org.byteveda.taskito.workflows.WorkflowRun;
+import org.byteveda.taskito.workflows.WorkflowStatus;
 
-/** Entry point: open a {@link Queue} over a storage backend. */
-public final class Taskito {
-    private Taskito() {}
+/**
+ * The Taskito client: a handle to a storage backend through which you enqueue,
+ * inspect, and administer jobs across every named queue. Obtain one from
+ * {@link #builder()}. Operations scoped to a single named queue (pause/resume)
+ * live on the {@link Queue} handle returned by {@link #queue(String)}.
+ */
+public interface Taskito extends AutoCloseable {
 
-    public static Builder builder() {
+    /** Begin configuring a client. */
+    static Builder builder() {
         return new Builder();
     }
 
-    /** Configures and opens a {@link Queue}. */
-    public static final class Builder {
+    /** A handle to one named queue, e.g. {@code taskito.queue("emails").pause()}. */
+    Queue queue(String name);
+
+    /** Register cross-cutting middleware (enqueue + worker hooks); returns {@code this}. */
+    Taskito use(Middleware middleware);
+
+    // ── Producer ────────────────────────────────────────────────────
+
+    /** Enqueue a typed payload using the task's default options; returns the job id. */
+    <T> String enqueue(Task<T> task, T payload);
+
+    <T> String enqueue(Task<T> task, T payload, EnqueueOptions options);
+
+    /** Enqueue by task name with an arbitrary payload and default options. */
+    String enqueue(String taskName, Object payload);
+
+    /** Enqueue a batch in one storage call; returns ids in input order. */
+    <T> List<String> enqueueMany(Task<T> task, List<T> payloads);
+
+    <T> List<String> enqueueMany(Task<T> task, List<T> payloads, EnqueueOptions options);
+
+    /** Alias of {@link #enqueueMany(Task, List)} in the guide's vocabulary. */
+    <T> List<String> enqueueAll(Task<T> task, List<T> payloads);
+
+    Optional<Job> getJob(String jobId);
+
+    /** Block until the job reaches a terminal state (tests only); throws on timeout. */
+    Optional<Job> awaitJob(String jobId, Duration timeout);
+
+    /** The job's raw serialized result, if complete. */
+    Optional<byte[]> getResult(String jobId);
+
+    /** The job's result deserialized to {@code type}, if complete. */
+    <R> Optional<R> getResult(String jobId, Class<R> type);
+
+    boolean cancel(String jobId);
+
+    boolean requestCancel(String jobId);
+
+    boolean isCancelRequested(String jobId);
+
+    void setProgress(String jobId, int progress);
+
+    // ── Inspection ──────────────────────────────────────────────────
+
+    QueueStats stats();
+
+    QueueStats statsByQueue(String queue);
+
+    Map<String, QueueStats> statsAllQueues();
+
+    List<Job> listJobs(JobFilter filter);
+
+    List<JobError> jobErrors(String jobId);
+
+    /** Per-execution metrics within the last {@code sinceMs}; null task = all. */
+    List<TaskMetric> metrics(String taskName, long sinceMs);
+
+    List<WorkerInfo> listWorkers();
+
+    // ── Admin ───────────────────────────────────────────────────────
+
+    List<DeadJob> listDead(long limit, long offset);
+
+    /** Dead-letter entries for a single task, newest first. */
+    List<DeadJob> listDeadByTask(String taskName, long limit, long offset);
+
+    /** Delete every dead-letter entry for a task; returns the number removed. */
+    long purgeDeadByTask(String taskName);
+
+    /** Re-enqueue a dead-letter entry; returns the new job id. */
+    String retryDead(String deadId);
+
+    /** Alias of {@link #retryDead(String)} in the guide's vocabulary. */
+    String retry(String deadId);
+
+    boolean deleteDead(String deadId);
+
+    long purgeDead(long olderThanMs);
+
+    long purgeCompleted(long olderThanMs);
+
+    /** The names of every currently paused queue. */
+    List<String> listPausedQueues();
+
+    Optional<String> getSetting(String key);
+
+    void setSetting(String key, String value);
+
+    boolean deleteSetting(String key);
+
+    Map<String, String> listSettings();
+
+    // ── Logs ────────────────────────────────────────────────────────
+
+    void writeTaskLog(String jobId, String taskName, String level, String message);
+
+    void writeTaskLog(String jobId, String taskName, String level, String message, String extra);
+
+    List<TaskLog> getTaskLogs(String jobId);
+
+    // ── Locks ───────────────────────────────────────────────────────
+
+    /** A distributed lock {@code name} with the given TTL; call {@link Lock#acquire()}. */
+    Lock lock(String name, long ttlMs);
+
+    /** A distributed lock {@code name} with a default 30s TTL. */
+    Lock lock(String name);
+
+    /** Acquire {@code name}, run {@code body} if obtained, then release; returns whether it ran. */
+    boolean withLock(String name, long ttlMs, Runnable body);
+
+    Optional<LockInfo> lockInfo(String name);
+
+    /** Alias of {@link #lockInfo(String)} in the guide's vocabulary. */
+    Optional<LockInfo> getLockInfo(String name);
+
+    // ── Periodic ────────────────────────────────────────────────────
+
+    /** Register (or replace) a cron task; returns the next fire time (Unix ms). */
+    long registerPeriodic(PeriodicTask task);
+
+    /** Every registered periodic task, enabled or paused. */
+    List<PeriodicInfo> listPeriodic();
+
+    /** Unschedule a periodic task; false if none had that name. */
+    boolean deletePeriodic(String name);
+
+    /** Stop a periodic task from firing without removing it; false if none had that name. */
+    boolean pausePeriodic(String name);
+
+    /** Resume a paused periodic task; false if none had that name. */
+    boolean resumePeriodic(String name);
+
+    // ── Workflows ───────────────────────────────────────────────────
+
+    /** Submit a workflow DAG; returns a handle to the run. */
+    WorkflowRun submitWorkflow(Workflow workflow);
+
+    /**
+     * Submit a workflow, supplying per-step payloads keyed by step name. A step's
+     * effective payload is {@code payloads.get(name)} when present, else the
+     * payload baked into the step. Pairs with the structural
+     * {@code Workflow.stepAfter(name, task, deps...)} form.
+     */
+    WorkflowRun submitWorkflow(Workflow workflow, Map<String, Object> payloads);
+
+    /** Current status of a workflow run, or empty if it no longer exists. */
+    Optional<WorkflowStatus> workflowStatus(String runId);
+
+    /** Cancel a workflow run: skip its pending nodes and mark it cancelled. */
+    void cancelWorkflow(String runId);
+
+    // ── Worker ──────────────────────────────────────────────────────
+
+    /** Begin building a worker over this client. */
+    Worker.Builder worker();
+
+    @Override
+    void close();
+
+    /** Configures and opens a {@link Taskito} client. */
+    final class Builder {
         private static final ObjectMapper JSON = new ObjectMapper();
         // Mirrors the Python/Node SDKs: a brokerless SQLite store under .taskito/.
         private static final String DEFAULT_SQLITE_DB = ".taskito/taskito.db";
@@ -86,12 +274,12 @@ public final class Taskito {
         }
 
         /** Open over an explicit backend, e.g. an in-memory fake in tests. */
-        public Queue open(QueueBackend backend) {
-            return new DefaultQueue(backend, serializer);
+        public Taskito open(QueueBackend backend) {
+            return new DefaultTaskito(backend, serializer);
         }
 
         /** Open the native backend described by the configured options. */
-        public Queue open() {
+        public Taskito open() {
             String backend = (String) options.getOrDefault("backend", "sqlite");
             if ("sqlite".equals(backend)) {
                 String dsn = (String) options.computeIfAbsent("dsn", key -> DEFAULT_SQLITE_DB);
@@ -99,7 +287,7 @@ public final class Taskito {
             } else if (!options.containsKey("dsn")) {
                 throw new TaskitoException("url (dsn) is required");
             }
-            return new DefaultQueue(JniQueueBackend.open(encodeOptions()), serializer);
+            return new DefaultTaskito(JniQueueBackend.open(encodeOptions()), serializer);
         }
 
         /** Create the SQLite file's parent directory (skip in-memory databases). */

--- a/sdks/java/src/main/java/org/byteveda/taskito/Taskito.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/Taskito.java
@@ -8,6 +8,7 @@ import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import org.byteveda.taskito.internal.JniQueueBackend;
@@ -218,7 +219,9 @@ public interface Taskito extends AutoCloseable {
         private Serializer serializer = new JsonSerializer();
 
         public Builder backend(String backend) {
-            options.put("backend", backend);
+            // Normalize at the boundary so callers may pass "SQLite"/"REDIS"; the
+            // default-DSN branch and the native layer then see a canonical name.
+            options.put("backend", backend == null ? null : backend.toLowerCase(Locale.ROOT));
             return this;
         }
 

--- a/sdks/java/src/main/java/org/byteveda/taskito/Taskito.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/Taskito.java
@@ -1,6 +1,10 @@
 package org.byteveda.taskito;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.byteveda.taskito.internal.JniQueueBackend;
@@ -19,6 +23,8 @@ public final class Taskito {
     /** Configures and opens a {@link Queue}. */
     public static final class Builder {
         private static final ObjectMapper JSON = new ObjectMapper();
+        // Mirrors the Python/Node SDKs: a brokerless SQLite store under .taskito/.
+        private static final String DEFAULT_SQLITE_DB = ".taskito/taskito.db";
 
         private final Map<String, Object> options = new LinkedHashMap<>();
         private Serializer serializer = new JsonSerializer();
@@ -32,6 +38,11 @@ public final class Taskito {
         public Builder url(String dsn) {
             options.put("dsn", dsn);
             return this;
+        }
+
+        /** Shortcut for {@code backend("sqlite")} using the default {@code .taskito/taskito.db}. */
+        public Builder sqlite() {
+            return backend("sqlite");
         }
 
         /** Shortcut for {@code backend("sqlite").url(path)}. */
@@ -81,10 +92,30 @@ public final class Taskito {
 
         /** Open the native backend described by the configured options. */
         public Queue open() {
-            if (!options.containsKey("dsn")) {
+            String backend = (String) options.getOrDefault("backend", "sqlite");
+            if ("sqlite".equals(backend)) {
+                String dsn = (String) options.computeIfAbsent("dsn", key -> DEFAULT_SQLITE_DB);
+                ensureSqliteParentDir(dsn);
+            } else if (!options.containsKey("dsn")) {
                 throw new TaskitoException("url (dsn) is required");
             }
             return new DefaultQueue(JniQueueBackend.open(encodeOptions()), serializer);
+        }
+
+        /** Create the SQLite file's parent directory (skip in-memory databases). */
+        private static void ensureSqliteParentDir(String dsn) {
+            if (dsn.equals(":memory:") || dsn.startsWith("file::memory:")) {
+                return;
+            }
+            Path parent = Paths.get(dsn).getParent();
+            if (parent == null) {
+                return;
+            }
+            try {
+                Files.createDirectories(parent);
+            } catch (IOException e) {
+                throw new TaskitoException("failed to create sqlite directory " + parent, e);
+            }
         }
 
         private String encodeOptions() {

--- a/sdks/java/src/main/java/org/byteveda/taskito/cli/Cli.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/cli/Cli.java
@@ -37,11 +37,15 @@ public final class Cli {
     @Option(names = "--backend", description = "Storage backend (default sqlite).", defaultValue = "sqlite")
     String backend;
 
-    @Option(names = "--url", required = true, description = "Connection string (SQLite path or URL).")
+    @Option(names = "--url", description = "Connection string (SQLite path or URL); defaults to .taskito/taskito.db.")
     String url;
 
     Queue open() {
-        return Taskito.builder().backend(backend).url(url).open();
+        Taskito.Builder builder = Taskito.builder().backend(backend);
+        if (url != null) {
+            builder.url(url);
+        }
+        return builder.open();
     }
 
     static String json(Object value) {

--- a/sdks/java/src/main/java/org/byteveda/taskito/cli/Cli.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/cli/Cli.java
@@ -33,6 +33,9 @@ import picocli.CommandLine.ParentCommand;
 public final class Cli {
     static final ObjectMapper JSON = new ObjectMapper();
 
+    @CommandLine.Spec
+    CommandLine.Model.CommandSpec spec;
+
     @Option(names = "--backend", description = "Storage backend (default sqlite).", defaultValue = "sqlite")
     String backend;
 
@@ -40,6 +43,11 @@ public final class Cli {
     String url;
 
     Taskito open() {
+        // Only SQLite has a sensible default store; every other backend needs a URL.
+        if (url == null && !"sqlite".equalsIgnoreCase(backend)) {
+            throw new CommandLine.ParameterException(
+                    spec.commandLine(), "--url is required for the '" + backend + "' backend");
+        }
         Taskito.Builder builder = Taskito.builder().backend(backend);
         if (url != null) {
             builder.url(url);

--- a/sdks/java/src/main/java/org/byteveda/taskito/cli/Cli.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/cli/Cli.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
-import org.byteveda.taskito.Queue;
 import org.byteveda.taskito.Taskito;
 import org.byteveda.taskito.dashboard.DashboardServer;
 import org.byteveda.taskito.model.DeadJob;
@@ -40,7 +39,7 @@ public final class Cli {
     @Option(names = "--url", description = "Connection string (SQLite path or URL); defaults to .taskito/taskito.db.")
     String url;
 
-    Queue open() {
+    Taskito open() {
         Taskito.Builder builder = Taskito.builder().backend(backend);
         if (url != null) {
             builder.url(url);
@@ -67,7 +66,7 @@ public final class Cli {
 
         @Override
         public Integer call() {
-            try (Queue queue = parent.open()) {
+            try (Taskito queue = parent.open()) {
                 System.out.println(json(queue.stats()));
             }
             return 0;
@@ -88,7 +87,7 @@ public final class Cli {
         @Override
         public Integer call() throws Exception {
             Object value = payload == null ? null : JSON.readValue(payload, Object.class);
-            try (Queue queue = parent.open()) {
+            try (Taskito queue = parent.open()) {
                 System.out.println(queue.enqueue(task, value));
             }
             return 0;
@@ -118,7 +117,7 @@ public final class Cli {
             if (queue != null) {
                 filter.queue(queue);
             }
-            try (Queue q = parent.open()) {
+            try (Taskito q = parent.open()) {
                 List<Job> jobs = q.listJobs(filter.build());
                 System.out.println(json(jobs));
             }
@@ -136,7 +135,7 @@ public final class Cli {
 
         @Override
         public Integer call() {
-            try (Queue queue = parent.open()) {
+            try (Taskito queue = parent.open()) {
                 return queue.cancel(id) ? 0 : 1;
             }
         }
@@ -152,8 +151,8 @@ public final class Cli {
 
         @Override
         public Integer call() {
-            try (Queue q = parent.open()) {
-                q.pauseQueue(queue);
+            try (Taskito q = parent.open()) {
+                q.queue(queue).pause();
             }
             return 0;
         }
@@ -169,8 +168,8 @@ public final class Cli {
 
         @Override
         public Integer call() {
-            try (Queue q = parent.open()) {
-                q.resumeQueue(queue);
+            try (Taskito q = parent.open()) {
+                q.queue(queue).resume();
             }
             return 0;
         }
@@ -184,7 +183,7 @@ public final class Cli {
         @ParentCommand
         Cli parent;
 
-        Queue open() {
+        Taskito open() {
             return parent.open();
         }
 
@@ -198,7 +197,7 @@ public final class Cli {
 
             @Override
             public Integer call() {
-                try (Queue queue = dlq.open()) {
+                try (Taskito queue = dlq.open()) {
                     List<DeadJob> dead = queue.listDead(limit, 0);
                     System.out.println(json(dead));
                 }
@@ -216,7 +215,7 @@ public final class Cli {
 
             @Override
             public Integer call() {
-                try (Queue queue = dlq.open()) {
+                try (Taskito queue = dlq.open()) {
                     System.out.println(queue.retryDead(id));
                 }
                 return 0;
@@ -233,7 +232,7 @@ public final class Cli {
 
             @Override
             public Integer call() {
-                try (Queue queue = dlq.open()) {
+                try (Taskito queue = dlq.open()) {
                     return queue.deleteDead(id) ? 0 : 1;
                 }
             }
@@ -256,7 +255,7 @@ public final class Cli {
 
         @Override
         public Integer call() throws Exception {
-            try (Queue queue = parent.open();
+            try (Taskito queue = parent.open();
                     DashboardServer server = DashboardServer.start(queue, port, token, staticDir)) {
                 System.out.println("dashboard on http://localhost:" + server.port());
                 new CountDownLatch(1).await();

--- a/sdks/java/src/main/java/org/byteveda/taskito/dashboard/DashboardAssets.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/dashboard/DashboardAssets.java
@@ -1,0 +1,223 @@
+package org.byteveda.taskito.dashboard;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.JarURLConnection;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.FileSystemException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.security.MessageDigest;
+import java.util.Comparator;
+import java.util.Enumeration;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.stream.Stream;
+import org.byteveda.taskito.TaskitoException;
+
+/**
+ * Locates the dashboard SPA that ships inside the taskito jar and hands back a
+ * filesystem directory the {@link DashboardServer} can serve — so callers never
+ * pass a path, mirroring how the Python/Node SDKs auto-discover their bundled
+ * assets.
+ *
+ * <p>When the classpath is a real jar the assets are extracted to a per-user,
+ * content-addressed directory (the name embeds a hash of {@code index.html}, so
+ * a rebuilt SPA gets a fresh directory and a stale one is never served). When
+ * the classpath is exploded (dev/tests) the resource directory is served in
+ * place. {@code -Dtaskito.dashboard.dir=/path} overrides discovery.
+ */
+final class DashboardAssets {
+    private static final String ROOT = "org/byteveda/taskito/dashboard";
+    private static final String SENTINEL = "/" + ROOT + "/index.html";
+    private static final String DIR_OVERRIDE = "taskito.dashboard.dir";
+
+    private static boolean attempted;
+    private static Path resolved;
+
+    private DashboardAssets() {}
+
+    /** The SPA root, or {@code null} when no SPA is bundled (then only /api/* responds). */
+    static synchronized Path resolveOrNull() {
+        String override = System.getProperty(DIR_OVERRIDE);
+        if (override != null) {
+            return Paths.get(override).normalize();
+        }
+        if (!attempted) {
+            attempted = true;
+            resolved = locate();
+        }
+        return resolved;
+    }
+
+    private static Path locate() {
+        URL index = DashboardAssets.class.getResource(SENTINEL);
+        if (index == null) {
+            return null;
+        }
+        try {
+            URI uri = index.toURI();
+            if ("file".equals(uri.getScheme())) {
+                return Paths.get(uri).getParent(); // exploded classpath (dev/tests)
+            }
+            return extractFromJar(jarPathOf(index), secureWorkdir());
+        } catch (URISyntaxException | IOException e) {
+            throw new TaskitoException("failed to load bundled dashboard assets", e);
+        }
+    }
+
+    /**
+     * Extract the SPA tree from {@code jarPath} into a content-addressed directory
+     * under {@code workdir}, returning that directory. Pure in its inputs (no
+     * classloader/global state) so it can be exercised against a synthetic jar.
+     */
+    static Path extractFromJar(Path jarPath, Path workdir) throws IOException {
+        String prefix = ROOT + "/";
+        try (JarFile jar = new JarFile(jarPath.toFile())) {
+            JarEntry indexEntry = jar.getJarEntry(prefix + "index.html");
+            if (indexEntry == null) {
+                throw new IOException("no " + prefix + "index.html in " + jarPath);
+            }
+            // index.html embeds Vite's hashed asset names, so its bytes change
+            // whenever any asset does — a cheap, stable content key for the tree.
+            byte[] indexBytes;
+            try (InputStream in = jar.getInputStream(indexEntry)) {
+                indexBytes = in.readAllBytes();
+            }
+            Path target =
+                    workdir.resolve("taskito-dashboard-" + sha256Hex(indexBytes).substring(0, 16));
+            if (Files.isRegularFile(target.resolve("index.html"))) {
+                return target; // extracted already, by us or a prior run
+            }
+            materialize(jar, prefix, workdir, target);
+            return target;
+        }
+    }
+
+    /**
+     * Extract into a private staging dir, then publish the whole tree to {@code target}
+     * with a single atomic directory move — so a reader never sees a half-written tree,
+     * and concurrent first-runs converge (the loser reuses the winner's identical copy).
+     */
+    private static void materialize(JarFile jar, String prefix, Path workdir, Path target) throws IOException {
+        Path staging = Files.createTempDirectory(workdir, ".dash-");
+        try {
+            extractTree(jar, prefix, staging);
+            publish(staging, target);
+        } finally {
+            deleteRecursive(staging);
+        }
+        // index.html appears only via the all-or-nothing move, so its presence is a
+        // complete-extraction signal — fail loudly if the publish silently no-op'd.
+        if (!Files.isRegularFile(target.resolve("index.html"))) {
+            throw new IOException("dashboard assets failed to materialize at " + target);
+        }
+    }
+
+    private static void publish(Path staging, Path target) throws IOException {
+        try {
+            Files.move(staging, target, StandardCopyOption.ATOMIC_MOVE);
+        } catch (AtomicMoveNotSupportedException crossStore) {
+            // Rare filesystem that can't rename atomically; copy in best-effort.
+            if (!Files.isDirectory(target)) {
+                copyTree(staging, target);
+            }
+        } catch (FileSystemException raced) {
+            // A concurrent run published first (target exists, non-empty). Reuse it;
+            // anything else is a genuine failure and must propagate.
+            if (!Files.isDirectory(target)) {
+                throw raced;
+            }
+        }
+    }
+
+    private static void extractTree(JarFile jar, String prefix, Path dest) throws IOException {
+        Enumeration<JarEntry> entries = jar.entries();
+        while (entries.hasMoreElements()) {
+            JarEntry entry = entries.nextElement();
+            // Jar entry names always use '/', so this is platform-independent.
+            if (entry.isDirectory() || !entry.getName().startsWith(prefix)) {
+                continue;
+            }
+            Path out = dest.resolve(entry.getName().substring(prefix.length())).normalize();
+            if (!out.startsWith(dest)) {
+                continue; // zip-slip guard
+            }
+            Files.createDirectories(out.getParent());
+            try (InputStream in = jar.getInputStream(entry)) {
+                Files.copy(in, out, StandardCopyOption.REPLACE_EXISTING);
+            }
+        }
+    }
+
+    private static void copyTree(Path src, Path dst) throws IOException {
+        try (Stream<Path> walk = Files.walk(src)) {
+            for (Path path : (Iterable<Path>) walk::iterator) {
+                Path out = dst.resolve(src.relativize(path).toString());
+                if (Files.isDirectory(path)) {
+                    Files.createDirectories(out);
+                } else {
+                    Files.createDirectories(out.getParent());
+                    Files.copy(path, out, StandardCopyOption.REPLACE_EXISTING);
+                }
+            }
+        }
+    }
+
+    private static Path jarPathOf(URL index) throws IOException {
+        JarURLConnection conn = (JarURLConnection) index.openConnection();
+        try {
+            return Paths.get(conn.getJarFileURL().toURI());
+        } catch (URISyntaxException e) {
+            throw new IOException("bad jar url: " + index, e);
+        }
+    }
+
+    /** Per-user extraction dir with owner-only perms, like the native loader's. */
+    private static Path secureWorkdir() throws IOException {
+        Path dir = Paths.get(System.getProperty("java.io.tmpdir"))
+                .resolve("taskito-dashboard-" + System.getProperty("user.name", "anon"));
+        Files.createDirectories(dir);
+        try {
+            Files.setPosixFilePermissions(dir, PosixFilePermissions.fromString("rwx------"));
+        } catch (UnsupportedOperationException nonPosix) {
+            // Windows etc.: per-user profile dirs are already ACL-restricted.
+        }
+        return dir;
+    }
+
+    private static void deleteRecursive(Path root) throws IOException {
+        if (!Files.exists(root)) {
+            return;
+        }
+        try (Stream<Path> walk = Files.walk(root)) {
+            walk.sorted(Comparator.reverseOrder()).forEach(path -> {
+                try {
+                    Files.deleteIfExists(path);
+                } catch (IOException ignored) {
+                    // best-effort cleanup of a staging dir
+                }
+            });
+        }
+    }
+
+    private static String sha256Hex(byte[] bytes) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256").digest(bytes);
+            StringBuilder hex = new StringBuilder(digest.length * 2);
+            for (byte b : digest) {
+                hex.append(Character.forDigit((b >> 4) & 0xf, 16));
+                hex.append(Character.forDigit(b & 0xf, 16));
+            }
+            return hex.toString();
+        } catch (Exception e) {
+            throw new TaskitoException("hashing dashboard assets failed", e);
+        }
+    }
+}

--- a/sdks/java/src/main/java/org/byteveda/taskito/dashboard/DashboardServer.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/dashboard/DashboardServer.java
@@ -21,14 +21,14 @@ import java.util.concurrent.Executors;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import org.byteveda.taskito.Queue;
+import org.byteveda.taskito.Taskito;
 import org.byteveda.taskito.TaskitoException;
 import org.byteveda.taskito.model.Job;
 import org.byteveda.taskito.model.JobFilter;
 import org.byteveda.taskito.model.JobStatus;
 
 /**
- * A read/action dashboard API + static-SPA server backed by a {@link Queue},
+ * A read/action dashboard API + static-SPA server backed by a {@link Taskito},
  * built on the JDK's {@code com.sun.net.httpserver}. The JSON contract is
  * snake_case with Unix-millisecond timestamps (see {@link Contract}).
  *
@@ -47,11 +47,11 @@ public final class DashboardServer implements AutoCloseable {
     private static final Pattern RESUME = Pattern.compile("^/api/queues/([^/]+)/resume$");
 
     private final HttpServer server;
-    private final Queue queue;
+    private final Taskito queue;
     private final String token;
     private final Path staticDir;
 
-    private DashboardServer(HttpServer server, Queue queue, String token, Path staticDir) {
+    private DashboardServer(HttpServer server, Taskito queue, String token, Path staticDir) {
         this.server = server;
         this.queue = queue;
         this.token = token;
@@ -59,12 +59,12 @@ public final class DashboardServer implements AutoCloseable {
     }
 
     /** Start on {@code port} (0 = ephemeral), serving the SPA bundled in the jar. */
-    public static DashboardServer start(Queue queue, int port) throws IOException {
+    public static DashboardServer start(Taskito queue, int port) throws IOException {
         return start(queue, port, null, null);
     }
 
-    /** As {@link #start(Queue, int)} but requiring {@code token} for {@code /api/*}. */
-    public static DashboardServer start(Queue queue, int port, String token) throws IOException {
+    /** As {@link #start(Taskito, int)} but requiring {@code token} for {@code /api/*}. */
+    public static DashboardServer start(Taskito queue, int port, String token) throws IOException {
         return start(queue, port, token, null);
     }
 
@@ -73,7 +73,7 @@ public final class DashboardServer implements AutoCloseable {
      * {@code staticDir} auto-discovers the SPA bundled in the jar; pass one only
      * to override it with an unpacked build.
      */
-    public static DashboardServer start(Queue queue, int port, String token, String staticDir) throws IOException {
+    public static DashboardServer start(Taskito queue, int port, String token, String staticDir) throws IOException {
         HttpServer server = HttpServer.create(new InetSocketAddress(port), 0);
         Path dir = staticDir != null ? Paths.get(staticDir).normalize() : DashboardAssets.resolveOrNull();
         DashboardServer dashboard = new DashboardServer(server, queue, token, dir);
@@ -183,13 +183,13 @@ public final class DashboardServer implements AutoCloseable {
         }
         Matcher pause = PAUSE.matcher(path);
         if (pause.matches()) {
-            queue.pauseQueue(pause.group(1));
+            queue.queue(pause.group(1)).pause();
             respond(exchange, 200, Collections.singletonMap("ok", true));
             return true;
         }
         Matcher resume = RESUME.matcher(path);
         if (resume.matches()) {
-            queue.resumeQueue(resume.group(1));
+            queue.queue(resume.group(1)).resume();
             respond(exchange, 200, Collections.singletonMap("ok", true));
             return true;
         }

--- a/sdks/java/src/main/java/org/byteveda/taskito/dashboard/DashboardServer.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/dashboard/DashboardServer.java
@@ -58,14 +58,24 @@ public final class DashboardServer implements AutoCloseable {
         this.staticDir = staticDir;
     }
 
+    /** Start on {@code port} (0 = ephemeral), serving the SPA bundled in the jar. */
     public static DashboardServer start(Queue queue, int port) throws IOException {
         return start(queue, port, null, null);
     }
 
-    /** Start on {@code port} (0 = ephemeral). {@code token}/{@code staticDir} may be null. */
+    /** As {@link #start(Queue, int)} but requiring {@code token} for {@code /api/*}. */
+    public static DashboardServer start(Queue queue, int port, String token) throws IOException {
+        return start(queue, port, token, null);
+    }
+
+    /**
+     * Start on {@code port} (0 = ephemeral). {@code token} may be null. A null
+     * {@code staticDir} auto-discovers the SPA bundled in the jar; pass one only
+     * to override it with an unpacked build.
+     */
     public static DashboardServer start(Queue queue, int port, String token, String staticDir) throws IOException {
         HttpServer server = HttpServer.create(new InetSocketAddress(port), 0);
-        Path dir = staticDir == null ? null : Paths.get(staticDir).normalize();
+        Path dir = staticDir != null ? Paths.get(staticDir).normalize() : DashboardAssets.resolveOrNull();
         DashboardServer dashboard = new DashboardServer(server, queue, token, dir);
         server.createContext("/", dashboard::dispatch);
         server.setExecutor(Executors.newCachedThreadPool());

--- a/sdks/java/src/main/java/org/byteveda/taskito/dashboard/DashboardServer.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/dashboard/DashboardServer.java
@@ -74,8 +74,9 @@ public final class DashboardServer implements AutoCloseable {
      * to override it with an unpacked build.
      */
     public static DashboardServer start(Taskito queue, int port, String token, String staticDir) throws IOException {
-        HttpServer server = HttpServer.create(new InetSocketAddress(port), 0);
+        // Resolve assets before binding so a discovery failure can't leak a bound port.
         Path dir = staticDir != null ? Paths.get(staticDir).normalize() : DashboardAssets.resolveOrNull();
+        HttpServer server = HttpServer.create(new InetSocketAddress(port), 0);
         DashboardServer dashboard = new DashboardServer(server, queue, token, dir);
         server.createContext("/", dashboard::dispatch);
         server.setExecutor(Executors.newCachedThreadPool());

--- a/sdks/java/src/main/java/org/byteveda/taskito/middleware/Middleware.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/middleware/Middleware.java
@@ -6,7 +6,7 @@ import org.byteveda.taskito.events.OutcomeEvent;
  * Cross-cutting hooks around enqueue, task execution, and job outcomes. All are
  * optional. {@code onEnqueue} runs on the producer before serialization;
  * {@code before}/{@code after}/{@code onError} wrap execution; the outcome hooks
- * fire after the core decides the result. Register with {@link org.byteveda.taskito.Queue#use}.
+ * fire after the core decides the result. Register with {@link org.byteveda.taskito.Taskito#use}.
  */
 public interface Middleware {
     default void onEnqueue(EnqueueContext context) {}

--- a/sdks/java/src/main/java/org/byteveda/taskito/model/JobFilter.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/model/JobFilter.java
@@ -3,7 +3,7 @@ package org.byteveda.taskito.model;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-/** Immutable filter for {@link org.byteveda.taskito.Queue#listJobs(JobFilter)}. Unset fields are ignored. */
+/** Immutable filter for {@link org.byteveda.taskito.Taskito#listJobs(JobFilter)}. Unset fields are ignored. */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public final class JobFilter {
     @JsonProperty("status")

--- a/sdks/java/src/main/java/org/byteveda/taskito/package-info.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/package-info.java
@@ -2,9 +2,10 @@
  * Taskito Java SDK — a typed client over the Rust task-queue core.
  *
  * <p>This root package is the front door: open a
- * {@link org.byteveda.taskito.Queue} via
- * {@link org.byteveda.taskito.Taskito#builder()}. Everything else is grouped by
- * feature:
+ * {@link org.byteveda.taskito.Taskito} client via
+ * {@link org.byteveda.taskito.Taskito#builder()}, then scope to one named queue
+ * with {@link org.byteveda.taskito.Taskito#queue(String)}. Everything else is
+ * grouped by feature:
  *
  * <ul>
  *   <li>{@code task} — {@link org.byteveda.taskito.task.Task} descriptors,

--- a/sdks/java/src/main/java/org/byteveda/taskito/webhooks/WebhookManager.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/webhooks/WebhookManager.java
@@ -8,7 +8,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
-import org.byteveda.taskito.Queue;
+import org.byteveda.taskito.Taskito;
 import org.byteveda.taskito.TaskitoException;
 import org.byteveda.taskito.events.OutcomeEvent;
 import org.byteveda.taskito.middleware.Middleware;
@@ -24,12 +24,12 @@ public final class WebhookManager implements Middleware {
     private final WebhookStore store;
     private final Deliverer deliverer = new Deliverer();
 
-    private WebhookManager(Queue queue) {
+    private WebhookManager(Taskito queue) {
         this.store = new WebhookStore(queue);
     }
 
     /** Create a manager and register it on {@code queue} for automatic dispatch. */
-    public static WebhookManager attach(Queue queue) {
+    public static WebhookManager attach(Taskito queue) {
         WebhookManager manager = new WebhookManager(queue);
         queue.use(manager);
         return manager;

--- a/sdks/java/src/main/java/org/byteveda/taskito/webhooks/WebhookStore.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/webhooks/WebhookStore.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.CollectionType;
 import java.util.ArrayList;
 import java.util.List;
-import org.byteveda.taskito.Queue;
+import org.byteveda.taskito.Taskito;
 import org.byteveda.taskito.TaskitoException;
 
 /** Persists webhooks as a JSON list in the queue's settings key/value store. */
@@ -12,9 +12,9 @@ final class WebhookStore {
     private static final String KEY = "taskito.webhooks";
     private static final ObjectMapper JSON = new ObjectMapper();
 
-    private final Queue queue;
+    private final Taskito queue;
 
-    WebhookStore(Queue queue) {
+    WebhookStore(Taskito queue) {
         this.queue = queue;
     }
 

--- a/sdks/java/src/main/java/org/byteveda/taskito/worker/Worker.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/worker/Worker.java
@@ -27,7 +27,7 @@ import org.byteveda.taskito.task.TaskFunction;
 import org.byteveda.taskito.workflows.WorkflowTracker;
 
 /**
- * A running worker. Build one with {@link org.byteveda.taskito.Queue#worker()}, register handlers,
+ * A running worker. Build one with {@link org.byteveda.taskito.Taskito#worker()}, register handlers,
  * then {@link Builder#start()}. {@link #close()} stops it and drains in-flight
  * jobs.
  */

--- a/sdks/java/src/main/java/org/byteveda/taskito/workflows/Workflow.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/workflows/Workflow.java
@@ -7,7 +7,7 @@ import org.byteveda.taskito.task.Task;
 
 /**
  * A workflow definition: a named, versioned DAG of {@link Step}s. Build one, then
- * submit it with {@code Queue.submitWorkflow}. Steps run in topological order;
+ * submit it with {@code Taskito.submitWorkflow}. Steps run in topological order;
  * a step waits for every predecessor named in its {@code after} list.
  */
 public final class Workflow {

--- a/sdks/java/src/test/java/org/byteveda/taskito/AnnotationProcessorTest.java
+++ b/sdks/java/src/test/java/org/byteveda/taskito/AnnotationProcessorTest.java
@@ -18,7 +18,7 @@ class AnnotationProcessorTest {
     @Test
     @Timeout(30)
     void generatedCompanionEnqueuesAndHandles(@TempDir Path dir) throws Exception {
-        try (Queue queue =
+        try (Taskito queue =
                 Taskito.builder().sqlite(dir.resolve("ap.db").toString()).open()) {
             // GreeterTasks is generated from @TaskHandler on Greeter; GREET/TOTAL
             // are typed Task constants (TOTAL carries the generic List<Integer>).
@@ -40,7 +40,7 @@ class AnnotationProcessorTest {
     @Test
     @Timeout(30)
     void registerViaGeneratedHandlerRegistry(@TempDir Path dir) throws Exception {
-        try (Queue queue =
+        try (Taskito queue =
                 Taskito.builder().sqlite(dir.resolve("hr.db").toString()).open()) {
             String id = queue.enqueue(GreeterTasks.GREET, "grace");
             CountDownLatch done = new CountDownLatch(1);

--- a/sdks/java/src/test/java/org/byteveda/taskito/DashboardTest.java
+++ b/sdks/java/src/test/java/org/byteveda/taskito/DashboardTest.java
@@ -38,7 +38,7 @@ class DashboardTest {
     @Timeout(30)
     void servesSnakeCaseContract(@TempDir Path dir) throws Exception {
         Task<Map<String, Object>> add = Task.of("add", mapType());
-        try (Queue queue = Taskito.builder()
+        try (Taskito queue = Taskito.builder()
                 .backend("sqlite")
                 .url(dir.resolve("t.db").toString())
                 .open()) {
@@ -68,7 +68,7 @@ class DashboardTest {
         Path spa = Files.createDirectories(dir.resolve("spa"));
         Files.writeString(spa.resolve("index.html"), "<h1>taskito</h1>");
         System.setProperty("taskito.dashboard.dir", spa.toString());
-        try (Queue queue =
+        try (Taskito queue =
                         Taskito.builder().sqlite(dir.resolve("t.db").toString()).open();
                 DashboardServer server = DashboardServer.start(queue, 0)) {
             int port = server.port();
@@ -85,7 +85,7 @@ class DashboardTest {
     @Test
     @Timeout(30)
     void enforcesToken(@TempDir Path dir) throws Exception {
-        try (Queue queue = Taskito.builder()
+        try (Taskito queue = Taskito.builder()
                 .backend("sqlite")
                 .url(dir.resolve("t.db").toString())
                 .open()) {

--- a/sdks/java/src/test/java/org/byteveda/taskito/DashboardTest.java
+++ b/sdks/java/src/test/java/org/byteveda/taskito/DashboardTest.java
@@ -7,6 +7,7 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Map;
@@ -56,6 +57,28 @@ class DashboardTest {
                 assertTrue(jobs.body().contains("\"task_name\":\"add\""));
                 assertTrue(jobs.body().contains("\"status\":\"pending\""));
             }
+        }
+    }
+
+    @Test
+    @Timeout(30)
+    void servesSpaWithoutAStaticPath(@TempDir Path dir) throws Exception {
+        // No path passed to start(); the server auto-discovers the SPA. Point the
+        // discovery override at a stand-in tree to exercise that wiring offline.
+        Path spa = Files.createDirectories(dir.resolve("spa"));
+        Files.writeString(spa.resolve("index.html"), "<h1>taskito</h1>");
+        System.setProperty("taskito.dashboard.dir", spa.toString());
+        try (Queue queue =
+                        Taskito.builder().sqlite(dir.resolve("t.db").toString()).open();
+                DashboardServer server = DashboardServer.start(queue, 0)) {
+            int port = server.port();
+            HttpResponse<String> root = get(port, "/");
+            assertEquals(200, root.statusCode());
+            assertTrue(root.body().contains("taskito"));
+            // SPA fallback: an unknown client route still resolves to index.html.
+            assertEquals(200, get(port, "/jobs").statusCode());
+        } finally {
+            System.clearProperty("taskito.dashboard.dir");
         }
     }
 

--- a/sdks/java/src/test/java/org/byteveda/taskito/DeadLetterByTaskTest.java
+++ b/sdks/java/src/test/java/org/byteveda/taskito/DeadLetterByTaskTest.java
@@ -23,7 +23,7 @@ class DeadLetterByTaskTest {
         Task<String> alpha = Task.of("alpha", String.class).maxRetries(0);
         Task<String> beta = Task.of("beta", String.class).maxRetries(0);
 
-        try (Queue queue = Taskito.builder()
+        try (Taskito queue = Taskito.builder()
                 .backend("sqlite")
                 .url(dir.resolve("t.db").toString())
                 .open()) {

--- a/sdks/java/src/test/java/org/byteveda/taskito/ErgonomicsTest.java
+++ b/sdks/java/src/test/java/org/byteveda/taskito/ErgonomicsTest.java
@@ -22,7 +22,7 @@ class ErgonomicsTest {
     @Timeout(30)
     void awaitJobReturnsTerminalState(@TempDir Path dir) throws Exception {
         Task<Integer> echo = Task.of("erg.echo", Integer.class).retries(0).timeout(Duration.ofSeconds(10));
-        try (Queue queue =
+        try (Taskito queue =
                 Taskito.builder().sqlite(dir.resolve("erg.db").toString()).open()) {
             String id = queue.enqueue(echo, 42);
             try (Worker worker = queue.worker().handle(echo, p -> p).start()) {
@@ -42,7 +42,7 @@ class ErgonomicsTest {
     @Test
     @Timeout(30)
     void lockSugar(@TempDir Path dir) {
-        try (Queue queue =
+        try (Taskito queue =
                 Taskito.builder().sqlite(dir.resolve("lock.db").toString()).open()) {
             try (Lock lock = queue.lock("erg-lock")) { // default-TTL overload
                 assertTrue(lock.tryAcquire(Duration.ofSeconds(1)));

--- a/sdks/java/src/test/java/org/byteveda/taskito/LockTest.java
+++ b/sdks/java/src/test/java/org/byteveda/taskito/LockTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 class LockTest {
 
-    private Queue open(Path dir) {
+    private Taskito open(Path dir) {
         return Taskito.builder()
                 .backend("sqlite")
                 .url(dir.resolve("t.db").toString())
@@ -21,7 +21,7 @@ class LockTest {
 
     @Test
     void acquireContendRelease(@TempDir Path dir) {
-        try (Queue queue = open(dir)) {
+        try (Taskito queue = open(dir)) {
             Lock first = queue.lock("L", 60_000);
             assertTrue(first.acquire());
             assertFalse(queue.lock("L", 60_000).acquire());
@@ -38,7 +38,7 @@ class LockTest {
 
     @Test
     void registerPeriodicValidatesCron(@TempDir Path dir) {
-        try (Queue queue = open(dir)) {
+        try (Taskito queue = open(dir)) {
             long before = System.currentTimeMillis();
             long next = queue.registerPeriodic(
                     PeriodicTask.builder("p", "tick", "0 0 12 * * *").build());

--- a/sdks/java/src/test/java/org/byteveda/taskito/PeriodicTest.java
+++ b/sdks/java/src/test/java/org/byteveda/taskito/PeriodicTest.java
@@ -26,7 +26,7 @@ class PeriodicTest {
     @Test
     @Timeout(30)
     void listPauseResumeDelete(@TempDir Path dir) {
-        try (Queue queue = Taskito.builder()
+        try (Taskito queue = Taskito.builder()
                 .backend("sqlite")
                 .url(dir.resolve("t.db").toString())
                 .open()) {

--- a/sdks/java/src/test/java/org/byteveda/taskito/QueueTest.java
+++ b/sdks/java/src/test/java/org/byteveda/taskito/QueueTest.java
@@ -28,7 +28,7 @@ class QueueTest {
         return (Class<Map<String, String>>) (Class<?>) Map.class;
     }
 
-    private Queue open(Path dir) {
+    private Taskito open(Path dir) {
         return Taskito.builder()
                 .backend("sqlite")
                 .url(dir.resolve("t.db").toString())
@@ -37,7 +37,7 @@ class QueueTest {
 
     @Test
     void enqueueGetCancelStats(@TempDir Path dir) {
-        try (Queue queue = open(dir)) {
+        try (Taskito queue = open(dir)) {
             String id = queue.enqueue(
                     SEND_EMAIL,
                     Collections.singletonMap("to", "a@b.c"),
@@ -60,14 +60,14 @@ class QueueTest {
 
     @Test
     void getMissingJobIsEmpty(@TempDir Path dir) {
-        try (Queue queue = open(dir)) {
+        try (Taskito queue = open(dir)) {
             assertTrue(queue.getJob("nope").isEmpty());
         }
     }
 
     @Test
     void enqueueManyAndFilteredList(@TempDir Path dir) {
-        try (Queue queue = open(dir)) {
+        try (Taskito queue = open(dir)) {
             List<String> ids = queue.enqueueMany(
                     SEND_EMAIL.withOptions(
                             EnqueueOptions.builder().queue("emails").build()),
@@ -88,7 +88,7 @@ class QueueTest {
 
     @Test
     void settingsRoundTrip(@TempDir Path dir) {
-        try (Queue queue = open(dir)) {
+        try (Taskito queue = open(dir)) {
             queue.setSetting("theme", "dark");
             assertEquals("dark", queue.getSetting("theme").orElse(""));
             assertEquals("dark", queue.listSettings().get("theme"));
@@ -99,17 +99,20 @@ class QueueTest {
 
     @Test
     void pauseAndResumeQueue(@TempDir Path dir) {
-        try (Queue queue = open(dir)) {
-            queue.pauseQueue("emails");
-            assertTrue(queue.listPausedQueues().contains("emails"));
-            queue.resumeQueue("emails");
-            assertFalse(queue.listPausedQueues().contains("emails"));
+        try (Taskito client = open(dir)) {
+            Queue emails = client.queue("emails");
+            emails.pause();
+            assertTrue(emails.isPaused());
+            assertTrue(client.listPausedQueues().contains("emails"));
+            emails.resume();
+            assertFalse(emails.isPaused());
+            assertFalse(client.listPausedQueues().contains("emails"));
         }
     }
 
     @Test
     void taskLogsRoundTrip(@TempDir Path dir) {
-        try (Queue queue = open(dir)) {
+        try (Taskito queue = open(dir)) {
             String id = queue.enqueue("send_email", Collections.singletonMap("to", "a"));
             queue.writeTaskLog(id, "send_email", "info", "hello");
             List<TaskLog> logs = queue.getTaskLogs(id);

--- a/sdks/java/src/test/java/org/byteveda/taskito/QueueTest.java
+++ b/sdks/java/src/test/java/org/byteveda/taskito/QueueTest.java
@@ -1,5 +1,6 @@
 package org.byteveda.taskito;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -33,6 +34,15 @@ class QueueTest {
                 .backend("sqlite")
                 .url(dir.resolve("t.db").toString())
                 .open();
+    }
+
+    @Test
+    void backendNameIsCaseInsensitive() {
+        // A mixed-case backend must still be recognized by the native layer.
+        try (Taskito client =
+                Taskito.builder().backend("SQLite").url(":memory:").open()) {
+            assertDoesNotThrow(client::stats);
+        }
     }
 
     @Test

--- a/sdks/java/src/test/java/org/byteveda/taskito/RetryPolicyTest.java
+++ b/sdks/java/src/test/java/org/byteveda/taskito/RetryPolicyTest.java
@@ -32,7 +32,7 @@ class RetryPolicyTest {
                 .maxRetries(3)
                 .retryPolicy(RetryPolicy.delays(Duration.ofMillis(10), Duration.ofMillis(10)));
 
-        try (Queue queue = Taskito.builder()
+        try (Taskito queue = Taskito.builder()
                 .backend("sqlite")
                 .url(dir.resolve("t.db").toString())
                 .open()) {

--- a/sdks/java/src/test/java/org/byteveda/taskito/WebhookTest.java
+++ b/sdks/java/src/test/java/org/byteveda/taskito/WebhookTest.java
@@ -16,7 +16,7 @@ class WebhookTest {
 
     @Test
     void crudRoundTrip(@TempDir Path dir) {
-        try (Queue queue = Taskito.builder()
+        try (Taskito queue = Taskito.builder()
                 .backend("sqlite")
                 .url(dir.resolve("t.db").toString())
                 .open()) {

--- a/sdks/java/src/test/java/org/byteveda/taskito/WorkerTest.java
+++ b/sdks/java/src/test/java/org/byteveda/taskito/WorkerTest.java
@@ -28,7 +28,7 @@ class WorkerTest {
     @Timeout(30)
     void runsTaskToCompletion(@TempDir Path dir) throws Exception {
         Task<Map<String, Object>> add = Task.of("add", mapType());
-        try (Queue queue = Taskito.builder()
+        try (Taskito queue = Taskito.builder()
                 .backend("sqlite")
                 .url(dir.resolve("t.db").toString())
                 .open()) {

--- a/sdks/java/src/test/java/org/byteveda/taskito/WorkflowFanOutTest.java
+++ b/sdks/java/src/test/java/org/byteveda/taskito/WorkflowFanOutTest.java
@@ -26,7 +26,7 @@ class WorkflowFanOutTest {
         Task<Integer> seed = Task.of("fo.seed", Integer.class);
         Task<Integer> square = Task.of("fo.square", Integer.class);
         Task<List<Integer>> sum = Task.of("fo.sum", new TypeReference<List<Integer>>() {});
-        try (Queue queue =
+        try (Taskito queue =
                 Taskito.builder().url(dir.resolve("fo.db").toString()).open()) {
             // seed(4) -> [1,2,3,4]; square each -> [1,4,9,16]; sum all -> 30
             Workflow wf = Workflow.named("fanpipe")

--- a/sdks/java/src/test/java/org/byteveda/taskito/WorkflowSubmitMapTest.java
+++ b/sdks/java/src/test/java/org/byteveda/taskito/WorkflowSubmitMapTest.java
@@ -23,7 +23,7 @@ class WorkflowSubmitMapTest {
         Task<Integer> extract = Task.of("sm.extract", Integer.class);
         Task<Integer> transform = Task.of("sm.transform", Integer.class);
         Task<Integer> load = Task.of("sm.load", Integer.class);
-        try (Queue queue =
+        try (Taskito queue =
                 Taskito.builder().sqlite(dir.resolve("sm.db").toString()).open()) {
             // Structural steps (deps only); payloads supplied at submit.
             Workflow etl = Workflow.named("etl")

--- a/sdks/java/src/test/java/org/byteveda/taskito/WorkflowTest.java
+++ b/sdks/java/src/test/java/org/byteveda/taskito/WorkflowTest.java
@@ -26,7 +26,7 @@ class WorkflowTest {
         Task<Integer> a = Task.of("wf.a", Integer.class);
         Task<Integer> b = Task.of("wf.b", Integer.class);
         Task<Integer> c = Task.of("wf.c", Integer.class);
-        try (Queue queue =
+        try (Taskito queue =
                 Taskito.builder().url(dir.resolve("wf.db").toString()).open()) {
             Workflow wf = Workflow.named("pipeline")
                     .step("a", a, 1)
@@ -55,7 +55,7 @@ class WorkflowTest {
         Task<Integer> a = Task.of("fc.a", Integer.class);
         Task<Integer> b = Task.of("fc.b", Integer.class);
         Task<Integer> c = Task.of("fc.c", Integer.class);
-        try (Queue queue =
+        try (Taskito queue =
                 Taskito.builder().url(dir.resolve("fc.db").toString()).open()) {
             Workflow wf = Workflow.named("failpipe")
                     .step("a", a, 1)
@@ -86,7 +86,7 @@ class WorkflowTest {
     void cancelSkipsPendingNodes(@TempDir Path dir) {
         Task<Integer> a = Task.of("cx.a", Integer.class);
         Task<Integer> b = Task.of("cx.b", Integer.class);
-        try (Queue queue =
+        try (Taskito queue =
                 Taskito.builder().url(dir.resolve("cx.db").toString()).open()) {
             Workflow wf = Workflow.named("cancelpipe").step("a", a, 1).step("b", b, 2, "a");
             WorkflowRun run = queue.submitWorkflow(wf);

--- a/sdks/java/src/test/java/org/byteveda/taskito/cli/CliTest.java
+++ b/sdks/java/src/test/java/org/byteveda/taskito/cli/CliTest.java
@@ -1,0 +1,18 @@
+package org.byteveda.taskito.cli;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+class CliTest {
+
+    @Test
+    void rejectsNonSqliteBackendWithoutUrl() {
+        Cli cli = new Cli();
+        new CommandLine(cli).parseArgs("--backend", "postgres");
+        CommandLine.ParameterException ex = assertThrows(CommandLine.ParameterException.class, cli::open);
+        assertTrue(ex.getMessage().contains("--url is required"));
+    }
+}

--- a/sdks/java/src/test/java/org/byteveda/taskito/dashboard/DashboardAssetsTest.java
+++ b/sdks/java/src/test/java/org/byteveda/taskito/dashboard/DashboardAssetsTest.java
@@ -1,0 +1,83 @@
+package org.byteveda.taskito.dashboard;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class DashboardAssetsTest {
+
+    @Test
+    void extractsSpaTreeAndIgnoresUnrelatedEntries(@TempDir Path tmp) throws IOException {
+        Path jar = buildSpaJar(tmp, "spa.jar", "<!doctype html>v1");
+        Path workdir = Files.createDirectories(tmp.resolve("work"));
+
+        Path target = DashboardAssets.extractFromJar(jar, workdir);
+
+        assertEquals("<!doctype html>v1", Files.readString(target.resolve("index.html")));
+        assertEquals("console.log(1)", Files.readString(target.resolve("assets/app.js")));
+        // Entries outside the dashboard prefix must not leak into the output.
+        assertFalse(Files.exists(target.resolve("other.txt")));
+        assertFalse(Files.exists(target.resolve("../other.txt")));
+    }
+
+    @Test
+    void reusesTheSameDirectoryOnReExtract(@TempDir Path tmp) throws IOException {
+        Path jar = buildSpaJar(tmp, "spa.jar", "<!doctype html>v1");
+        Path workdir = Files.createDirectories(tmp.resolve("work"));
+
+        Path first = DashboardAssets.extractFromJar(jar, workdir);
+        Path second = DashboardAssets.extractFromJar(jar, workdir);
+
+        assertEquals(first, second);
+        assertTrue(Files.isRegularFile(second.resolve("index.html")));
+    }
+
+    @Test
+    void differentSpaContentGetsADistinctDirectory(@TempDir Path tmp) throws IOException {
+        Path workdir = Files.createDirectories(tmp.resolve("work"));
+
+        Path v1 = DashboardAssets.extractFromJar(buildSpaJar(tmp, "v1.jar", "<!doctype html>v1"), workdir);
+        Path v2 = DashboardAssets.extractFromJar(buildSpaJar(tmp, "v2.jar", "<!doctype html>v2"), workdir);
+
+        assertNotEquals(v1, v2);
+    }
+
+    @Test
+    void dirOverridePropertyShortCircuitsDiscovery(@TempDir Path tmp) {
+        String key = "taskito.dashboard.dir";
+        System.setProperty(key, tmp.toString());
+        try {
+            assertEquals(Paths.get(tmp.toString()).normalize(), DashboardAssets.resolveOrNull());
+        } finally {
+            System.clearProperty(key);
+        }
+    }
+
+    /** A jar with a fake SPA under the dashboard prefix plus one unrelated entry. */
+    private static Path buildSpaJar(Path dir, String name, String indexBody) throws IOException {
+        Path jar = dir.resolve(name);
+        try (JarOutputStream jos = new JarOutputStream(Files.newOutputStream(jar))) {
+            write(jos, "org/byteveda/taskito/dashboard/index.html", indexBody);
+            write(jos, "org/byteveda/taskito/dashboard/assets/app.js", "console.log(1)");
+            write(jos, "org/byteveda/taskito/other.txt", "unrelated");
+        }
+        return jar;
+    }
+
+    private static void write(JarOutputStream jos, String name, String body) throws IOException {
+        jos.putNextEntry(new JarEntry(name));
+        jos.write(body.getBytes(StandardCharsets.UTF_8));
+        jos.closeEntry();
+    }
+}

--- a/sdks/java/test-support/src/main/java/org/byteveda/taskito/test/InMemoryTaskito.java
+++ b/sdks/java/test-support/src/main/java/org/byteveda/taskito/test/InMemoryTaskito.java
@@ -1,11 +1,10 @@
 package org.byteveda.taskito.test;
 
-import org.byteveda.taskito.Queue;
 import org.byteveda.taskito.Taskito;
 import org.byteveda.taskito.serialization.Serializer;
 
 /**
- * Opens a {@link Queue} backed by an {@link InMemoryQueueBackend} — no JNI, no
+ * Opens a {@link Taskito} backed by an {@link InMemoryQueueBackend} — no JNI, no
  * disk. Intended for fast unit tests of producers, handlers, retries, and
  * dead-lettering. Workflows are not supported in-memory.
  */
@@ -13,12 +12,12 @@ public final class InMemoryTaskito {
     private InMemoryTaskito() {}
 
     /** A queue over a fresh in-memory backend using the default JSON serializer. */
-    public static Queue open() {
+    public static Taskito open() {
         return Taskito.builder().open(new InMemoryQueueBackend());
     }
 
     /** A queue over a fresh in-memory backend with a custom serializer. */
-    public static Queue open(Serializer serializer) {
+    public static Taskito open(Serializer serializer) {
         return Taskito.builder().serializer(serializer).open(new InMemoryQueueBackend());
     }
 }

--- a/sdks/java/test-support/src/test/java/org/byteveda/taskito/test/InMemoryQueueBackendTest.java
+++ b/sdks/java/test-support/src/test/java/org/byteveda/taskito/test/InMemoryQueueBackendTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
-import org.byteveda.taskito.Queue;
+import org.byteveda.taskito.Taskito;
 import org.byteveda.taskito.model.Job;
 import org.byteveda.taskito.model.JobStatus;
 import org.byteveda.taskito.task.Task;
@@ -18,7 +18,7 @@ class InMemoryQueueBackendTest {
     @Timeout(20)
     void runsJobToCompletion() throws Exception {
         Task<Integer> dbl = Task.of("im.double", Integer.class);
-        try (Queue queue = InMemoryTaskito.open()) { // no JNI, no disk
+        try (Taskito queue = InMemoryTaskito.open()) { // no JNI, no disk
             String id = queue.enqueue(dbl, 21);
             try (Worker worker = queue.worker().handle(dbl, p -> p * 2).start()) {
                 Job job = queue.awaitJob(id, Duration.ofSeconds(10)).orElseThrow();
@@ -32,7 +32,7 @@ class InMemoryQueueBackendTest {
     @Timeout(20)
     void retriesThenDeadLetters() throws Exception {
         Task<Integer> boom = Task.of("im.boom", Integer.class).retries(2);
-        try (Queue queue = InMemoryTaskito.open()) {
+        try (Taskito queue = InMemoryTaskito.open()) {
             String id = queue.enqueue(boom, 1);
             try (Worker worker = queue.worker()
                     .handle(boom, p -> {

--- a/sdks/java/test-support/src/test/java/org/byteveda/taskito/test/MiddlewareContextTest.java
+++ b/sdks/java/test-support/src/test/java/org/byteveda/taskito/test/MiddlewareContextTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicReference;
-import org.byteveda.taskito.Queue;
+import org.byteveda.taskito.Taskito;
 import org.byteveda.taskito.middleware.EnqueueContext;
 import org.byteveda.taskito.middleware.Middleware;
 import org.byteveda.taskito.middleware.TaskContext;
@@ -20,7 +20,7 @@ class MiddlewareContextTest {
     void metadataTravelsAndAttributesAreShared() throws Exception {
         AtomicReference<String> afterSaw = new AtomicReference<>();
         Task<Integer> echo = Task.of("mw.echo", Integer.class);
-        try (Queue queue = InMemoryTaskito.open()) {
+        try (Taskito queue = InMemoryTaskito.open()) {
             queue.use(new Middleware() {
                 @Override
                 public void onEnqueue(EnqueueContext ctx) {


### PR DESCRIPTION
Two Java SDK ergonomics fixes so callers pass *commands, not paths* — matching the Python/Node SDKs.

## Dashboard auto-discovery
`DashboardServer.start(queue, port)` and `start(queue, port, token)` no longer need a static-dir argument — the bundled SPA is found inside the jar automatically.

- New `DashboardAssets`: content-addressed extraction (hash of `index.html`) to a per-user workdir, published with a single atomic directory move (race-safe across processes), zip-slip guarded. Exploded classpath (dev/tests) is served in place. `-Dtaskito.dashboard.dir` overrides discovery.
- Cross-platform: jar entries always use `/`; POSIX perms are best-effort (skipped on Windows); `AtomicMoveNotSupported` falls back to a tree copy.
- The 4-arg `start(...staticDir)` stays (`null` → auto) for the CLI `--static` override.

## Default `.taskito/` store
`Taskito.builder().sqlite()` (no arg) defaults to `.taskito/taskito.db`; `open()` auto-creates the parent directory (skips `:memory:`). CLI `--url` is now optional. Mirrors the Python/Node `.taskito/taskito.db` convention.

## Tests
- `DashboardAssetsTest` (4): extraction, prefix filtering, idempotent re-extract, content-addressed versioning, override property — driven by synthetic jars.
- `DashboardTest`: serves the SPA with no path passed.
- Generated dashboard assets are gitignored (CI stages them at publish, like the Python static dir).

No Rust changed — all Java shell. No version bump (ships in the next Java release).

Verified end-to-end against a local snapshot: SPA auto-served, `.taskito/taskito.db` auto-created, worker + dead-letter working.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Java apps now default to a SQLite backend with `.taskito/taskito.db` when not explicitly configured, plus a SQLite shortcut.
  * The dashboard can auto-discover and serve bundled SPA assets when no custom static path is provided.
* **Bug Fixes**
  * Dashboard routing now reliably serves the app shell (`index.html`) for unknown SPA paths.
  * CLI `--url` is optional for SQLite; non-SQLite backends still require `--url`.
* **Documentation**
  * Java README examples updated to use `Taskito` directly.
* **Tests**
  * Added coverage for SPA serving without a static path and for dashboard asset extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->