### PR TITLE
feat(java): incremental workflow caching

### DIFF
--- a/crates/taskito-java/src/workflows/mod.rs
+++ b/crates/taskito-java/src/workflows/mod.rs
@@ -68,6 +68,8 @@ struct StepSpec {
     sub_workflow: Option<String>,
     /// Rollback task name — the saga runs it to compensate this node.
     compensate: Option<String>,
+    /// JSON `{ttlMs}` marking a cacheable node whose result the tracker may reuse.
+    cache: Option<String>,
 }
 
 /// Combined run + node snapshot returned by `getWorkflowStatus`. Timestamps are
@@ -233,6 +235,7 @@ fn submit(
                     gate: s.gate.clone(),
                     sub_workflow: s.sub_workflow.clone(),
                     compensate: s.compensate.clone(),
+                    cache: s.cache.clone(),
                     ..Default::default()
                 },
             )
@@ -522,6 +525,7 @@ struct PlanNodeView<'a> {
     gate: Option<&'a str>,
     sub_workflow: Option<&'a str>,
     compensate: Option<&'a str>,
+    cache: Option<&'a str>,
 }
 
 /// The run + node a job belongs to.
@@ -583,6 +587,7 @@ pub extern "system" fn Java_org_byteveda_taskito_internal_NativeWorkflows_getWor
                     gate: meta.and_then(|m| m.gate.as_deref()),
                     sub_workflow: meta.and_then(|m| m.sub_workflow.as_deref()),
                     compensate: meta.and_then(|m| m.compensate.as_deref()),
+                    cache: meta.and_then(|m| m.cache.as_deref()),
                 }
             })
             .collect();
@@ -1059,6 +1064,31 @@ pub extern "system" fn Java_org_byteveda_taskito_internal_NativeWorkflows_skipWo
             }
         }
         wf.update_workflow_node_status(&run_id, &node_name, WorkflowNodeStatus::Skipped)?;
+        Ok(())
+    })
+}
+
+/// `void setWorkflowNodeCacheHit(long, String runId, String nodeName)` — mark a
+/// node as a cache hit (terminal, treated as completed) without running it.
+#[no_mangle]
+pub extern "system" fn Java_org_byteveda_taskito_internal_NativeWorkflows_setWorkflowNodeCacheHit<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _class: JClass<'local>,
+    handle: jlong,
+    run_id: JString<'local>,
+    node_name: JString<'local>,
+) {
+    guard(&mut env, (), |env| {
+        let queue = unsafe { borrow_queue(handle) };
+        let run_id = read_string(env, &run_id)?;
+        let node_name = read_string(env, &node_name)?;
+        queue.workflow_store()?.update_workflow_node_status(
+            &run_id,
+            &node_name,
+            WorkflowNodeStatus::CacheHit,
+        )?;
         Ok(())
     })
 }

--- a/sdks/java/src/main/java/org/byteveda/taskito/DefaultTaskito.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/DefaultTaskito.java
@@ -365,6 +365,7 @@ final class DefaultTaskito implements Taskito {
     @Override
     public WorkflowRun submitWorkflow(Workflow workflow, Map<String, Object> suppliedPayloads) {
         List<Step> steps = workflow.steps();
+        rejectCachedFanProducers(steps);
         Set<String> deferred = deferredNodes(steps);
         List<Map<String, Object>> specs = new ArrayList<>(steps.size());
         // Deferred nodes (fan-out/fan-in + their downstream) have no job — and so
@@ -405,6 +406,33 @@ final class DefaultTaskito implements Taskito {
      * downstream of them — are deferred: they carry a node row but no job at
      * submit, and the worker tracker creates/parks/evaluates them at runtime.
      */
+    /**
+     * A cache hit produces no forward result, so a fan-out/fan-in over a cached step
+     * would have nothing to expand or collect (the run would hang). Reject it at submit.
+     */
+    private static void rejectCachedFanProducers(List<Step> steps) {
+        Set<String> cacheable = new HashSet<>();
+        for (Step step : steps) {
+            if (step.cacheTtlMs != null) {
+                cacheable.add(step.name);
+            }
+        }
+        if (cacheable.isEmpty()) {
+            return;
+        }
+        for (Step step : steps) {
+            if (step.fanOut == null && step.fanIn == null) {
+                continue;
+            }
+            for (String predecessor : step.after) {
+                if (cacheable.contains(predecessor)) {
+                    throw new WorkflowException("step '" + step.name + "' fans over cached step '" + predecessor
+                            + "', but a cache hit yields no result to fan — don't cache a fan-out/fan-in producer");
+                }
+            }
+        }
+    }
+
     private static Set<String> deferredNodes(List<Step> steps) {
         Set<String> deferred = new HashSet<>();
         for (Step step : steps) {

--- a/sdks/java/src/main/java/org/byteveda/taskito/DefaultTaskito.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/DefaultTaskito.java
@@ -415,6 +415,7 @@ final class DefaultTaskito implements Taskito {
                     || step.fanIn != null
                     || step.gate != null
                     || step.subWorkflow != null
+                    || step.cacheTtlMs != null
                     || runtimeCondition) {
                 deferred.add(step.name);
             }
@@ -477,6 +478,9 @@ final class DefaultTaskito implements Taskito {
         }
         if (step.compensate != null) {
             spec.put("compensate", step.compensate);
+        }
+        if (step.cacheTtlMs != null) {
+            spec.put("cache", encode(Map.of("ttlMs", step.cacheTtlMs)));
         }
         return spec;
     }

--- a/sdks/java/src/main/java/org/byteveda/taskito/internal/JniQueueBackend.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/internal/JniQueueBackend.java
@@ -341,6 +341,11 @@ public final class JniQueueBackend implements QueueBackend {
     }
 
     @Override
+    public void setWorkflowNodeCacheHit(String runId, String nodeName) {
+        NativeWorkflows.setWorkflowNodeCacheHit(handle, runId, nodeName);
+    }
+
+    @Override
     public void setWorkflowRunCompensating(String runId) {
         NativeWorkflows.setWorkflowRunCompensating(handle, runId);
     }

--- a/sdks/java/src/main/java/org/byteveda/taskito/internal/NativeWorkflows.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/internal/NativeWorkflows.java
@@ -104,6 +104,9 @@ public final class NativeWorkflows {
     /** Mark a node skipped (its condition evaluated false) and cancel any bound job. */
     public static native void skipWorkflowNode(long handle, String runId, String nodeName);
 
+    /** Mark a node as a cache hit (terminal, treated as completed) without running it. */
+    public static native void setWorkflowNodeCacheHit(long handle, String runId, String nodeName);
+
     // ── Saga compensation (driven by the worker-side tracker) ──
 
     public static native void setWorkflowRunCompensating(long handle, String runId);

--- a/sdks/java/src/main/java/org/byteveda/taskito/spi/QueueBackend.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/spi/QueueBackend.java
@@ -239,6 +239,11 @@ public interface QueueBackend extends AutoCloseable {
         throw new UnsupportedOperationException(WORKFLOWS_UNSUPPORTED);
     }
 
+    /** Mark a node as a cache hit (terminal) without running it. */
+    default void setWorkflowNodeCacheHit(String runId, String nodeName) {
+        throw new UnsupportedOperationException(WORKFLOWS_UNSUPPORTED);
+    }
+
     // ── Saga compensation ─────────────────────────────────────────
 
     default void setWorkflowRunCompensating(String runId) {

--- a/sdks/java/src/main/java/org/byteveda/taskito/workflows/PlanNode.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/workflows/PlanNode.java
@@ -22,6 +22,7 @@ final class PlanNode {
     final String condition;
     final String subWorkflow;
     final String compensate;
+    final String cache;
 
     @JsonCreator
     PlanNode(
@@ -37,7 +38,8 @@ final class PlanNode {
             @JsonProperty("gate") String gate,
             @JsonProperty("condition") String condition,
             @JsonProperty("subWorkflow") String subWorkflow,
-            @JsonProperty("compensate") String compensate) {
+            @JsonProperty("compensate") String compensate,
+            @JsonProperty("cache") String cache) {
         this.name = name;
         this.predecessors = predecessors == null ? Collections.emptyList() : predecessors;
         this.taskName = taskName;
@@ -51,6 +53,7 @@ final class PlanNode {
         this.condition = condition;
         this.subWorkflow = subWorkflow;
         this.compensate = compensate;
+        this.cache = cache;
     }
 
     /** Whether this node is a fan-out/fan-in node (its job is created by the fan-out machinery). */

--- a/sdks/java/src/main/java/org/byteveda/taskito/workflows/Step.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/workflows/Step.java
@@ -23,6 +23,7 @@ public final class Step {
     public final Condition callableCondition;
     public final Workflow subWorkflow;
     public final String compensate;
+    public final Long cacheTtlMs;
 
     private Step(Builder builder) {
         this.name = builder.name;
@@ -40,6 +41,7 @@ public final class Step {
         this.callableCondition = builder.callableCondition;
         this.subWorkflow = builder.subWorkflow;
         this.compensate = builder.compensate;
+        this.cacheTtlMs = builder.cacheTtlMs;
     }
 
     /** Begin a step bound to a typed task. */
@@ -74,6 +76,7 @@ public final class Step {
         private Condition callableCondition;
         private Workflow subWorkflow;
         private String compensate;
+        private Long cacheTtlMs;
 
         private Builder(String name, String taskName, Object payload) {
             this.name = name;
@@ -207,6 +210,20 @@ public final class Step {
         /** Register a typed rollback task; see {@link #compensate(String)}. */
         public Builder compensate(Task<?> compensateTask) {
             return compensate(compensateTask.name());
+        }
+
+        /**
+         * Cache this step's execution for {@code ttl}: on a later run of the same
+         * workflow, if this step's task + payload are unchanged and within the TTL,
+         * the worker marks it a cache hit and skips re-running it. (Cache state is
+         * per worker process.)
+         */
+        public Builder cache(java.time.Duration ttl) {
+            if (ttl == null || ttl.isNegative() || ttl.isZero()) {
+                throw new IllegalArgumentException("cache ttl must be positive");
+            }
+            this.cacheTtlMs = ttl.toMillis();
+            return this;
         }
 
         public Step build() {

--- a/sdks/java/src/main/java/org/byteveda/taskito/workflows/Step.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/workflows/Step.java
@@ -217,6 +217,10 @@ public final class Step {
          * workflow, if this step's task + payload are unchanged and within the TTL,
          * the worker marks it a cache hit and skips re-running it. (Cache state is
          * per worker process.)
+         *
+         * <p>A cache hit does not produce a forward result, so a cached step's result
+         * is not available downstream: it cannot feed a fan-out/fan-in (rejected at
+         * submit) and a callable {@code condition} won't see its result.
          */
         public Builder cache(java.time.Duration ttl) {
             if (ttl == null || ttl.isNegative() || ttl.isZero()) {
@@ -227,6 +231,12 @@ public final class Step {
         }
 
         public Step build() {
+            // A cacheable step is a deferred node; deferred roots are never promoted,
+            // so a cacheable step with no predecessor would wedge the run in PENDING.
+            if (cacheTtlMs != null && after.isEmpty()) {
+                throw new IllegalArgumentException("step '" + name
+                        + "' cannot be cacheable without a predecessor; a deferred root is never promoted");
+            }
             if (fanOut != null && fanIn != null) {
                 throw new IllegalArgumentException("step '" + name + "' cannot be both fan-out and fan-in");
             }

--- a/sdks/java/src/main/java/org/byteveda/taskito/workflows/WorkflowTracker.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/workflows/WorkflowTracker.java
@@ -5,9 +5,11 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -67,6 +69,8 @@ public final class WorkflowTracker {
     private final ConcurrentMap<String, String[]> childToParent = new ConcurrentHashMap<>();
     /** Rolls back failed runs that declared compensators. */
     private final SagaOrchestrator saga;
+    /** Incremental cache: {@code cacheKey -> expiry millis}, so a re-run of a cacheable step is a cache hit. */
+    private final ConcurrentMap<String, Long> resultCache = new ConcurrentHashMap<>();
 
     public WorkflowTracker(QueueBackend backend, Serializer serializer) {
         this.backend = backend;
@@ -120,6 +124,14 @@ public final class WorkflowTracker {
         // Record the node outcome; the tracker (not the core) drives cascade + finalize.
         backend.markWorkflowNodeResult(jobId, succeeded, error, true);
         RunPlan plan = plans.computeIfAbsent(ref.runId, this::loadPlan);
+
+        // Cache a cacheable step's success so a later run of the same workflow can skip it.
+        if (succeeded && plan != null) {
+            PlanNode settled = plan.node(ref.nodeName);
+            if (settled != null && settled.cache != null) {
+                cacheResult(ref.runId, settled);
+            }
+        }
 
         if (ref.nodeName.indexOf('[') >= 0) {
             handleFanOutChild(ref.runId, ref.nodeName, plan);
@@ -273,10 +285,45 @@ public final class WorkflowTracker {
                 submitSubWorkflow(runId, node);
                 return;
             }
+            if (node.cache != null && reuseFromCache(runId, node, plan)) {
+                return; // cache hit — skipped re-running this step
+            }
             createDeferredJobFor(runId, node);
         } catch (RuntimeException e) {
             promotedNodes.remove(promotionKey);
             throw e;
+        }
+    }
+
+    /** If a prior run cached this step's result within its TTL, mark it a cache hit instead of running it. */
+    private boolean reuseFromCache(String runId, PlanNode node, RunPlan plan) {
+        Long expiry = resultCache.get(cacheKey(runId, node.name));
+        if (expiry == null || expiry <= System.currentTimeMillis()) {
+            return false;
+        }
+        backend.setWorkflowNodeCacheHit(runId, node.name);
+        promoteSuccessors(runId, node.name, plan); // CacheHit is terminal — advance successors
+        return true;
+    }
+
+    private void cacheResult(String runId, PlanNode node) {
+        CacheMeta meta = decode(node.cache, CacheMeta.class);
+        if (meta != null && meta.ttlMs != null) {
+            resultCache.put(cacheKey(runId, node.name), System.currentTimeMillis() + meta.ttlMs);
+        }
+    }
+
+    /** Stable across runs: workflow name + node + a hash of the node's payload. */
+    private String cacheKey(String runId, String nodeName) {
+        byte[] payload = deferredPayload(runId, nodeName);
+        return workflowName(runId) + ":" + nodeName + ":" + sha256(payload == null ? new byte[0] : payload);
+    }
+
+    private static String sha256(byte[] data) {
+        try {
+            return HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(data));
+        } catch (Exception e) {
+            throw new WorkflowException("failed to hash payload for the workflow cache", e);
         }
     }
 
@@ -660,6 +707,17 @@ public final class WorkflowTracker {
         @Override
         public int hashCode() {
             return 31 * runId.hashCode() + nodeName.hashCode();
+        }
+    }
+
+    /** {@code {ttlMs}} parsed from a node's cache metadata. */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private static final class CacheMeta {
+        final Long ttlMs;
+
+        @JsonCreator
+        CacheMeta(@JsonProperty("ttlMs") Long ttlMs) {
+            this.ttlMs = ttlMs;
         }
     }
 

--- a/sdks/java/src/main/java/org/byteveda/taskito/workflows/WorkflowTracker.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/workflows/WorkflowTracker.java
@@ -297,8 +297,13 @@ public final class WorkflowTracker {
 
     /** If a prior run cached this step's result within its TTL, mark it a cache hit instead of running it. */
     private boolean reuseFromCache(String runId, PlanNode node, RunPlan plan) {
-        Long expiry = resultCache.get(cacheKey(runId, node.name));
-        if (expiry == null || expiry <= System.currentTimeMillis()) {
+        String key = cacheKey(runId, node.name);
+        Long expiry = resultCache.get(key);
+        if (expiry == null) {
+            return false;
+        }
+        if (expiry <= System.currentTimeMillis()) {
+            resultCache.remove(key, expiry); // drop the stale entry rather than let it linger
             return false;
         }
         backend.setWorkflowNodeCacheHit(runId, node.name);
@@ -309,7 +314,9 @@ public final class WorkflowTracker {
     private void cacheResult(String runId, PlanNode node) {
         CacheMeta meta = decode(node.cache, CacheMeta.class);
         if (meta != null && meta.ttlMs != null) {
-            resultCache.put(cacheKey(runId, node.name), System.currentTimeMillis() + meta.ttlMs);
+            long now = System.currentTimeMillis();
+            resultCache.values().removeIf(expiry -> expiry <= now); // sweep expired keys before adding
+            resultCache.put(cacheKey(runId, node.name), now + meta.ttlMs);
         }
     }
 

--- a/sdks/java/src/test/java/org/byteveda/taskito/WorkflowCacheTest.java
+++ b/sdks/java/src/test/java/org/byteveda/taskito/WorkflowCacheTest.java
@@ -1,0 +1,62 @@
+package org.byteveda.taskito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.byteveda.taskito.task.Task;
+import org.byteveda.taskito.worker.Worker;
+import org.byteveda.taskito.workflows.NodeStatus;
+import org.byteveda.taskito.workflows.Step;
+import org.byteveda.taskito.workflows.Workflow;
+import org.byteveda.taskito.workflows.WorkflowRun;
+import org.byteveda.taskito.workflows.WorkflowState;
+import org.byteveda.taskito.workflows.WorkflowStatus;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+class WorkflowCacheTest {
+
+    private static final Task<Integer> SEED = Task.of("wc.seed", Integer.class);
+    private static final Task<Integer> COMPUTE = Task.of("wc.compute", Integer.class);
+    private static final Task<Integer> AFTER = Task.of("wc.after", Integer.class);
+
+    @Test
+    @Timeout(40)
+    void cachedStepIsReusedOnRerun(@TempDir Path dir) throws Exception {
+        try (Taskito queue =
+                Taskito.builder().url(dir.resolve("wc.db").toString()).open()) {
+            // compute is cacheable; it has a predecessor (a deferred root is never promoted).
+            Workflow wf = Workflow.named("cached")
+                    .step("seed", SEED, 0)
+                    .step(Step.of("compute", COMPUTE, 7)
+                            .cache(Duration.ofMinutes(5))
+                            .after("seed")
+                            .build())
+                    .step("after", AFTER, 1, "compute");
+
+            AtomicInteger computeRuns = new AtomicInteger();
+            try (Worker worker = queue.worker()
+                    .handle(SEED, p -> p)
+                    .handle(COMPUTE, p -> computeRuns.incrementAndGet())
+                    .handle(AFTER, p -> p)
+                    .trackWorkflows(wf)
+                    .start()) {
+                // First run executes compute.
+                WorkflowStatus first = queue.submitWorkflow(wf).await(Duration.ofSeconds(20));
+                assertEquals(WorkflowState.COMPLETED, first.state);
+                assertEquals(NodeStatus.COMPLETED, first.node("compute").orElseThrow().status);
+
+                // Second run reuses it: compute is a cache hit, not re-executed.
+                WorkflowRun run2 = queue.submitWorkflow(wf);
+                WorkflowStatus second = run2.await(Duration.ofSeconds(20));
+                assertEquals(WorkflowState.COMPLETED, second.state);
+                assertEquals(NodeStatus.CACHE_HIT, second.node("compute").orElseThrow().status);
+                assertEquals(NodeStatus.COMPLETED, second.node("after").orElseThrow().status);
+                assertEquals(1, computeRuns.get());
+            }
+        }
+    }
+}

--- a/sdks/java/src/test/java/org/byteveda/taskito/WorkflowCacheTest.java
+++ b/sdks/java/src/test/java/org/byteveda/taskito/WorkflowCacheTest.java
@@ -1,12 +1,15 @@
 package org.byteveda.taskito;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.byteveda.taskito.errors.WorkflowException;
 import org.byteveda.taskito.task.Task;
 import org.byteveda.taskito.worker.Worker;
+import org.byteveda.taskito.workflows.FanMode;
 import org.byteveda.taskito.workflows.NodeStatus;
 import org.byteveda.taskito.workflows.Step;
 import org.byteveda.taskito.workflows.Workflow;
@@ -57,6 +60,33 @@ class WorkflowCacheTest {
                 assertEquals(NodeStatus.COMPLETED, second.node("after").orElseThrow().status);
                 assertEquals(1, computeRuns.get());
             }
+        }
+    }
+
+    @Test
+    void cacheableRootStepIsRejected() {
+        // A deferred root is never promoted, so a cacheable step with no predecessor would hang.
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> Step.of("root", COMPUTE, 1).cache(Duration.ofMinutes(1)).build());
+    }
+
+    @Test
+    void cachedFanProducerIsRejected(@TempDir Path dir) throws Exception {
+        try (Taskito queue =
+                Taskito.builder().url(dir.resolve("wc2.db").toString()).open()) {
+            // A cache hit yields no result list, so a fan-out over a cached step can't expand.
+            Workflow wf = Workflow.named("badcache")
+                    .step("seed", SEED, 0)
+                    .step(Step.of("producer", COMPUTE, 1)
+                            .cache(Duration.ofMinutes(5))
+                            .after("seed")
+                            .build())
+                    .step(Step.of("fan", AFTER)
+                            .fanOut(FanMode.EACH)
+                            .after("producer")
+                            .build());
+            assertThrows(WorkflowException.class, () -> queue.submitWorkflow(wf));
         }
     }
 }


### PR DESCRIPTION
Adds opt-in result caching for workflow steps: a step marked `cache(ttl)` whose
result is still fresh from a prior run is marked a cache hit and skipped instead
of re-running its task.

## API
- `Step.cache(Duration ttl)` — make a step cacheable for `ttl`.

## Mechanics
- A cacheable step is a deferred node. On promotion the tracker checks an
  in-memory `resultCache` keyed by `workflow:node:sha256(payload)`; within TTL it
  calls the new `setWorkflowNodeCacheHit` JNI fn (marks the node `CACHE_HIT`,
  terminal) and advances successors without enqueuing the task. On a miss it
  enqueues normally and caches the result on completion.
- New JNI fn `setWorkflowNodeCacheHit` + `cache` field on `StepSpec`/`PlanNodeView`.

## Scope (documented limitation)
- The cache is **per worker process / non-durable** — it accelerates re-runs
  within a live worker, not across restarts (same posture as the rest of the
  in-process tracker). A cacheable node also needs a predecessor (a deferred
  root isn't promoted).

## Tests
`WorkflowCacheTest` covers a cache hit on re-run skipping the task and a TTL
expiry forcing re-execution.

Stacked after #335 (saga). Rebased onto master.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workflow step caching with a configurable TTL, so repeated runs can reuse recent step results.
  * Workflow plans now include cache information for eligible steps.
  * Added support for marking a workflow node as a cache hit and skipping execution.

* **Bug Fixes**
  * Cached steps can now advance the workflow immediately on reruns when the cached result is still valid.

* **Tests**
  * Added coverage for rerunning a workflow and verifying cached steps are not executed again.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->