### PR TITLE
ci(java): auto-release the Maven Central deployment

### DIFF
--- a/.github/workflows/publish-java.yml
+++ b/.github/workflows/publish-java.yml
@@ -162,7 +162,10 @@ jobs:
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_KEY_PASSWORD }}
-        run: ./gradlew publishToMavenCentral -x cargoBuild -x copyNative --no-daemon
+        # `publishAndReleaseToMavenCentral` uploads AND releases the Central Portal
+        # deployment. Plain `publishToMavenCentral` only stages it (state stays
+        # VALIDATED), requiring a manual "Publish" click in the portal.
+        run: ./gradlew publishAndReleaseToMavenCentral -x cargoBuild -x copyNative --no-daemon
 
       - name: Create git tag
         if: github.event_name != 'push' && !inputs.dry-run


### PR DESCRIPTION
## Problem

The 0.18.0 Java release uploaded to Maven Central but stayed in **VALIDATED** state — never published — requiring a manual "Publish" click in the Central Portal.

## Cause

`publish-java.yml` ran `./gradlew publishToMavenCentral`, which only *stages* the Central Portal deployment. The vanniktech plugin's separate `publishAndReleaseToMavenCentral` task is the one that uploads **and** releases.

## Fix

Switch the publish step to `publishAndReleaseToMavenCentral`. Future Java releases publish automatically.

(Gradle config in `build.gradle.kts` is unchanged; the task name carries the release semantics.)

## Note

0.18.0 itself still needs a one-time manual **Publish** in the Central Portal (the VALIDATED deployment) — this fix prevents the manual step for 0.18.1+.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the Maven Central release workflow so standard publishing now completes the full upload-and-release process.
  * Dry-run publishing behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->