### PR TITLE
refactor(storage): drop job_payloads, skip-locked dequeue, add indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to taskito are documented here. The format is based on
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html). All SDKs (Python, Node, Java) and the
 underlying Rust crates are released together, in lock-step.
 
+## Unreleased
+
+### Changed
+
+- **Storage dequeue hardening.** Postgres now dequeues with `FOR UPDATE SKIP LOCKED`,
+  so concurrent workers claim disjoint jobs instead of all scanning the same
+  candidates and racing on the claim. `dequeue_batch` no longer reads payload blobs
+  during its candidate scan, and expired batch candidates are archived instead of
+  left stranded in the live table. No API or wire change.
+
+### Added
+
+- **Indexes for dead-letter and filter paths.** `dead_letter` (previously unindexed)
+  gains indexes on `failed_at` and `task_name`; `jobs` gains `(task_name, status)`
+  and partial indexes on `expires_at` / `namespace`; `archived_jobs` gains
+  `created_at` and `namespace`. Keeps DLQ, listing, and maintenance queries flat as
+  tables grow.
+
+### Removed
+
+- **`job_payloads` side table.** Reverted the 0.15 payload side table — payload and
+  result live inline on `jobs`/`archived_jobs` again. The narrow dequeue scan already
+  excludes the blobs by column selection (Postgres TOAST / SQLite overflow keep them
+  off the scanned pages), so the side table bought nothing. It is dropped on
+  migration; the inline columns were never removed, so no data moves.
+
 ## 0.17.0
 
 Feature release across the SDKs: periodic-task management, task-scoped dead-letter queries, and

--- a/crates/taskito-core/src/job.rs
+++ b/crates/taskito-core/src/job.rs
@@ -159,10 +159,9 @@ impl From<ArchivedJobRow> for Job {
 }
 
 impl Job {
-    /// Assemble a [`Job`] from a blob-free [`NarrowJobRow`] plus the
-    /// `payload`/`result` fetched separately from the `job_payloads` side
-    /// table. The narrow row carries every non-blob column; the caller
-    /// supplies the blobs after claiming the single job it wants.
+    /// Assemble a [`Job`] from a blob-free [`NarrowJobRow`] plus `payload`/
+    /// `result` supplied by the caller. The narrow row carries every non-blob
+    /// column; reap/listing paths that don't need the blobs pass empty ones.
     pub fn from_narrow(narrow: NarrowJobRow, payload: Vec<u8>, result: Option<Vec<u8>>) -> Self {
         Self {
             id: narrow.id,

--- a/crates/taskito-core/src/storage/diesel_common/dead_letter.rs
+++ b/crates/taskito-core/src/storage/diesel_common/dead_letter.rs
@@ -218,17 +218,6 @@ macro_rules! impl_diesel_dead_letter_ops {
                         .values(&row)
                         .execute(conn)?;
 
-                    // Dual-write the payload to the 1:1 side table so the
-                    // re-enqueued job is readable through the narrow dequeue /
-                    // get_job join path.
-                    diesel::insert_into(super::super::schema::job_payloads::table)
-                        .values(&super::super::models::NewJobPayloadRow {
-                            job_id: &job.id,
-                            payload: &job.payload,
-                            result: None,
-                        })
-                        .execute(conn)?;
-
                     let deleted = diesel::delete(dead_letter::table.find(dead_id)).execute(conn)?;
                     if deleted == 0 {
                         // A concurrent retry won the race. Roll back the

--- a/crates/taskito-core/src/storage/diesel_common/jobs.rs
+++ b/crates/taskito-core/src/storage/diesel_common/jobs.rs
@@ -31,12 +31,6 @@ macro_rules! impl_diesel_job_ops {
                     replay_history::table.filter(replay_history::original_job_id.eq_any(job_ids)),
                 )
                 .execute(conn)?;
-                // Explicit delete of the side-table rows. The FK declares
-                // ON DELETE CASCADE, but SQLite only enforces foreign keys when
-                // `PRAGMA foreign_keys = ON` is set, so we delete here to be
-                // correct regardless of the connection's FK-enforcement state.
-                diesel::delete(job_payloads::table.filter(job_payloads::job_id.eq_any(job_ids)))
-                    .execute(conn)?;
 
                 Ok(())
             }
@@ -78,13 +72,8 @@ macro_rules! impl_diesel_job_ops {
                 diesel::insert_into(archived_jobs::table)
                     .values(&archived)
                     .execute(conn)?;
-                // Archived jobs keep their blobs in `archived_jobs`'s own
-                // payload/result columns and have no `job_payloads` row. Drop
-                // the side-table row explicitly: SQLite doesn't enforce the
-                // ON DELETE CASCADE FK unless `PRAGMA foreign_keys = ON`, so
-                // relying on the cascade would leak `job_payloads` rows.
-                diesel::delete(job_payloads::table.filter(job_payloads::job_id.eq(&row.id)))
-                    .execute(conn)?;
+                // Archived jobs keep their blobs inline in `archived_jobs`'s own
+                // payload/result columns, copied above from the live row.
                 diesel::delete(jobs::table.filter(jobs::id.eq(&row.id))).execute(conn)?;
                 Ok(())
             }
@@ -199,17 +188,6 @@ macro_rules! impl_diesel_job_ops {
                         .values(&row)
                         .execute(conn)?;
 
-                    // Dual-write the payload to the 1:1 side table. The kept
-                    // `jobs.payload` column above stays populated for one-release
-                    // rollback safety; reads come from `job_payloads`.
-                    diesel::insert_into(job_payloads::table)
-                        .values(&NewJobPayloadRow {
-                            job_id: &job.id,
-                            payload: &job.payload,
-                            result: None,
-                        })
-                        .execute(conn)?;
-
                     // Insert dependency rows
                     for dep_id in &depends_on {
                         let dep_row = NewJobDependencyRow {
@@ -276,21 +254,6 @@ macro_rules! impl_diesel_job_ops {
                     // INSERTs — far fewer round trips / statement executions.
                     for chunk in rows.chunks(BATCH_INSERT_CHUNK) {
                         diesel::insert_into(jobs::table)
-                            .values(chunk)
-                            .execute(conn)?;
-                    }
-
-                    // Dual-write payload side-table rows in matching chunks.
-                    let payload_rows: Vec<NewJobPayloadRow> = jobs
-                        .iter()
-                        .map(|job| NewJobPayloadRow {
-                            job_id: &job.id,
-                            payload: &job.payload,
-                            result: None,
-                        })
-                        .collect();
-                    for chunk in payload_rows.chunks(BATCH_INSERT_CHUNK) {
-                        diesel::insert_into(job_payloads::table)
                             .values(chunk)
                             .execute(conn)?;
                     }
@@ -362,14 +325,6 @@ macro_rules! impl_diesel_job_ops {
                             .values(&row)
                             .execute(conn)?;
 
-                        diesel::insert_into(job_payloads::table)
-                            .values(&NewJobPayloadRow {
-                                job_id: &job.id,
-                                payload: &job.payload,
-                                result: None,
-                            })
-                            .execute(conn)?;
-
                         for dep_id in &depends_on {
                             let dep_row = NewJobDependencyRow {
                                 id: &uuid::Uuid::now_v7().to_string(),
@@ -436,25 +391,11 @@ macro_rules! impl_diesel_job_ops {
                 namespace: Option<&str>,
             ) -> Result<Option<Job>> {
                 self.write_transaction(|conn| {
-                    let mut query = jobs::table
-                        .filter(jobs::queue.eq(queue_name))
-                        .filter(jobs::status.eq(JobStatus::Pending as i32))
-                        .filter(jobs::scheduled_at.le(now))
-                        .order((jobs::priority.desc(), jobs::scheduled_at.asc()))
-                        .limit(100)
-                        .into_boxed();
-
-                    if let Some(ns) = namespace {
-                        query = query.filter(jobs::namespace.eq(ns));
-                    } else {
-                        query = query.filter(jobs::namespace.is_null());
-                    }
-
-                    // Narrow scan: select every column EXCEPT the payload/result
-                    // blobs. Claiming one job out of up to 100 candidates no
-                    // longer reads 99 discarded blobs into heap.
+                    // Narrow candidate scan (no payload/result blobs). Postgres
+                    // applies FOR UPDATE SKIP LOCKED so concurrent workers claim
+                    // disjoint rows; SQLite serializes writers via BEGIN IMMEDIATE.
                     let candidates: Vec<NarrowJobRow> =
-                        query.select(NarrowJobRow::as_select()).load(conn)?;
+                        Self::scan_dequeue_candidates(conn, queue_name, now, namespace, 100)?;
 
                     for row in candidates {
                         // Skip expired jobs — archive them as cancelled. The
@@ -497,23 +438,14 @@ macro_rules! impl_diesel_job_ops {
                             continue;
                         }
 
-                        let updated: NarrowJobRow = jobs::table
+                        // Load the full winning row (with blobs) inline and
+                        // assemble the Job. Only the one claimed row reads blobs.
+                        let updated: JobRow = jobs::table
                             .find(&row.id)
-                            .select(NarrowJobRow::as_select())
+                            .select(JobRow::as_select())
                             .first(conn)?;
 
-                        // Now fetch only the winning job's blobs from the side
-                        // table and assemble the full Job.
-                        let payload_row: JobPayloadRow = job_payloads::table
-                            .find(&updated.id)
-                            .select(JobPayloadRow::as_select())
-                            .first(conn)?;
-
-                        return Ok(Some(Job::from_narrow(
-                            updated,
-                            payload_row.payload,
-                            payload_row.result,
-                        )));
+                        return Ok(Some(Job::from(updated)));
                     }
 
                     Ok(None)
@@ -561,21 +493,12 @@ macro_rules! impl_diesel_job_ops {
                 let scan_limit = (max.saturating_mul(4)).min(400) as i64;
 
                 self.write_transaction(|conn| {
-                    let mut query = jobs::table
-                        .filter(jobs::queue.eq(queue_name))
-                        .filter(jobs::status.eq(JobStatus::Pending as i32))
-                        .filter(jobs::scheduled_at.le(now))
-                        .order((jobs::priority.desc(), jobs::scheduled_at.asc()))
-                        .limit(scan_limit)
-                        .into_boxed();
-
-                    if let Some(ns) = namespace {
-                        query = query.filter(jobs::namespace.eq(ns));
-                    } else {
-                        query = query.filter(jobs::namespace.is_null());
-                    }
-
-                    let candidates: Vec<JobRow> = query.select(JobRow::as_select()).load(conn)?;
+                    // Narrow candidate scan, identical to `dequeue` (no blobs;
+                    // Postgres applies FOR UPDATE SKIP LOCKED). Only claimed
+                    // winners load their payload inline below.
+                    let candidates: Vec<NarrowJobRow> = Self::scan_dequeue_candidates(
+                        conn, queue_name, now, namespace, scan_limit,
+                    )?;
 
                     let mut claimed: Vec<Job> = Vec::with_capacity(max.min(candidates.len()));
 
@@ -584,17 +507,18 @@ macro_rules! impl_diesel_job_ops {
                             break;
                         }
 
-                        // Skip expired jobs (and mark them cancelled).
+                        // Skip expired jobs — archive them as cancelled so they
+                        // leave the live `jobs` table (matching `dequeue`).
                         if let Some(expires_at) = row.expires_at {
                             if now > expires_at {
-                                diesel::update(jobs::table)
-                                    .filter(jobs::id.eq(&row.id))
-                                    .set((
-                                        jobs::status.eq(JobStatus::Cancelled as i32),
-                                        jobs::completed_at.eq(now),
-                                        jobs::error.eq("expired before execution"),
-                                    ))
-                                    .execute(conn)?;
+                                let mut full: JobRow = jobs::table
+                                    .find(&row.id)
+                                    .select(JobRow::as_select())
+                                    .first(conn)?;
+                                full.status = JobStatus::Cancelled as i32;
+                                full.completed_at = Some(now);
+                                full.error = Some("expired before execution".to_string());
+                                Self::archive_job_row(conn, &full)?;
                                 continue;
                             }
                         }
@@ -963,19 +887,14 @@ macro_rules! impl_diesel_job_ops {
             pub fn get_job(&self, id: &str) -> Result<Option<Job>> {
                 let mut conn = self.conn()?;
 
-                let row: Option<(NarrowJobRow, JobPayloadRow)> = jobs::table
-                    .inner_join(job_payloads::table.on(job_payloads::job_id.eq(jobs::id)))
-                    .filter(jobs::id.eq(id))
-                    .select((NarrowJobRow::as_select(), JobPayloadRow::as_select()))
+                let row: Option<JobRow> = jobs::table
+                    .find(id)
+                    .select(JobRow::as_select())
                     .first(&mut conn)
                     .optional()?;
 
-                if let Some((narrow, payload)) = row {
-                    return Ok(Some(Job::from_narrow(
-                        narrow,
-                        payload.payload,
-                        payload.result,
-                    )));
+                if let Some(jobrow) = row {
+                    return Ok(Some(Job::from(jobrow)));
                 }
 
                 let archived: Option<ArchivedJobRow> = archived_jobs::table
@@ -1180,10 +1099,7 @@ macro_rules! impl_diesel_job_ops {
             ) -> Result<Vec<Job>> {
                 let mut conn = self.conn()?;
 
-                let mut query = jobs::table
-                    .inner_join(job_payloads::table.on(job_payloads::job_id.eq(jobs::id)))
-                    .into_boxed()
-                    .order(jobs::created_at.desc());
+                let mut query = jobs::table.into_boxed().order(jobs::created_at.desc());
 
                 if let Some(s) = status {
                     query = query.filter(jobs::status.eq(s));
@@ -1210,18 +1126,13 @@ macro_rules! impl_diesel_job_ops {
                     query = query.filter(jobs::namespace.eq(ns));
                 }
 
-                let rows: Vec<(NarrowJobRow, JobPayloadRow)> = query
+                let rows: Vec<JobRow> = query
                     .limit(limit)
                     .offset(offset)
-                    .select((NarrowJobRow::as_select(), JobPayloadRow::as_select()))
+                    .select(JobRow::as_select())
                     .load(&mut conn)?;
 
-                Ok(rows
-                    .into_iter()
-                    .map(|(narrow, payload)| {
-                        Job::from_narrow(narrow, payload.payload, payload.result)
-                    })
-                    .collect())
+                Ok(rows.into_iter().map(Job::from).collect())
             }
 
             /// Query the `archived_jobs` table with the shared filter set.

--- a/crates/taskito-core/src/storage/diesel_common/migrations.rs
+++ b/crates/taskito-core/src/storage/diesel_common/migrations.rs
@@ -96,13 +96,6 @@ pub fn create_tables(d: &Dialect) -> Vec<String> {
             )"
         ),
         format!(
-            "CREATE TABLE IF NOT EXISTS job_payloads (
-                job_id  TEXT PRIMARY KEY REFERENCES jobs(id) ON DELETE CASCADE,
-                payload {bin} NOT NULL,
-                result  {bin}
-            )"
-        ),
-        format!(
             "CREATE TABLE IF NOT EXISTS dead_letter (
                 id              TEXT PRIMARY KEY,
                 original_job_id TEXT NOT NULL,
@@ -297,6 +290,21 @@ pub fn create_indexes() -> &'static [&'static str] {
                 ON archived_jobs(queue, status)",
         "CREATE INDEX IF NOT EXISTS idx_distributed_locks_expires ON distributed_locks(expires_at)",
         "CREATE INDEX IF NOT EXISTS idx_execution_claims_claimed ON execution_claims(claimed_at)",
+        // dead_letter had no indexes: every DLQ list/purge/auto-retry was a full
+        // scan, and list_dead_for_retry runs on every maintenance tick.
+        "CREATE INDEX IF NOT EXISTS idx_dead_letter_failed_at ON dead_letter(failed_at)",
+        "CREATE INDEX IF NOT EXISTS idx_dead_letter_task ON dead_letter(task_name)",
+        // count_running_by_task / cancel_pending_by_task filter (task_name, status).
+        "CREATE INDEX IF NOT EXISTS idx_jobs_task_status ON jobs(task_name, status)",
+        // expire_pending_jobs scans pending rows for a due expires_at.
+        "CREATE INDEX IF NOT EXISTS idx_jobs_expires_at
+                ON jobs(expires_at) WHERE expires_at IS NOT NULL",
+        // namespace-filtered listing (and namespace-less dequeue scans).
+        "CREATE INDEX IF NOT EXISTS idx_jobs_namespace
+                ON jobs(namespace) WHERE namespace IS NOT NULL",
+        // list_archived_filtered orders by created_at; namespace filter likewise.
+        "CREATE INDEX IF NOT EXISTS idx_archived_jobs_created_at ON archived_jobs(created_at)",
+        "CREATE INDEX IF NOT EXISTS idx_archived_jobs_namespace ON archived_jobs(namespace)",
     ]
 }
 
@@ -381,19 +389,14 @@ pub fn backfill_statements() -> &'static [&'static str] {
     ]
 }
 
-/// Backfill the `job_payloads` side table from the kept `jobs.payload` /
-/// `jobs.result` columns. Idempotent: SQLite uses `INSERT OR IGNORE`, Postgres
-/// `ON CONFLICT (job_id) DO NOTHING`, so it only copies rows that aren't there
-/// yet. After a database that pre-dates the side table is migrated, every live
-/// job gets a matching payload row; subsequent runs match nothing.
-pub fn backfill_payload_side_table(d: &Dialect) -> Vec<String> {
-    let stmt = if d.alter_if_not_exists.is_empty() {
-        // SQLite: empty `alter_if_not_exists` marks this dialect.
-        "INSERT OR IGNORE INTO job_payloads (job_id, payload, result) \
-         SELECT id, payload, result FROM jobs"
-    } else {
-        "INSERT INTO job_payloads (job_id, payload, result) \
-         SELECT id, payload, result FROM jobs ON CONFLICT (job_id) DO NOTHING"
-    };
-    vec![stmt.to_string()]
+/// Drop tables from earlier schema versions that are no longer used. Run after
+/// [`create_tables`]; `DROP TABLE IF EXISTS` makes it a no-op on fresh databases
+/// and idempotent on re-run.
+///
+/// `job_payloads` was a 1:1 side table that duplicated `jobs.payload`. Payload
+/// and result now live inline on `jobs`/`archived_jobs`; the narrow dequeue scan
+/// selects around the blobs (Postgres TOAST / SQLite overflow keep them off the
+/// scanned pages), so the side table bought nothing and is removed.
+pub fn drop_legacy_tables() -> &'static [&'static str] {
+    &["DROP TABLE IF EXISTS job_payloads"]
 }

--- a/crates/taskito-core/src/storage/models.rs
+++ b/crates/taskito-core/src/storage/models.rs
@@ -3,8 +3,8 @@ use serde::{Deserialize, Serialize};
 
 use super::schema::{
     archived_jobs, circuit_breakers, dashboard_settings, dead_letter, distributed_locks,
-    execution_claims, job_dependencies, job_errors, job_payloads, jobs, periodic_tasks,
-    queue_state, rate_limits, replay_history, task_logs, task_metrics, workers,
+    execution_claims, job_dependencies, job_errors, jobs, periodic_tasks, queue_state, rate_limits,
+    replay_history, task_logs, task_metrics, workers,
 };
 
 /// A row in the `jobs` table (for SELECT queries).
@@ -40,7 +40,9 @@ pub struct JobRow {
 /// A row in the `jobs` table with every column EXCEPT the `payload`/`result`
 /// blobs. The hot dequeue candidate scan, reap, and listing paths select this
 /// so claiming one job never reads up to 100 discarded payload blobs into heap.
-/// The blobs live in the 1:1 `job_payloads` side table.
+/// The blobs live inline in `jobs.payload`/`jobs.result` and are loaded (via the
+/// full [`JobRow`]) only for the single claimed winner. Postgres TOAST and SQLite
+/// overflow pages keep them off the pages a narrow select scans.
 #[derive(Queryable, Selectable, Debug, Clone)]
 #[diesel(table_name = jobs)]
 pub struct NarrowJobRow {
@@ -66,24 +68,6 @@ pub struct NarrowJobRow {
     pub result_ttl_ms: Option<i64>,
     pub namespace: Option<String>,
     pub has_deps: bool,
-}
-
-/// A row in the 1:1 `job_payloads` side table (for SELECT queries).
-#[derive(Queryable, Selectable, Debug, Clone)]
-#[diesel(table_name = job_payloads)]
-pub struct JobPayloadRow {
-    pub job_id: String,
-    pub payload: Vec<u8>,
-    pub result: Option<Vec<u8>>,
-}
-
-/// Insertable struct for `job_payloads` side-table rows.
-#[derive(Insertable, Debug)]
-#[diesel(table_name = job_payloads)]
-pub struct NewJobPayloadRow<'a> {
-    pub job_id: &'a str,
-    pub payload: &'a [u8],
-    pub result: Option<&'a [u8]>,
 }
 
 /// Insertable struct for creating new jobs.

--- a/crates/taskito-core/src/storage/postgres/archival.rs
+++ b/crates/taskito-core/src/storage/postgres/archival.rs
@@ -38,17 +38,6 @@ impl PostgresStorage {
             .bind::<diesel::sql_types::BigInt, _>(cutoff_ms)
             .execute(conn)?;
 
-            // The ON DELETE CASCADE FK would clear these on the jobs delete, but
-            // delete explicitly first to keep the ordering unambiguous and match
-            // the SQLite path.
-            diesel::sql_query(format!(
-                "DELETE FROM job_payloads WHERE job_id IN \
-                 (SELECT id FROM jobs WHERE status IN ({archivable_statuses}) \
-                  AND completed_at IS NOT NULL AND completed_at < $1)",
-            ))
-            .bind::<diesel::sql_types::BigInt, _>(cutoff_ms)
-            .execute(conn)?;
-
             diesel::sql_query(format!(
                 "DELETE FROM jobs WHERE status IN ({archivable_statuses}) AND completed_at IS NOT NULL AND completed_at < $1",
             ))

--- a/crates/taskito-core/src/storage/postgres/jobs.rs
+++ b/crates/taskito-core/src/storage/postgres/jobs.rs
@@ -3,8 +3,7 @@ use diesel::prelude::*;
 
 use super::super::models::*;
 use super::super::schema::{
-    archived_jobs, job_dependencies, job_errors, job_payloads, jobs, replay_history, task_logs,
-    task_metrics,
+    archived_jobs, job_dependencies, job_errors, jobs, replay_history, task_logs, task_metrics,
 };
 use super::PostgresStorage;
 use crate::error::{QueueError, Result};
@@ -25,5 +24,49 @@ impl PostgresStorage {
         let mut pooled = self.conn()?;
         let conn: &mut PgConnection = &mut pooled;
         conn.transaction(f)
+    }
+
+    /// Load up to `limit` ready candidate rows (narrow — no payload/result
+    /// blobs) for a dequeue, locking each with `FOR UPDATE SKIP LOCKED`.
+    ///
+    /// SKIP LOCKED is what lets many Postgres workers dequeue concurrently
+    /// without contending: each worker's scan skips rows another worker has
+    /// already locked in its open transaction, so they claim disjoint sets
+    /// instead of all racing on the same head rows. Runs inside the caller's
+    /// `write_transaction`, which holds the locks until the claim commits.
+    ///
+    /// Locking is not available on a boxed query in Diesel, so the namespace
+    /// filter is branched into two concrete (un-boxed) statements rather than
+    /// built dynamically.
+    fn scan_dequeue_candidates(
+        conn: &mut PgConnection,
+        queue_name: &str,
+        now: i64,
+        namespace: Option<&str>,
+        limit: i64,
+    ) -> diesel::result::QueryResult<Vec<NarrowJobRow>> {
+        let base = jobs::table
+            .filter(jobs::queue.eq(queue_name))
+            .filter(jobs::status.eq(JobStatus::Pending as i32))
+            .filter(jobs::scheduled_at.le(now));
+
+        match namespace {
+            Some(ns) => base
+                .filter(jobs::namespace.eq(ns))
+                .order((jobs::priority.desc(), jobs::scheduled_at.asc()))
+                .limit(limit)
+                .select(NarrowJobRow::as_select())
+                .for_update()
+                .skip_locked()
+                .load(conn),
+            None => base
+                .filter(jobs::namespace.is_null())
+                .order((jobs::priority.desc(), jobs::scheduled_at.asc()))
+                .limit(limit)
+                .select(NarrowJobRow::as_select())
+                .for_update()
+                .skip_locked()
+                .load(conn),
+        }
     }
 }

--- a/crates/taskito-core/src/storage/postgres/mod.rs
+++ b/crates/taskito-core/src/storage/postgres/mod.rs
@@ -148,19 +148,23 @@ impl PostgresStorage {
         for sql in common_migrations::create_tables(&common_migrations::POSTGRES) {
             diesel::sql_query(&sql).execute(&mut conn)?;
         }
-        for sql in common_migrations::create_indexes() {
-            diesel::sql_query(*sql).execute(&mut conn)?;
-        }
+        // Alters run before indexes: some indexed columns (e.g. `namespace`) are
+        // added here, so the index DDL must see the fully-widened tables.
         for sql in common_migrations::alter_statements(&common_migrations::POSTGRES) {
             migration_alter(&mut conn, &sql)?;
+        }
+        for sql in common_migrations::create_indexes() {
+            diesel::sql_query(*sql).execute(&mut conn)?;
         }
         // Data backfills must fail loudly — a swallowed failure would leave
         // has_deps wrong and let dequeue bypass dependency enforcement.
         for sql in common_migrations::backfill_statements() {
             diesel::sql_query(*sql).execute(&mut conn)?;
         }
-        for sql in common_migrations::backfill_payload_side_table(&common_migrations::POSTGRES) {
-            diesel::sql_query(&sql).execute(&mut conn)?;
+        // Drop legacy tables (e.g. the old `job_payloads` side table). `IF EXISTS`
+        // keeps it idempotent, so run it directly rather than via `migration_alter`.
+        for sql in common_migrations::drop_legacy_tables() {
+            diesel::sql_query(*sql).execute(&mut conn)?;
         }
         drop(conn);
 

--- a/crates/taskito-core/src/storage/schema.rs
+++ b/crates/taskito-core/src/storage/schema.rs
@@ -225,13 +225,4 @@ diesel::table! {
     }
 }
 
-diesel::table! {
-    job_payloads (job_id) {
-        job_id -> Text,
-        payload -> Binary,
-        result -> Nullable<Binary>,
-    }
-}
-
 diesel::allow_tables_to_appear_in_same_query!(jobs, job_dependencies);
-diesel::allow_tables_to_appear_in_same_query!(jobs, job_payloads);

--- a/crates/taskito-core/src/storage/sqlite/archival.rs
+++ b/crates/taskito-core/src/storage/sqlite/archival.rs
@@ -39,17 +39,6 @@ impl SqliteStorage {
             .bind::<diesel::sql_types::BigInt, _>(cutoff_ms)
             .execute(conn)?;
 
-            // Drop the side-table rows for the jobs about to be deleted.
-            // SQLite doesn't enforce the ON DELETE CASCADE FK unless
-            // `PRAGMA foreign_keys = ON`, so delete explicitly to avoid orphans.
-            diesel::sql_query(format!(
-                "DELETE FROM job_payloads WHERE job_id IN \
-                 (SELECT id FROM jobs WHERE status IN ({archivable_statuses}) \
-                  AND completed_at IS NOT NULL AND completed_at < ?1)",
-            ))
-            .bind::<diesel::sql_types::BigInt, _>(cutoff_ms)
-            .execute(conn)?;
-
             diesel::sql_query(format!(
                 "DELETE FROM jobs WHERE status IN ({archivable_statuses}) AND completed_at IS NOT NULL AND completed_at < ?1",
             ))

--- a/crates/taskito-core/src/storage/sqlite/jobs.rs
+++ b/crates/taskito-core/src/storage/sqlite/jobs.rs
@@ -3,8 +3,7 @@ use diesel::sqlite::SqliteConnection;
 
 use super::super::models::*;
 use super::super::schema::{
-    archived_jobs, job_dependencies, job_errors, job_payloads, jobs, replay_history, task_logs,
-    task_metrics,
+    archived_jobs, job_dependencies, job_errors, jobs, replay_history, task_logs, task_metrics,
 };
 use super::SqliteStorage;
 use crate::error::{QueueError, Result};
@@ -32,5 +31,30 @@ impl SqliteStorage {
     {
         let mut conn = self.conn()?;
         conn.immediate_transaction(f)
+    }
+
+    /// Load up to `limit` ready candidate rows (narrow — no payload/result
+    /// blobs) for a dequeue. SQLite needs no row-level locking clause: the
+    /// `BEGIN IMMEDIATE` write transaction already serializes writers, so two
+    /// dequeues never scan the same uncommitted candidates concurrently.
+    fn scan_dequeue_candidates(
+        conn: &mut SqliteConnection,
+        queue_name: &str,
+        now: i64,
+        namespace: Option<&str>,
+        limit: i64,
+    ) -> diesel::result::QueryResult<Vec<NarrowJobRow>> {
+        let mut query = jobs::table
+            .filter(jobs::queue.eq(queue_name))
+            .filter(jobs::status.eq(JobStatus::Pending as i32))
+            .filter(jobs::scheduled_at.le(now))
+            .order((jobs::priority.desc(), jobs::scheduled_at.asc()))
+            .limit(limit)
+            .into_boxed();
+        query = match namespace {
+            Some(ns) => query.filter(jobs::namespace.eq(ns)),
+            None => query.filter(jobs::namespace.is_null()),
+        };
+        query.select(NarrowJobRow::as_select()).load(conn)
     }
 }

--- a/crates/taskito-core/src/storage/sqlite/mod.rs
+++ b/crates/taskito-core/src/storage/sqlite/mod.rs
@@ -136,19 +136,23 @@ impl SqliteStorage {
         for sql in common_migrations::create_tables(&common_migrations::SQLITE) {
             diesel::sql_query(&sql).execute(&mut conn)?;
         }
-        for sql in common_migrations::create_indexes() {
-            diesel::sql_query(*sql).execute(&mut conn)?;
-        }
+        // Alters run before indexes: some indexed columns (e.g. `namespace`) are
+        // added here, so the index DDL must see the fully-widened tables.
         for sql in common_migrations::alter_statements(&common_migrations::SQLITE) {
             migration_alter(&mut conn, &sql)?;
+        }
+        for sql in common_migrations::create_indexes() {
+            diesel::sql_query(*sql).execute(&mut conn)?;
         }
         // Data backfills must fail loudly — a swallowed failure would leave
         // has_deps wrong and let dequeue bypass dependency enforcement.
         for sql in common_migrations::backfill_statements() {
             diesel::sql_query(*sql).execute(&mut conn)?;
         }
-        for sql in common_migrations::backfill_payload_side_table(&common_migrations::SQLITE) {
-            diesel::sql_query(&sql).execute(&mut conn)?;
+        // Drop legacy tables (e.g. the old `job_payloads` side table). `IF EXISTS`
+        // keeps it idempotent, so run it directly rather than via `migration_alter`.
+        for sql in common_migrations::drop_legacy_tables() {
+            diesel::sql_query(*sql).execute(&mut conn)?;
         }
         drop(conn);
 

--- a/crates/taskito-core/src/storage/sqlite/tests.rs
+++ b/crates/taskito-core/src/storage/sqlite/tests.rs
@@ -1033,37 +1033,18 @@ fn test_fail_and_cancel_archive_immediately() {
     );
 }
 
-// ── Payload side-table (job_payloads) ────────────────────────────────
-
-/// Count rows in `job_payloads` for a given job id.
-fn payload_row_count(storage: &SqliteStorage, job_id: &str) -> i64 {
-    use crate::storage::schema::job_payloads;
-    use diesel::prelude::*;
-    let mut conn = storage.conn().unwrap();
-    job_payloads::table
-        .filter(job_payloads::job_id.eq(job_id))
-        .count()
-        .get_result(&mut conn)
-        .unwrap()
-}
+// ── Payload storage (inline on jobs) ─────────────────────────────────
 
 #[test]
-fn test_enqueue_populates_payload_side_table() {
-    use crate::storage::schema::job_payloads;
-    use diesel::prelude::*;
+fn test_enqueue_stores_payload_inline() {
     let storage = test_storage();
-    let mut nj = make_job("side_table");
+    let mut nj = make_job("inline_payload");
     nj.payload = vec![9, 8, 7, 6];
     let job = storage.enqueue(nj).unwrap();
 
-    let mut conn = storage.conn().unwrap();
-    let (payload, result): (Vec<u8>, Option<Vec<u8>>) = job_payloads::table
-        .filter(job_payloads::job_id.eq(&job.id))
-        .select((job_payloads::payload, job_payloads::result))
-        .first(&mut conn)
-        .unwrap();
-    assert_eq!(payload, vec![9, 8, 7, 6]);
-    assert!(result.is_none());
+    let fetched = storage.get_job(&job.id).unwrap().unwrap();
+    assert_eq!(fetched.payload, vec![9, 8, 7, 6]);
+    assert_eq!(fetched.status, JobStatus::Pending);
 }
 
 #[test]
@@ -1082,50 +1063,129 @@ fn test_dequeue_returns_full_payload() {
 }
 
 #[test]
-fn test_complete_archives_and_removes_side_table_row() {
+fn test_dequeue_batch_returns_full_payload() {
     let storage = test_storage();
-    let job = storage.enqueue(make_job("complete_side")).unwrap();
+    let mut a = make_job("batch_pa");
+    a.payload = vec![1, 2, 3];
+    let mut b = make_job("batch_pb");
+    b.payload = vec![4, 5, 6];
+    storage.enqueue(a).unwrap();
+    storage.enqueue(b).unwrap();
+
+    let claimed = storage
+        .dequeue_batch("default", now_millis() + 1000, None, 10)
+        .unwrap();
+    assert_eq!(claimed.len(), 2);
+    for j in &claimed {
+        assert_eq!(j.status, JobStatus::Running);
+    }
+    let payloads: std::collections::HashSet<Vec<u8>> =
+        claimed.iter().map(|j| j.payload.clone()).collect();
+    assert!(payloads.contains(&vec![1, 2, 3]));
+    assert!(payloads.contains(&vec![4, 5, 6]));
+}
+
+#[test]
+fn test_dequeue_batch_archives_expired() {
+    let storage = test_storage();
+    let mut expired = make_job("batch_expired");
+    expired.expires_at = Some(now_millis() - 1000);
+    let expired_job = storage.enqueue(expired).unwrap();
+    let fresh_job = storage.enqueue(make_job("batch_fresh")).unwrap();
+
+    let claimed = storage
+        .dequeue_batch("default", now_millis() + 1000, None, 10)
+        .unwrap();
+
+    // Only the fresh job is claimed; the expired one is archived, not stranded
+    // in `jobs` as a terminal row.
+    assert_eq!(claimed.len(), 1);
+    assert_eq!(claimed[0].id, fresh_job.id);
+    assert_eq!(jobs_row_count(&storage, &expired_job.id), 0);
+    let fetched = storage.get_job(&expired_job.id).unwrap().unwrap();
+    assert_eq!(fetched.status, JobStatus::Cancelled);
+}
+
+#[test]
+fn test_complete_archives_job() {
+    let storage = test_storage();
+    let job = storage.enqueue(make_job("complete_inline")).unwrap();
     storage.dequeue("default", now_millis(), None).unwrap();
-    // The side-table row exists while the job is live.
-    assert_eq!(payload_row_count(&storage, &job.id), 1);
 
     storage.complete(&job.id, Some(vec![5, 5, 5])).unwrap();
 
-    // Completing archives the job: the live row and its side-table row are
-    // both gone; the result is preserved in `archived_jobs`.
+    // Completing archives the job: the live row is gone; payload+result are
+    // preserved inline in `archived_jobs`.
     assert_eq!(jobs_row_count(&storage, &job.id), 0);
-    assert_eq!(payload_row_count(&storage, &job.id), 0);
     let fetched = storage.get_job(&job.id).unwrap().unwrap();
+    assert_eq!(fetched.status, JobStatus::Complete);
     assert_eq!(fetched.result, Some(vec![5, 5, 5]));
 }
 
 #[test]
 fn test_get_job_returns_payload_and_result() {
     let storage = test_storage();
-    let mut nj = make_job("get_side");
+    let mut nj = make_job("get_inline");
     nj.payload = vec![1, 1, 2, 3, 5];
     let job = storage.enqueue(nj).unwrap();
     storage.dequeue("default", now_millis(), None).unwrap();
     storage.complete(&job.id, Some(vec![8, 13])).unwrap();
 
-    // After archival, get_job assembles payload + result from `archived_jobs`.
+    // After archival, get_job reads payload + result from `archived_jobs`.
     let fetched = storage.get_job(&job.id).unwrap().unwrap();
     assert_eq!(fetched.payload, vec![1, 1, 2, 3, 5]);
     assert_eq!(fetched.result, Some(vec![8, 13]));
 }
 
 #[test]
-fn test_side_table_stays_one_to_one_with_live_jobs() {
+fn test_cancel_pending_archives_job() {
     let storage = test_storage();
-    let job = storage.enqueue(make_job("cascade_side")).unwrap();
-    // A live (pending) job has exactly one side-table row.
-    assert_eq!(payload_row_count(&storage, &job.id), 1);
+    let job = storage.enqueue(make_job("cancel_inline")).unwrap();
 
-    // Cancelling the pending job archives it and drops the side-table row,
-    // keeping `job_payloads` 1:1 with the live `jobs` table (no leak).
+    // Cancelling a pending job archives it: the live row leaves `jobs`.
     assert!(storage.cancel_job(&job.id).unwrap());
     assert_eq!(jobs_row_count(&storage, &job.id), 0);
-    assert_eq!(payload_row_count(&storage, &job.id), 0);
+    assert_eq!(
+        storage.get_job(&job.id).unwrap().unwrap().status,
+        JobStatus::Cancelled
+    );
+}
+
+#[test]
+fn test_new_indexes_present() {
+    use diesel::prelude::*;
+    use diesel::sql_types::Text;
+
+    #[derive(QueryableByName)]
+    struct IdxName {
+        #[diesel(sql_type = Text)]
+        name: String,
+    }
+
+    let storage = test_storage();
+    let mut conn = storage.conn().unwrap();
+    let names: Vec<String> =
+        diesel::sql_query("SELECT name FROM sqlite_master WHERE type = 'index'")
+            .load::<IdxName>(&mut conn)
+            .unwrap()
+            .into_iter()
+            .map(|r| r.name)
+            .collect();
+
+    for expected in [
+        "idx_dead_letter_failed_at",
+        "idx_dead_letter_task",
+        "idx_jobs_task_status",
+        "idx_jobs_expires_at",
+        "idx_jobs_namespace",
+        "idx_archived_jobs_created_at",
+        "idx_archived_jobs_namespace",
+    ] {
+        assert!(
+            names.iter().any(|n| n == expected),
+            "missing index {expected}"
+        );
+    }
 }
 
 // -- DLQ policies --

--- a/crates/taskito-core/tests/rust/storage_tests.rs
+++ b/crates/taskito-core/tests/rust/storage_tests.rs
@@ -603,12 +603,11 @@ fn test_dependent_blocked_by_cancelled_parent(s: &impl Storage) {
     );
 }
 
-/// Exercise the payload/result round-trip through the full job lifecycle.
-/// On the Diesel backends this verifies the `job_payloads` side table is
-/// populated on enqueue, returned by dequeue, and read back by get_job after
-/// the job is archived. Redis passes trivially: its Job JSON already carries
-/// the blobs.
-fn test_payload_side_table(s: &impl Storage) {
+/// Exercise the payload/result round-trip through the full job lifecycle:
+/// payload stored on enqueue, returned by dequeue, and read back by get_job
+/// after the job is archived. On the Diesel backends payload/result live inline
+/// on `jobs`/`archived_jobs`; Redis carries them in the Job JSON.
+fn test_payload_roundtrip(s: &impl Storage) {
     let q = "q-payload-side-table";
     let mut nj = make_job(q, "payload_side_task");
     nj.payload = vec![0xDE, 0xAD, 0xBE, 0xEF];
@@ -626,14 +625,10 @@ fn test_payload_side_table(s: &impl Storage) {
     assert_eq!(fetched.result, Some(vec![0x01, 0x02, 0x03]));
 }
 
-/// A job run to completion is archived: its blobs move into `archived_jobs`
-/// and its `job_payloads` side-table row is dropped (no leak). `get_job` must
-/// still resolve the full payload + result from the archive. On the Diesel
-/// backends the archived job has no side-table row, so a stray join would lose
-/// it — this guards that the archived fallback reads `archived_jobs` directly.
-/// Redis passes trivially. The SQLite-only test
-/// `test_side_table_stays_one_to_one_with_live_jobs` asserts the row removal
-/// directly against `job_payloads`.
+/// A job run to completion is archived: its blobs move into `archived_jobs` and
+/// the live `jobs` row is removed. `get_job` must still resolve the full payload
+/// and result from the archive, and a terminal-status list must carry the
+/// blobs. Redis passes trivially.
 fn test_archived_job_payload_resolves(s: &impl Storage) {
     let q = "q-archived-payload-resolves";
     let mut nj = make_job(q, "archived_payload_task");
@@ -709,6 +704,42 @@ fn test_periodic_crud(s: &impl Storage) {
     assert!(!s.delete_periodic("pc-a").unwrap());
 }
 
+/// Two workers draining one queue concurrently must claim disjoint jobs — every
+/// enqueued job is handed out exactly once, never twice. Exercises the Postgres
+/// `FOR UPDATE SKIP LOCKED` dequeue path and the SQLite `BEGIN IMMEDIATE` /
+/// affected-row-count guard, and the Redis Lua claim. Uses scoped threads so the
+/// shared `&Storage` needs no `Arc`.
+fn test_concurrent_dequeue_no_double_claim(s: &impl Storage) {
+    let q = "q-concurrent-claim";
+    const N: usize = 60;
+    for i in 0..N {
+        s.enqueue(make_job(q, &format!("cc_{i}"))).unwrap();
+    }
+
+    let claimed = std::sync::Mutex::new(Vec::<String>::new());
+    let now = now_millis() + 1000;
+    std::thread::scope(|scope| {
+        for _ in 0..2 {
+            scope.spawn(|| {
+                while let Some(job) = s.dequeue(q, now, None).unwrap() {
+                    claimed.lock().unwrap().push(job.id);
+                }
+            });
+        }
+    });
+
+    let mut ids = claimed.into_inner().unwrap();
+    let total = ids.len();
+    ids.sort();
+    ids.dedup();
+    assert_eq!(ids.len(), total, "a job was claimed more than once");
+    assert_eq!(
+        ids.len(),
+        N,
+        "every enqueued job must be claimed exactly once"
+    );
+}
+
 fn run_storage_tests(s: &impl Storage) {
     test_enqueue_and_get(s);
     test_dequeue(s);
@@ -738,8 +769,9 @@ fn run_storage_tests(s: &impl Storage) {
     test_immediate_archival(s);
     test_enqueue_dep_on_completed_archived_job(s);
     test_dependent_blocked_by_cancelled_parent(s);
-    test_payload_side_table(s);
+    test_payload_roundtrip(s);
     test_archived_job_payload_resolves(s);
+    test_concurrent_dequeue_no_double_claim(s);
     test_rate_limit_token_exhaustion(s);
 }
 

--- a/docs/content/docs/python/guides/operations/upgrading-0.15.mdx
+++ b/docs/content/docs/python/guides/operations/upgrading-0.15.mdx
@@ -145,24 +145,23 @@ and may take a few seconds on large databases.
 
 ## 6. Job payloads moved to a side table (`job_payloads`)
 
-**What changed.** Payload BLOBs are now stored in a separate `job_payloads`
-table rather than inline on the `jobs` row. The dequeue path no longer loads
-payload bytes for candidate jobs it does not ultimately claim, reducing I/O
-under contention.
+<Callout type="warn">
+  **Superseded.** A later release **removed** the `job_payloads` side table and
+  moved payloads back inline on `jobs`/`archived_jobs`. The narrow dequeue scan
+  already excludes the blobs by column selection, so the side table bought
+  nothing. The `jobs.payload`/`jobs.result` columns were never dropped, so the
+  removal moves no data and needs no upgrade window. This section is kept only as
+  history for databases that passed through 0.15.
+</Callout>
 
-This is transparent — no API change, no change to enqueue or result behaviour.
-
-**Rollback safety:** the `jobs.payload` and `jobs.result` columns are **kept
-and dual-written in 0.15**. If you need to roll back to a pre-0.15 binary, the
-data is still there.
-
-**0.16 column drop:** `jobs.payload` and `jobs.result` will be **dropped in the
-0.16 migration**. Plan your 0.16 upgrade window accordingly — once 0.16 is
-deployed you cannot roll that database back to 0.15.
+**What 0.15 did.** Payload BLOBs were stored in a separate `job_payloads` table
+rather than inline on the `jobs` row, dual-written alongside the kept
+`jobs.payload`/`jobs.result` columns. This was transparent — no API change, no
+change to enqueue or result behaviour.
 
 <Callout type="info">
-  Redis is unaffected by this change. The Redis backend stores job payloads
-  inline in the job JSON object and does not use the `job_payloads` table.
+  Redis was never affected: the Redis backend stores job payloads inline in the
+  job JSON object and never used a side table.
 </Callout>
 
 ## Upgrade checklist

--- a/docs/content/docs/python/guides/operations/upgrading-0.15.mdx
+++ b/docs/content/docs/python/guides/operations/upgrading-0.15.mdx
@@ -177,5 +177,3 @@ change to enqueue or result behaviour.
   the extension with `--features push-dispatch`. Not required for correctness.
 - [ ] **Downgrade floor:** after upgrading any database to 0.15, do not run
   pre-0.15 binaries against it.
-- [ ] **0.16 column drop:** the `jobs.payload` and `jobs.result` columns will
-  be removed in 0.16. Ensure all workers are on 0.15 before upgrading to 0.16.

--- a/docs/content/docs/resources/changelog.mdx
+++ b/docs/content/docs/resources/changelog.mdx
@@ -10,6 +10,32 @@ All notable changes to taskito are documented here. The format is based on
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html). All SDKs (Python, Node, Java) and the
 underlying Rust crates are released together, in lock-step.
 
+## Unreleased
+
+### Changed
+
+- **Storage dequeue hardening.** Postgres now dequeues with `FOR UPDATE SKIP LOCKED`,
+  so concurrent workers claim disjoint jobs instead of all scanning the same
+  candidates and racing on the claim. `dequeue_batch` no longer reads payload blobs
+  during its candidate scan, and expired batch candidates are archived instead of
+  left stranded in the live table. No API or wire change.
+
+### Added
+
+- **Indexes for dead-letter and filter paths.** `dead_letter` (previously unindexed)
+  gains indexes on `failed_at` and `task_name`; `jobs` gains `(task_name, status)`
+  and partial indexes on `expires_at` / `namespace`; `archived_jobs` gains
+  `created_at` and `namespace`. Keeps DLQ, listing, and maintenance queries flat as
+  tables grow.
+
+### Removed
+
+- **`job_payloads` side table.** Reverted the 0.15 payload side table — payload and
+  result live inline on `jobs`/`archived_jobs` again. The narrow dequeue scan already
+  excludes the blobs by column selection (Postgres TOAST / SQLite overflow keep them
+  off the scanned pages), so the side table bought nothing. It is dropped on
+  migration; the inline columns were never removed, so no data moves.
+
 ## 0.17.0
 
 Feature release across the SDKs: periodic-task management, task-scoped dead-letter queries, and


### PR DESCRIPTION
## Summary

Tier-1 hardening of the storage core. All changes are internal — **no public SDK, wire-format, or `Storage`-trait change**.

### 1. Postgres dequeue uses `FOR UPDATE SKIP LOCKED`
The candidate scan is extracted into a per-backend `scan_dequeue_candidates`. Postgres locks each candidate with `FOR UPDATE SKIP LOCKED` so concurrent workers claim disjoint jobs instead of all scanning the same rows and racing on the claim `UPDATE`. SQLite keeps the boxed scan (`BEGIN IMMEDIATE` already serializes writers). Locking is unavailable on a Diesel boxed query, so the Postgres path branches the namespace filter into two concrete statements.

### 2. Removed the `job_payloads` side table (revert to inline)
Payload and result live inline on `jobs`/`archived_jobs` again. The narrow dequeue scan already excludes the blobs by column selection (Postgres TOAST / SQLite overflow keep them off the scanned pages), so the side table bought nothing — it only added a dual-write, a dead `result` column, and an inconsistency (`dequeue`/`get_job` read the side table, `dequeue_batch` read inline). Dropped on migration; the inline columns were never removed, so no data moves.

### 3. Indexes for dead-letter and filter paths
`dead_letter` had **zero** indexes — every DLQ list/purge/auto-retry was a full scan, some on every maintenance tick. Added: `dead_letter(failed_at)`, `dead_letter(task_name)`, `jobs(task_name, status)`, partial `jobs(expires_at)`, partial `jobs(namespace)`, `archived_jobs(created_at)`, `archived_jobs(namespace)`. Index creation now runs after the column `ALTER`s so the `namespace` indexes see the widened tables.

### 4. `dequeue_batch` consistency
Now uses the narrow candidate scan like `dequeue` (was reading up to 400 full blob rows per poll), and archives expired candidates instead of leaving them stranded in the live `jobs` table as `Cancelled`.

## Testing
- `cargo check` default + `--features postgres` + `--features redis` — clean
- `cargo test --workspace` + `--features workflows` — all green, including a new concurrent no-double-claim contract test (exercises the SKIP LOCKED path on Postgres)
- `cargo clippy` default + postgres + redis — zero warnings
- Python suite: **1077 passed, 4 skipped**

## Out of scope (deliberate)
status→enum, BIGINT→timestamptz, metadata→jsonb, and table consolidation are all breaking and break multi-backend (SQLite/Redis) parity for no real gain. Real Postgres `LISTEN/NOTIFY` (Diesel can't expose `PQnotifies`) and Redis Streams reliability are separate follow-ups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job processing reliability under concurrency by hardening dequeue candidate claiming to prevent duplicate claims and race conditions.
  * Expired batch candidates are now archived automatically instead of lingering in active queue tables.
  * Archived and completed jobs return payload and result data consistently using inline storage (no side-table joins).
* **Performance**
  * Faster dead-letter and filtered job listing, including batch/dequeue workflows, thanks to new composite and partial database indexes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->