### PR TITLE
chore(release): 0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to taskito are documented here. The format is based on
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html). All SDKs (Python, Node, Java) and the
 underlying Rust crates are released together, in lock-step.
 
-## Unreleased
+## 0.18.0
+
+Reliability and storage release: Postgres dequeues with `SKIP LOCKED`, crashed workers'
+in-flight jobs are recovered within ~30s instead of waiting their full timeout, and the
+dead-letter and filter paths are indexed. The internal `job_payloads` side table was removed
+(payloads inline again). No public API or wire-format change.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1481,7 +1481,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "taskito-core"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1505,7 +1505,7 @@ dependencies = [
 
 [[package]]
 name = "taskito-java"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
@@ -1523,7 +1523,7 @@ dependencies = [
 
 [[package]]
 name = "taskito-mesh"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "base64",
  "bincode",
@@ -1538,7 +1538,7 @@ dependencies = [
 
 [[package]]
 name = "taskito-node"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
@@ -1557,7 +1557,7 @@ dependencies = [
 
 [[package]]
 name = "taskito-python"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -1577,7 +1577,7 @@ dependencies = [
 
 [[package]]
 name = "taskito-workflows"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "dagron-core",
  "diesel",

--- a/crates/taskito-core/Cargo.toml
+++ b/crates/taskito-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-core"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 
 [features]

--- a/crates/taskito-java/Cargo.toml
+++ b/crates/taskito-java/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-java"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 description = "Java (JNI) bindings for the Taskito task-queue core"
 license = "MIT"

--- a/crates/taskito-mesh/Cargo.toml
+++ b/crates/taskito-mesh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-mesh"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 
 [dependencies]

--- a/crates/taskito-node/Cargo.toml
+++ b/crates/taskito-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-node"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 description = "Node.js (napi-rs) bindings for the Taskito task-queue core"
 license = "MIT"

--- a/crates/taskito-python/Cargo.toml
+++ b/crates/taskito-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-python"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 
 [features]

--- a/crates/taskito-workflows/Cargo.toml
+++ b/crates/taskito-workflows/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskito-workflows"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 
 [features]

--- a/docs/content/docs/resources/changelog.mdx
+++ b/docs/content/docs/resources/changelog.mdx
@@ -10,7 +10,12 @@ All notable changes to taskito are documented here. The format is based on
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html). All SDKs (Python, Node, Java) and the
 underlying Rust crates are released together, in lock-step.
 
-## Unreleased
+## 0.18.0
+
+Reliability and storage release: Postgres dequeues with `SKIP LOCKED`, crashed workers'
+in-flight jobs are recovered within ~30s instead of waiting their full timeout, and the
+dead-letter and filter paths are indexed. The internal `job_payloads` side table was removed
+(payloads inline again). No public API or wire-format change.
 
 ### Changed
 

--- a/sdks/java/build.gradle.kts
+++ b/sdks/java/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "org.byteveda"
-version = "0.17.0"
+version = "0.18.0"
 
 java {
     // Sources + javadoc jars are added by the maven-publish plugin below.

--- a/sdks/java/graalvm-smoke/build.gradle.kts
+++ b/sdks/java/graalvm-smoke/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "org.byteveda"
-version = "0.17.0"
+version = "0.18.0"
 
 repositories {
     mavenCentral()

--- a/sdks/java/processor/build.gradle.kts
+++ b/sdks/java/processor/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "org.byteveda"
-version = "0.17.0"
+version = "0.18.0"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_11

--- a/sdks/java/test-support/build.gradle.kts
+++ b/sdks/java/test-support/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "org.byteveda"
-version = "0.17.0"
+version = "0.18.0"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_11

--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byteveda/taskito",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Rust-powered task queue for Node.js — no broker required.",
   "license": "MIT",
   "type": "module",

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "taskito"
-version = "0.17.0"
+version = "0.18.0"
 description = "Rust-powered task queue for Python. No broker required."
 requires-python = ">=3.10"
 license = { file = "LICENSE" }

--- a/sdks/python/taskito/__init__.py
+++ b/sdks/python/taskito/__init__.py
@@ -122,4 +122,4 @@ try:
 
     __version__ = _get_version("taskito")
 except PackageNotFoundError:
-    __version__ = "0.17.0"
+    __version__ = "0.18.0"


### PR DESCRIPTION
## 0.18.0 release prep

Version bumped 0.17.0 → 0.18.0 across all crates and SDKs (13 manifests + `Cargo.lock`), and the `Unreleased` changelog section cut to `0.18.0`.

### Contents (already merged to master)
- **#319** — storage hardening: dropped `job_payloads` side table, Postgres `FOR UPDATE SKIP LOCKED` dequeue, dead-letter / filter-path indexes.
- **#320** — fast in-flight job recovery on worker death (+ Redis colon-owner fix).
- **#321** — Java SDK: generated test sources resolved in IDEs.

No public API or wire-format change.

### Version locations bumped
6 crate `Cargo.toml`, `sdks/python/pyproject.toml`, `sdks/python/taskito/__init__.py`, `sdks/node/package.json`, 4 Java `build.gradle.kts` (root + processor + test-support + graalvm-smoke), `Cargo.lock`.

### After merge (manual, from the GitHub UI)
- Python → PyPI: tag `0.18.0` → `publish.yml`.
- Node → npm `@byteveda/taskito`: tag `node-v0.18.0` → `publish-node.yml`.
- Java → Maven Central: tag `java-v0.18.0` → `publish-java.yml`.

Verified: `cargo check --workspace` green, ruff/mypy/tsc pre-commit pass, changelog mdx regenerated from source.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job processing reliability and recovery after worker interruptions.
  * Enhanced performance for queue-related lookups and dead-letter handling.

* **Documentation**
  * Added the 0.18.0 release notes to the changelog.

* **Chores**
  * Updated package and project versions to 0.18.0 across supported builds and SDKs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->