### PR TITLE
fix(java): drop unused worker var in graalvm smoke

### DIFF
--- a/sdks/java/graalvm-smoke/src/main/java/org/byteveda/taskito/graalvm/Smoke.java
+++ b/sdks/java/graalvm-smoke/src/main/java/org/byteveda/taskito/graalvm/Smoke.java
@@ -31,10 +31,11 @@ public final class Smoke {
             String id = queue.enqueue(echo, "graalvm");
 
             CountDownLatch done = new CountDownLatch(1);
-            try (Worker worker = queue.worker()
+            Worker worker = queue.worker()
                     .handle(echo, (String payload) -> payload.length())
                     .on(EventName.SUCCESS, event -> done.countDown())
-                    .start()) {
+                    .start();
+            try (worker) {
                 if (!done.await(20, TimeUnit.SECONDS)) {
                     throw new IllegalStateException("task did not complete");
                 }


### PR DESCRIPTION
The GraalVM smoke's worker was bound by a try-with-resources whose name was
never read, tripping an "unused local variable" diagnostic. Hoist the worker
to its own statement and manage it via `try (worker)` (Java 9+ resource
reference) — same lifecycle, no unused binding.

Compile-only, no behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the smoke test flow to handle worker startup and cleanup in a clearer sequence.
  * No user-facing behavior changed; task execution, result checks, and job listing checks remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->