### PR TITLE
refactor(java): typed exception hierarchy

### DIFF
--- a/sdks/java/src/main/java/org/byteveda/taskito/DefaultTaskito.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/DefaultTaskito.java
@@ -14,6 +14,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import org.byteveda.taskito.core.CoreFacade;
+import org.byteveda.taskito.errors.SerializationException;
+import org.byteveda.taskito.errors.WorkflowException;
 import org.byteveda.taskito.locks.Lock;
 import org.byteveda.taskito.locks.LockInfo;
 import org.byteveda.taskito.middleware.EnqueueContext;
@@ -377,7 +379,7 @@ final class DefaultTaskito implements Taskito {
                 // A payloadless structural step (stepAfter) must get its payload at
                 // submit; fail fast rather than enqueue a null-payload job.
                 if (payload == null && !suppliedPayloads.containsKey(step.name)) {
-                    throw new TaskitoException("workflow step '" + step.name
+                    throw new WorkflowException("workflow step '" + step.name
                             + "' has no payload; supply one via submitWorkflow(wf, payloads)");
                 }
                 payloadNames.add(step.name);
@@ -547,7 +549,7 @@ final class DefaultTaskito implements Taskito {
         try {
             return VIEWS.writeValueAsString(value);
         } catch (Exception e) {
-            throw new TaskitoException("failed to encode request", e);
+            throw new SerializationException("failed to encode request", e);
         }
     }
 
@@ -555,7 +557,7 @@ final class DefaultTaskito implements Taskito {
         try {
             return VIEWS.readValue(json, type);
         } catch (Exception e) {
-            throw new TaskitoException("failed to decode native response", e);
+            throw new SerializationException("failed to decode native response", e);
         }
     }
 
@@ -564,7 +566,7 @@ final class DefaultTaskito implements Taskito {
         try {
             return VIEWS.readValue(json, type);
         } catch (Exception e) {
-            throw new TaskitoException("failed to decode native response", e);
+            throw new SerializationException("failed to decode native response", e);
         }
     }
 
@@ -573,7 +575,7 @@ final class DefaultTaskito implements Taskito {
         try {
             return VIEWS.readValue(json, type);
         } catch (Exception e) {
-            throw new TaskitoException("failed to decode native response", e);
+            throw new SerializationException("failed to decode native response", e);
         }
     }
 }

--- a/sdks/java/src/main/java/org/byteveda/taskito/DefaultTaskito.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/DefaultTaskito.java
@@ -493,13 +493,13 @@ final class DefaultTaskito implements Taskito {
             // A child run has no submit-time payload map and no callable registry, so
             // any step that depends on either would lose state — reject it at build time.
             if ("callable".equals(step.condition)) {
-                throw new TaskitoException("child workflow step '" + step.name
+                throw new WorkflowException("child workflow step '" + step.name
                         + "' uses condition(Condition); a sub-workflow cannot carry callable predicates");
             }
             boolean controlNode =
                     step.fanOut != null || step.fanIn != null || step.gate != null || step.subWorkflow != null;
             if (!controlNode && step.payload == null) {
-                throw new TaskitoException("child workflow step '" + step.name
+                throw new WorkflowException("child workflow step '" + step.name
                         + "' has no payload; a sub-workflow cannot supply child step payloads at submit");
             }
             specs.add(stepSpec(step));

--- a/sdks/java/src/main/java/org/byteveda/taskito/Taskito.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/Taskito.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import org.byteveda.taskito.errors.ConfigurationException;
 import org.byteveda.taskito.internal.JniQueueBackend;
 import org.byteveda.taskito.locks.Lock;
 import org.byteveda.taskito.locks.LockInfo;
@@ -288,7 +289,7 @@ public interface Taskito extends AutoCloseable {
                 String dsn = (String) options.computeIfAbsent("dsn", key -> DEFAULT_SQLITE_DB);
                 ensureSqliteParentDir(dsn);
             } else if (!options.containsKey("dsn")) {
-                throw new TaskitoException("url (dsn) is required");
+                throw new ConfigurationException("url (dsn) is required");
             }
             return new DefaultTaskito(JniQueueBackend.open(encodeOptions()), serializer);
         }
@@ -305,7 +306,7 @@ public interface Taskito extends AutoCloseable {
             try {
                 Files.createDirectories(parent);
             } catch (IOException e) {
-                throw new TaskitoException("failed to create sqlite directory " + parent, e);
+                throw new ConfigurationException("failed to create sqlite directory " + parent, e);
             }
         }
 
@@ -313,7 +314,7 @@ public interface Taskito extends AutoCloseable {
             try {
                 return JSON.writeValueAsString(options);
             } catch (Exception e) {
-                throw new TaskitoException("failed to encode open options", e);
+                throw new ConfigurationException("failed to encode open options", e);
             }
         }
     }

--- a/sdks/java/src/main/java/org/byteveda/taskito/dashboard/DashboardServer.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/dashboard/DashboardServer.java
@@ -22,7 +22,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.byteveda.taskito.Taskito;
-import org.byteveda.taskito.TaskitoException;
+import org.byteveda.taskito.errors.SerializationException;
 import org.byteveda.taskito.model.Job;
 import org.byteveda.taskito.model.JobFilter;
 import org.byteveda.taskito.model.JobStatus;
@@ -317,7 +317,7 @@ public final class DashboardServer implements AutoCloseable {
         try {
             out = JSON.writeValueAsBytes(body);
         } catch (Exception e) {
-            throw new TaskitoException("failed to encode response", e);
+            throw new SerializationException("failed to encode response", e);
         }
         exchange.getResponseHeaders().set("Content-Type", "application/json");
         exchange.sendResponseHeaders(status, out.length);

--- a/sdks/java/src/main/java/org/byteveda/taskito/errors/ConfigurationException.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/errors/ConfigurationException.java
@@ -1,0 +1,17 @@
+package org.byteveda.taskito.errors;
+
+import org.byteveda.taskito.TaskitoException;
+
+/**
+ * The SDK was misconfigured — e.g. a required connection URL is missing, or a
+ * storage directory could not be created.
+ */
+public class ConfigurationException extends TaskitoException {
+    public ConfigurationException(String message) {
+        super(message);
+    }
+
+    public ConfigurationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/sdks/java/src/main/java/org/byteveda/taskito/errors/CryptoException.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/errors/CryptoException.java
@@ -1,0 +1,17 @@
+package org.byteveda.taskito.errors;
+
+/**
+ * A cryptographic operation in a signing or encrypting serializer failed —
+ * encryption/decryption, HMAC computation, a signature mismatch, or a payload
+ * too short to carry its tag/IV. A {@link SerializationException} because it
+ * occurs while (de)serializing a secured payload.
+ */
+public class CryptoException extends SerializationException {
+    public CryptoException(String message) {
+        super(message);
+    }
+
+    public CryptoException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/sdks/java/src/main/java/org/byteveda/taskito/errors/LockException.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/errors/LockException.java
@@ -1,0 +1,17 @@
+package org.byteveda.taskito.errors;
+
+import org.byteveda.taskito.TaskitoException;
+
+/**
+ * A distributed lock operation failed or was interrupted while waiting to
+ * acquire the lock.
+ */
+public class LockException extends TaskitoException {
+    public LockException(String message) {
+        super(message);
+    }
+
+    public LockException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/sdks/java/src/main/java/org/byteveda/taskito/errors/SerializationException.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/errors/SerializationException.java
@@ -1,0 +1,18 @@
+package org.byteveda.taskito.errors;
+
+import org.byteveda.taskito.TaskitoException;
+
+/**
+ * A payload, option blob, or native response could not be serialized or
+ * deserialized — e.g. an unregistered type, malformed JSON, or a result whose
+ * shape does not match the expected class.
+ */
+public class SerializationException extends TaskitoException {
+    public SerializationException(String message) {
+        super(message);
+    }
+
+    public SerializationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/sdks/java/src/main/java/org/byteveda/taskito/errors/WebhookException.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/errors/WebhookException.java
@@ -1,0 +1,16 @@
+package org.byteveda.taskito.errors;
+
+import org.byteveda.taskito.TaskitoException;
+
+/**
+ * A webhook could not be stored, loaded, signed, or its payload encoded.
+ */
+public class WebhookException extends TaskitoException {
+    public WebhookException(String message) {
+        super(message);
+    }
+
+    public WebhookException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/sdks/java/src/main/java/org/byteveda/taskito/errors/WorkflowException.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/errors/WorkflowException.java
@@ -1,0 +1,18 @@
+package org.byteveda.taskito.errors;
+
+import org.byteveda.taskito.TaskitoException;
+
+/**
+ * A workflow could not be driven to completion — e.g. a run was not found, a
+ * deferred node has no registered payload, a callable condition was not
+ * registered on the worker, or awaiting a run was interrupted.
+ */
+public class WorkflowException extends TaskitoException {
+    public WorkflowException(String message) {
+        super(message);
+    }
+
+    public WorkflowException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/sdks/java/src/main/java/org/byteveda/taskito/errors/package-info.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/errors/package-info.java
@@ -1,0 +1,10 @@
+/**
+ * Specific unchecked exceptions for Taskito failure scenarios.
+ *
+ * <p>All extend {@link org.byteveda.taskito.TaskitoException}, so a caller can
+ * catch the base type to handle any SDK error, or a specific subtype
+ * ({@link org.byteveda.taskito.errors.SerializationException},
+ * {@link org.byteveda.taskito.errors.WorkflowException}, etc.) to react to one
+ * category. Native (JNI) errors surface as the base {@code TaskitoException}.
+ */
+package org.byteveda.taskito.errors;

--- a/sdks/java/src/main/java/org/byteveda/taskito/events/EventName.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/events/EventName.java
@@ -1,6 +1,6 @@
 package org.byteveda.taskito.events;
 
-import org.byteveda.taskito.TaskitoException;
+import org.byteveda.taskito.errors.SerializationException;
 
 /** Terminal outcome of a job, delivered to worker event listeners. */
 public enum EventName {
@@ -21,7 +21,7 @@ public enum EventName {
             case "cancelled":
                 return CANCELLED;
             default:
-                throw new TaskitoException("unknown outcome kind: " + kind);
+                throw new SerializationException("unknown outcome kind: " + kind);
         }
     }
 }

--- a/sdks/java/src/main/java/org/byteveda/taskito/locks/Lock.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/locks/Lock.java
@@ -2,7 +2,7 @@ package org.byteveda.taskito.locks;
 
 import java.time.Duration;
 import java.util.UUID;
-import org.byteveda.taskito.TaskitoException;
+import org.byteveda.taskito.errors.LockException;
 import org.byteveda.taskito.spi.QueueBackend;
 
 /**
@@ -40,7 +40,7 @@ public final class Lock implements AutoCloseable {
                 Thread.sleep(50);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-                throw new TaskitoException("interrupted while acquiring lock '" + name + "'", e);
+                throw new LockException("interrupted while acquiring lock '" + name + "'", e);
             }
         }
         return true;

--- a/sdks/java/src/main/java/org/byteveda/taskito/model/JobStatus.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/model/JobStatus.java
@@ -3,7 +3,7 @@ package org.byteveda.taskito.model;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.Locale;
-import org.byteveda.taskito.TaskitoException;
+import org.byteveda.taskito.errors.SerializationException;
 
 /** Lifecycle state of a job. Wire form is the lowercase name, shared across SDKs. */
 public enum JobStatus {
@@ -22,12 +22,12 @@ public enum JobStatus {
     @JsonCreator
     public static JobStatus fromWire(String wire) {
         if (wire == null) {
-            throw new TaskitoException("job status is null");
+            throw new SerializationException("job status is null");
         }
         try {
             return valueOf(wire.toUpperCase(Locale.ROOT));
         } catch (IllegalArgumentException e) {
-            throw new TaskitoException("unknown job status: " + wire, e);
+            throw new SerializationException("unknown job status: " + wire, e);
         }
     }
 }

--- a/sdks/java/src/main/java/org/byteveda/taskito/serialization/EncryptedSerializer.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/serialization/EncryptedSerializer.java
@@ -6,7 +6,7 @@ import java.util.Arrays;
 import javax.crypto.Cipher;
 import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
-import org.byteveda.taskito.TaskitoException;
+import org.byteveda.taskito.errors.CryptoException;
 
 /**
  * Wraps a delegate serializer with AES-GCM encryption. Each payload is prefixed
@@ -40,7 +40,7 @@ public final class EncryptedSerializer implements Serializer {
             System.arraycopy(ciphertext, 0, out, IV_LENGTH, ciphertext.length);
             return out;
         } catch (Exception e) {
-            throw new TaskitoException("encryption failed", e);
+            throw new CryptoException("encryption failed", e);
         }
     }
 
@@ -57,7 +57,7 @@ public final class EncryptedSerializer implements Serializer {
     /** Strip the IV, decrypt + authenticate (GCM), and return the plaintext. */
     private byte[] decrypt(byte[] bytes) {
         if (bytes.length < IV_LENGTH) {
-            throw new TaskitoException("encrypted payload is too short");
+            throw new CryptoException("encrypted payload is too short");
         }
         try {
             byte[] iv = Arrays.copyOfRange(bytes, 0, IV_LENGTH);
@@ -66,7 +66,7 @@ public final class EncryptedSerializer implements Serializer {
             cipher.init(Cipher.DECRYPT_MODE, key, new GCMParameterSpec(TAG_BITS, iv));
             return cipher.doFinal(ciphertext);
         } catch (Exception e) {
-            throw new TaskitoException("decryption failed", e);
+            throw new CryptoException("decryption failed", e);
         }
     }
 }

--- a/sdks/java/src/main/java/org/byteveda/taskito/serialization/JsonSerializer.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/serialization/JsonSerializer.java
@@ -2,7 +2,7 @@ package org.byteveda.taskito.serialization;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.lang.reflect.Type;
-import org.byteveda.taskito.TaskitoException;
+import org.byteveda.taskito.errors.SerializationException;
 
 /** Default {@link Serializer}: JSON via Jackson. */
 public final class JsonSerializer implements Serializer {
@@ -21,7 +21,7 @@ public final class JsonSerializer implements Serializer {
         try {
             return mapper.writeValueAsBytes(value);
         } catch (Exception e) {
-            throw new TaskitoException("failed to serialize payload", e);
+            throw new SerializationException("failed to serialize payload", e);
         }
     }
 
@@ -30,7 +30,7 @@ public final class JsonSerializer implements Serializer {
         try {
             return mapper.readValue(bytes, type);
         } catch (Exception e) {
-            throw new TaskitoException("failed to deserialize payload", e);
+            throw new SerializationException("failed to deserialize payload", e);
         }
     }
 
@@ -39,7 +39,7 @@ public final class JsonSerializer implements Serializer {
         try {
             return mapper.readValue(bytes, mapper.getTypeFactory().constructType(type));
         } catch (Exception e) {
-            throw new TaskitoException("failed to deserialize payload", e);
+            throw new SerializationException("failed to deserialize payload", e);
         }
     }
 }

--- a/sdks/java/src/main/java/org/byteveda/taskito/serialization/SignedSerializer.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/serialization/SignedSerializer.java
@@ -5,7 +5,7 @@ import java.security.MessageDigest;
 import java.util.Arrays;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
-import org.byteveda.taskito.TaskitoException;
+import org.byteveda.taskito.errors.CryptoException;
 
 /**
  * Wraps a delegate serializer, prefixing each payload with an HMAC-SHA256 tag.
@@ -46,12 +46,12 @@ public final class SignedSerializer implements Serializer {
     /** Verify the HMAC tag (constant-time) and return the signed body. */
     private byte[] verify(byte[] bytes) {
         if (bytes.length < MAC_LENGTH) {
-            throw new TaskitoException("signed payload is too short");
+            throw new CryptoException("signed payload is too short");
         }
         byte[] mac = Arrays.copyOfRange(bytes, 0, MAC_LENGTH);
         byte[] body = Arrays.copyOfRange(bytes, MAC_LENGTH, bytes.length);
         if (!MessageDigest.isEqual(mac, mac(body))) {
-            throw new TaskitoException("signature mismatch");
+            throw new CryptoException("signature mismatch");
         }
         return body;
     }
@@ -62,7 +62,7 @@ public final class SignedSerializer implements Serializer {
             mac.init(new SecretKeySpec(key, ALGORITHM));
             return mac.doFinal(body);
         } catch (Exception e) {
-            throw new TaskitoException("HMAC computation failed", e);
+            throw new CryptoException("HMAC computation failed", e);
         }
     }
 }

--- a/sdks/java/src/main/java/org/byteveda/taskito/webhooks/Deliverer.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/webhooks/Deliverer.java
@@ -8,7 +8,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
-import org.byteveda.taskito.TaskitoException;
+import org.byteveda.taskito.errors.WebhookException;
 
 /** Delivers webhook payloads over HTTP with an optional HMAC signature and retries. */
 final class Deliverer {
@@ -45,7 +45,7 @@ final class Deliverer {
             mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), ALGORITHM));
             return hex(mac.doFinal(body));
         } catch (Exception e) {
-            throw new TaskitoException("webhook signature failed", e);
+            throw new WebhookException("webhook signature failed", e);
         }
     }
 

--- a/sdks/java/src/main/java/org/byteveda/taskito/webhooks/WebhookManager.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/webhooks/WebhookManager.java
@@ -9,7 +9,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import org.byteveda.taskito.Taskito;
-import org.byteveda.taskito.TaskitoException;
+import org.byteveda.taskito.errors.WebhookException;
 import org.byteveda.taskito.events.OutcomeEvent;
 import org.byteveda.taskito.middleware.Middleware;
 
@@ -118,7 +118,7 @@ public final class WebhookManager implements Middleware {
         try {
             return JSON.writeValueAsBytes(body);
         } catch (Exception e) {
-            throw new TaskitoException("webhook payload encoding failed", e);
+            throw new WebhookException("webhook payload encoding failed", e);
         }
     }
 }

--- a/sdks/java/src/main/java/org/byteveda/taskito/webhooks/WebhookStore.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/webhooks/WebhookStore.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.type.CollectionType;
 import java.util.ArrayList;
 import java.util.List;
 import org.byteveda.taskito.Taskito;
-import org.byteveda.taskito.TaskitoException;
+import org.byteveda.taskito.errors.WebhookException;
 
 /** Persists webhooks as a JSON list in the queue's settings key/value store. */
 final class WebhookStore {
@@ -26,7 +26,7 @@ final class WebhookStore {
         try {
             queue.setSetting(KEY, JSON.writeValueAsString(webhooks));
         } catch (Exception e) {
-            throw new TaskitoException("failed to persist webhooks", e);
+            throw new WebhookException("failed to persist webhooks", e);
         }
     }
 
@@ -35,7 +35,7 @@ final class WebhookStore {
             CollectionType type = JSON.getTypeFactory().constructCollectionType(List.class, Webhook.class);
             return JSON.readValue(json, type);
         } catch (Exception e) {
-            throw new TaskitoException("failed to read webhooks", e);
+            throw new WebhookException("failed to read webhooks", e);
         }
     }
 }

--- a/sdks/java/src/main/java/org/byteveda/taskito/worker/Worker.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/worker/Worker.java
@@ -13,7 +13,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
-import org.byteveda.taskito.TaskitoException;
+import org.byteveda.taskito.errors.SerializationException;
+import org.byteveda.taskito.errors.WorkflowException;
 import org.byteveda.taskito.events.Emitter;
 import org.byteveda.taskito.events.EventName;
 import org.byteveda.taskito.events.OutcomeEvent;
@@ -71,7 +72,7 @@ public final class Worker implements AutoCloseable {
 
     private WorkflowTracker requireTracker() {
         if (tracker == null) {
-            throw new TaskitoException("worker is not tracking workflows; call trackWorkflows() on the builder");
+            throw new WorkflowException("worker is not tracking workflows; call trackWorkflows() on the builder");
         }
         return tracker;
     }
@@ -255,7 +256,7 @@ public final class Worker implements AutoCloseable {
             try {
                 return JSON.writeValueAsString(options);
             } catch (Exception e) {
-                throw new TaskitoException("failed to encode worker options", e);
+                throw new SerializationException("failed to encode worker options", e);
             }
         }
 

--- a/sdks/java/src/main/java/org/byteveda/taskito/workflows/WorkflowRun.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/workflows/WorkflowRun.java
@@ -3,7 +3,8 @@ package org.byteveda.taskito.workflows;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Duration;
 import java.util.Optional;
-import org.byteveda.taskito.TaskitoException;
+import org.byteveda.taskito.errors.SerializationException;
+import org.byteveda.taskito.errors.WorkflowException;
 import org.byteveda.taskito.spi.QueueBackend;
 
 /** A submitted workflow run. Query {@link #status()}, block on {@link #await}, or {@link #cancel()}. */
@@ -47,18 +48,18 @@ public final class WorkflowRun implements AutoCloseable {
     public WorkflowStatus await(Duration timeout, Duration pollInterval) {
         long deadline = System.nanoTime() + timeout.toNanos();
         while (true) {
-            WorkflowStatus status = status().orElseThrow(() -> new TaskitoException("workflow run not found: " + id));
+            WorkflowStatus status = status().orElseThrow(() -> new WorkflowException("workflow run not found: " + id));
             if (status.isTerminal()) {
                 return status;
             }
             if (System.nanoTime() >= deadline) {
-                throw new TaskitoException("workflow '" + id + "' did not finish within " + timeout);
+                throw new WorkflowException("workflow '" + id + "' did not finish within " + timeout);
             }
             try {
                 Thread.sleep(pollInterval.toMillis());
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-                throw new TaskitoException("interrupted while awaiting workflow " + id, e);
+                throw new WorkflowException("interrupted while awaiting workflow " + id, e);
             }
         }
     }
@@ -78,7 +79,7 @@ public final class WorkflowRun implements AutoCloseable {
         try {
             return json.readValue(raw, WorkflowStatus.class);
         } catch (Exception e) {
-            throw new TaskitoException("failed to decode workflow status", e);
+            throw new SerializationException("failed to decode workflow status", e);
         }
     }
 }

--- a/sdks/java/src/main/java/org/byteveda/taskito/workflows/WorkflowTracker.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/workflows/WorkflowTracker.java
@@ -18,7 +18,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import org.byteveda.taskito.TaskitoException;
+import org.byteveda.taskito.errors.SerializationException;
+import org.byteveda.taskito.errors.WorkflowException;
 import org.byteveda.taskito.events.OutcomeEvent;
 import org.byteveda.taskito.serialization.Serializer;
 import org.byteveda.taskito.spi.QueueBackend;
@@ -308,7 +309,7 @@ public final class WorkflowTracker {
         if ("callable".equals(node.condition)) {
             Condition predicate = callableCondition(runId, node.name);
             if (predicate == null) {
-                throw new TaskitoException("callable condition for workflow node '" + node.name
+                throw new WorkflowException("callable condition for workflow node '" + node.name
                         + "' is not registered; track the workflow on the worker via trackWorkflows(workflow)");
             }
             return predicate.test(buildContext(runId, statuses));
@@ -401,7 +402,7 @@ public final class WorkflowTracker {
     private void createDeferredJobFor(String runId, PlanNode node) {
         byte[] payload = deferredPayload(runId, node.name);
         if (payload == null) {
-            throw new TaskitoException("no payload for deferred workflow node '" + node.name
+            throw new WorkflowException("no payload for deferred workflow node '" + node.name
                     + "'; register the workflow on the worker via trackWorkflows(workflow)");
         }
         backend.createDeferredJob(
@@ -509,10 +510,10 @@ public final class WorkflowTracker {
                 Thread.sleep(100);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-                throw new TaskitoException("interrupted awaiting result for workflow job " + jobId, e);
+                throw new WorkflowException("interrupted awaiting result for workflow job " + jobId, e);
             }
         }
-        throw new TaskitoException("no result for workflow job " + jobId + " after 5s");
+        throw new WorkflowException("no result for workflow job " + jobId + " after 5s");
     }
 
     private Map<String, NodeSnapshot> statusMap(String runId) {
@@ -587,7 +588,7 @@ public final class WorkflowTracker {
         try {
             return json.readValue(raw, type);
         } catch (Exception e) {
-            throw new TaskitoException("failed to decode workflow data", e);
+            throw new SerializationException("failed to decode workflow data", e);
         }
     }
 
@@ -596,7 +597,7 @@ public final class WorkflowTracker {
         try {
             return json.readValue(raw, type);
         } catch (Exception e) {
-            throw new TaskitoException("failed to decode workflow plan", e);
+            throw new SerializationException("failed to decode workflow plan", e);
         }
     }
 

--- a/sdks/java/src/test/java/org/byteveda/taskito/ExceptionHierarchyTest.java
+++ b/sdks/java/src/test/java/org/byteveda/taskito/ExceptionHierarchyTest.java
@@ -1,0 +1,48 @@
+package org.byteveda.taskito;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.byteveda.taskito.errors.ConfigurationException;
+import org.byteveda.taskito.errors.CryptoException;
+import org.byteveda.taskito.errors.LockException;
+import org.byteveda.taskito.errors.SerializationException;
+import org.byteveda.taskito.errors.WebhookException;
+import org.byteveda.taskito.errors.WorkflowException;
+import org.byteveda.taskito.serialization.JsonSerializer;
+import org.byteveda.taskito.serialization.Serializer;
+import org.byteveda.taskito.serialization.SignedSerializer;
+import org.junit.jupiter.api.Test;
+
+class ExceptionHierarchyTest {
+
+    @Test
+    void everySpecificExceptionExtendsTheBase() {
+        assertTrue(TaskitoException.class.isAssignableFrom(SerializationException.class));
+        assertTrue(TaskitoException.class.isAssignableFrom(WorkflowException.class));
+        assertTrue(TaskitoException.class.isAssignableFrom(LockException.class));
+        assertTrue(TaskitoException.class.isAssignableFrom(ConfigurationException.class));
+        assertTrue(TaskitoException.class.isAssignableFrom(WebhookException.class));
+        // CryptoException is a kind of SerializationException.
+        assertTrue(SerializationException.class.isAssignableFrom(CryptoException.class));
+    }
+
+    @Test
+    void malformedPayloadThrowsSerializationException() {
+        Serializer json = new JsonSerializer();
+        assertThrows(SerializationException.class, () -> json.deserialize("not json".getBytes(), Integer.class));
+    }
+
+    @Test
+    void tamperedSignedPayloadThrowsCryptoException() {
+        Serializer signed = new SignedSerializer(new JsonSerializer(), "secret".getBytes());
+        byte[] bytes = signed.serialize(42);
+        bytes[0] ^= 0x01; // corrupt the HMAC tag
+
+        CryptoException error = assertThrows(CryptoException.class, () -> signed.deserialize(bytes, Integer.class));
+        // A caller may catch it as the category or the base type.
+        assertInstanceOf(SerializationException.class, error);
+        assertInstanceOf(TaskitoException.class, error);
+    }
+}


### PR DESCRIPTION
Replaces blanket `TaskitoException` throws with a small typed hierarchy so
callers can catch the failure class that matters to them. Every new type
extends the root `TaskitoException`, so existing `catch (TaskitoException)`
keeps working — non-breaking.

## New `errors/` package
- `SerializationException` (+ subclass `CryptoException` for sign/encrypt failures)
- `WorkflowException` — workflow submit/track/compensation failures
- `LockException`, `ConfigurationException`, `WebhookException`

## Rewiring
~30 throw sites across serializers, locks, webhooks, workflows, dashboard, and
the producer/admin surface now throw the specific type. Native JNI boundary
errors stay base `TaskitoException` (their cause is opaque).

## Tests
`ExceptionHierarchyTest` asserts each type is catchable as `TaskitoException`
and that the documented throw sites raise the specific subclass.

Prerequisite for the saga PR (compensation failures throw `WorkflowException`).
Rebased onto master after #333.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting by switching many SDK failures to clearer, category-specific exceptions across workflow execution, serialization/deserialization, signing/encryption, webhook delivery, locking, and dashboard responses.
  * Invalid JSON, corrupted signed payloads, missing workflow/payload details, and interrupted waits now surface more precise exception types and messages.
  * Workflow submission now fails fast with a `WorkflowException` for certain payloadless structural steps and missing required workflow step data.
* **New Features**
  * Added dedicated exception classes (e.g., `ConfigurationException`, `SerializationException`, `CryptoException`, `LockException`, `WebhookException`, `WorkflowException`) to support finer-grained exception handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->