### PR TITLE
feat(java): worker resource dependency injection

### DIFF
--- a/sdks/java/src/main/java/org/byteveda/taskito/DefaultTaskito.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/DefaultTaskito.java
@@ -13,6 +13,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Consumer;
+import java.util.function.Function;
 import org.byteveda.taskito.core.CoreFacade;
 import org.byteveda.taskito.errors.SerializationException;
 import org.byteveda.taskito.errors.WorkflowException;
@@ -29,6 +31,11 @@ import org.byteveda.taskito.model.QueueStats;
 import org.byteveda.taskito.model.TaskLog;
 import org.byteveda.taskito.model.TaskMetric;
 import org.byteveda.taskito.model.WorkerInfo;
+import org.byteveda.taskito.resources.ResourceContext;
+import org.byteveda.taskito.resources.ResourceDefinition;
+import org.byteveda.taskito.resources.ResourceRuntime;
+import org.byteveda.taskito.resources.ResourceScope;
+import org.byteveda.taskito.resources.ResourceStat;
 import org.byteveda.taskito.scheduling.PeriodicTask;
 import org.byteveda.taskito.serialization.Serializer;
 import org.byteveda.taskito.spi.QueueBackend;
@@ -55,6 +62,7 @@ final class DefaultTaskito implements Taskito {
     private final CoreFacade facade;
     private final Serializer serializer;
     private final List<Middleware> middleware = new CopyOnWriteArrayList<>();
+    private final ResourceRuntime resources = new ResourceRuntime();
 
     DefaultTaskito(QueueBackend backend, Serializer serializer) {
         this.backend = backend;
@@ -71,6 +79,36 @@ final class DefaultTaskito implements Taskito {
     public Taskito use(Middleware middleware) {
         this.middleware.add(middleware);
         return this;
+    }
+
+    // ── Resources ────────────────────────────────────────────────────
+
+    @Override
+    public <T> Taskito resource(String name, Function<ResourceContext, T> factory) {
+        return resource(name, ResourceScope.WORKER, factory);
+    }
+
+    @Override
+    public <T> Taskito resource(String name, ResourceScope scope, Function<ResourceContext, T> factory) {
+        resources.register(name, new ResourceDefinition(factory::apply, scope, null));
+        return this;
+    }
+
+    @Override
+    public <T> Taskito resource(
+            String name, ResourceScope scope, Function<ResourceContext, T> factory, Consumer<T> dispose) {
+        resources.register(name, new ResourceDefinition(factory::apply, scope, value -> dispose.accept(cast(value))));
+        return this;
+    }
+
+    @Override
+    public Map<String, ResourceStat> resourceMetrics() {
+        return resources.metrics();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T cast(Object value) {
+        return (T) value;
     }
 
     // ── Producer ────────────────────────────────────────────────────
@@ -576,7 +614,7 @@ final class DefaultTaskito implements Taskito {
 
     @Override
     public Worker.Builder worker() {
-        return Worker.builder(backend, serializer, middleware);
+        return Worker.builder(backend, serializer, middleware, resources);
     }
 
     @Override

--- a/sdks/java/src/main/java/org/byteveda/taskito/DefaultTaskito.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/DefaultTaskito.java
@@ -614,7 +614,8 @@ final class DefaultTaskito implements Taskito {
 
     @Override
     public Worker.Builder worker() {
-        return Worker.builder(backend, serializer, middleware, resources);
+        // Each worker gets its own runtime (own WORKER-scoped cache) over shared definitions.
+        return Worker.builder(backend, serializer, middleware, resources.forWorker());
     }
 
     @Override

--- a/sdks/java/src/main/java/org/byteveda/taskito/Taskito.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/Taskito.java
@@ -11,6 +11,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
 import org.byteveda.taskito.errors.ConfigurationException;
 import org.byteveda.taskito.internal.JniQueueBackend;
 import org.byteveda.taskito.locks.Lock;
@@ -25,6 +27,9 @@ import org.byteveda.taskito.model.QueueStats;
 import org.byteveda.taskito.model.TaskLog;
 import org.byteveda.taskito.model.TaskMetric;
 import org.byteveda.taskito.model.WorkerInfo;
+import org.byteveda.taskito.resources.ResourceContext;
+import org.byteveda.taskito.resources.ResourceScope;
+import org.byteveda.taskito.resources.ResourceStat;
 import org.byteveda.taskito.scheduling.PeriodicTask;
 import org.byteveda.taskito.serialization.JsonSerializer;
 import org.byteveda.taskito.serialization.Serializer;
@@ -54,6 +59,20 @@ public interface Taskito extends AutoCloseable {
 
     /** Register cross-cutting middleware (enqueue + worker hooks); returns {@code this}. */
     Taskito use(Middleware middleware);
+
+    // ── Resources (worker-side dependency injection) ─────────────────
+
+    /** Register a worker-scoped resource resolved in handlers via {@code Resources.use(name)}. */
+    <T> Taskito resource(String name, Function<ResourceContext, T> factory);
+
+    /** Register a resource with an explicit {@link ResourceScope}. */
+    <T> Taskito resource(String name, ResourceScope scope, Function<ResourceContext, T> factory);
+
+    /** Register a resource with a scope and a disposer run when the scope ends. */
+    <T> Taskito resource(String name, ResourceScope scope, Function<ResourceContext, T> factory, Consumer<T> dispose);
+
+    /** Per-resource counters (created / disposed / active). */
+    Map<String, ResourceStat> resourceMetrics();
 
     // ── Producer ────────────────────────────────────────────────────
 

--- a/sdks/java/src/main/java/org/byteveda/taskito/errors/ResourceException.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/errors/ResourceException.java
@@ -1,0 +1,18 @@
+package org.byteveda.taskito.errors;
+
+import org.byteveda.taskito.TaskitoException;
+
+/**
+ * A worker resource could not be built, resolved, or disposed — e.g. a factory
+ * threw, an unknown resource name was requested, or {@code Resources.use} was
+ * called outside a task handler.
+ */
+public class ResourceException extends TaskitoException {
+    public ResourceException(String message) {
+        super(message);
+    }
+
+    public ResourceException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/sdks/java/src/main/java/org/byteveda/taskito/internal/ScopeContext.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/internal/ScopeContext.java
@@ -1,0 +1,31 @@
+package org.byteveda.taskito.internal;
+
+/**
+ * A single seam for per-task context propagation. Backed by a {@link ThreadLocal}
+ * today (the SDK targets Java 17); if the floor later rises to a JDK with a
+ * stable {@code ScopedValue}, only this class changes — callers are unaffected.
+ *
+ * <p>Each task runs on a pooled worker thread, so callers must {@link #set} on
+ * entry and {@link #clear} in a {@code finally} on exit to avoid leaking context
+ * into the next task scheduled on that thread.
+ *
+ * @param <T> the value carried for the duration of a task
+ */
+public final class ScopeContext<T> {
+    private final ThreadLocal<T> holder = new ThreadLocal<>();
+
+    /** The value bound on the current thread, or {@code null} if none. */
+    public T get() {
+        return holder.get();
+    }
+
+    /** Bind {@code value} on the current thread. */
+    public void set(T value) {
+        holder.set(value);
+    }
+
+    /** Unbind any value on the current thread. */
+    public void clear() {
+        holder.remove();
+    }
+}

--- a/sdks/java/src/main/java/org/byteveda/taskito/resources/ResourceContext.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/resources/ResourceContext.java
@@ -1,0 +1,14 @@
+package org.byteveda.taskito.resources;
+
+/**
+ * Handed to a resource factory so it can depend on other resources. A
+ * {@code WORKER} factory may only {@link #use} other worker resources; a
+ * {@code TASK} factory may use either.
+ */
+public interface ResourceContext {
+    /** The scope the factory is building for. */
+    ResourceScope scope();
+
+    /** Resolve another resource by name (building it if needed). */
+    <T> T use(String name);
+}

--- a/sdks/java/src/main/java/org/byteveda/taskito/resources/ResourceDefinition.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/resources/ResourceDefinition.java
@@ -1,0 +1,34 @@
+package org.byteveda.taskito.resources;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/**
+ * How to build (and optionally dispose) a resource.
+ *
+ * @param factory builds the resource, possibly using others via the context
+ * @param scope the resource's lifetime (defaults to {@link ResourceScope#WORKER})
+ * @param dispose optional cleanup run when the scope ends ({@code null} for none)
+ */
+public record ResourceDefinition(
+        Function<ResourceContext, Object> factory, ResourceScope scope, Consumer<Object> dispose) {
+
+    public ResourceDefinition {
+        if (factory == null) {
+            throw new IllegalArgumentException("resource factory must not be null");
+        }
+        if (scope == null) {
+            scope = ResourceScope.WORKER;
+        }
+    }
+
+    /** A worker-scoped resource with no disposer. */
+    public static ResourceDefinition worker(Function<ResourceContext, Object> factory) {
+        return new ResourceDefinition(factory, ResourceScope.WORKER, null);
+    }
+
+    /** A task-scoped resource with no disposer. */
+    public static ResourceDefinition task(Function<ResourceContext, Object> factory) {
+        return new ResourceDefinition(factory, ResourceScope.TASK, null);
+    }
+}

--- a/sdks/java/src/main/java/org/byteveda/taskito/resources/ResourceRuntime.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/resources/ResourceRuntime.java
@@ -5,7 +5,9 @@ import java.lang.System.Logger.Level;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLong;
@@ -33,6 +35,9 @@ public final class ResourceRuntime {
     private final ConcurrentMap<String, Object> workerCache = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, ReentrantLock> workerLocks = new ConcurrentHashMap<>();
     private final Deque<Runnable> workerTeardown = new ArrayDeque<>();
+    /** Names being resolved on the current thread, so a dependency cycle fails fast instead of recursing. */
+    private final ThreadLocal<Set<String>> resolving = ThreadLocal.withInitial(LinkedHashSet::new);
+
     private int leases; // guarded by this
 
     /** Context handed to a worker factory: it may only use other worker resources. */
@@ -165,10 +170,18 @@ public final class ResourceRuntime {
     }
 
     private Object build(String name, ResourceDefinition definition, ResourceContext context) {
+        Set<String> chain = resolving.get();
+        if (!chain.add(name)) {
+            throw new ResourceException("circular resource dependency at '" + name + "' (chain: " + chain + ")");
+        }
         try {
             return definition.factory().apply(context);
+        } catch (ResourceException e) {
+            throw e; // a nested unknown/cycle/build failure already carries its message
         } catch (RuntimeException e) {
             throw new ResourceException("failed to build resource '" + name + "'", e);
+        } finally {
+            chain.remove(name);
         }
     }
 

--- a/sdks/java/src/main/java/org/byteveda/taskito/resources/ResourceRuntime.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/resources/ResourceRuntime.java
@@ -1,0 +1,194 @@
+package org.byteveda.taskito.resources;
+
+import java.lang.System.Logger;
+import java.lang.System.Logger.Level;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
+import org.byteveda.taskito.errors.ResourceException;
+
+/**
+ * Registry and lifecycle for worker resources. Holds the definitions, the
+ * single shared cache of worker-scoped instances, and per-resource counters.
+ * Worker-scoped resources are built at most once (under a per-name lock, so a
+ * concurrent first-use does not double-build) and disposed LIFO when the last
+ * worker lease is released.
+ */
+public final class ResourceRuntime {
+    private static final Logger LOG = System.getLogger(ResourceRuntime.class.getName());
+    /** Cache sentinel for a factory that legitimately returned {@code null}. */
+    private static final Object NULL = new Object();
+
+    private final ConcurrentMap<String, ResourceDefinition> definitions = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, Object> workerCache = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, ReentrantLock> workerLocks = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, Counter> counters = new ConcurrentHashMap<>();
+    private final Deque<Runnable> workerTeardown = new ArrayDeque<>();
+    private int leases; // guarded by this
+
+    /** Context handed to a worker factory: it may only use other worker resources. */
+    private final ResourceContext workerContext = new ResourceContext() {
+        @Override
+        public ResourceScope scope() {
+            return ResourceScope.WORKER;
+        }
+
+        @Override
+        public <T> T use(String name) {
+            return cast(resolveWorker(name));
+        }
+    };
+
+    /** Register a resource under {@code name}, replacing any prior definition. */
+    public void register(String name, ResourceDefinition definition) {
+        definitions.put(name, definition);
+        counters.computeIfAbsent(name, key -> new Counter());
+    }
+
+    /** Whether any resource is registered (lets the worker skip all wiring when unused). */
+    public boolean isEmpty() {
+        return definitions.isEmpty();
+    }
+
+    /** A fresh per-invocation scope for one task. */
+    public TaskScope createTaskScope() {
+        return new TaskScope(this);
+    }
+
+    /** Lease the worker resources (paired with {@link #teardownWorker}). */
+    public synchronized void acquireWorker() {
+        leases++;
+    }
+
+    /** Release a worker lease; when the last one drops, dispose worker resources LIFO. */
+    public synchronized void teardownWorker() {
+        if (leases > 0) {
+            leases--;
+        }
+        if (leases == 0) {
+            disposeWorker();
+        }
+    }
+
+    /** Per-resource counters snapshot. */
+    public Map<String, ResourceStat> metrics() {
+        Map<String, ResourceStat> out = new LinkedHashMap<>();
+        counters.forEach((name, counter) -> {
+            long created = counter.created.get();
+            long disposed = counter.disposed.get();
+            out.put(name, new ResourceStat(created, disposed, created - disposed));
+        });
+        return out;
+    }
+
+    /** Resolve a worker-scoped resource, building it once under a per-name lock. */
+    Object resolveWorker(String name) {
+        ResourceDefinition definition = definition(name);
+        if (definition.scope() != ResourceScope.WORKER) {
+            throw new ResourceException("resource '" + name + "' is task-scoped; a worker resource cannot use it");
+        }
+        Object cached = workerCache.get(name);
+        if (cached != null) {
+            return unwrap(cached);
+        }
+        ReentrantLock lock = workerLocks.computeIfAbsent(name, key -> new ReentrantLock());
+        lock.lock();
+        try {
+            cached = workerCache.get(name);
+            if (cached != null) {
+                return unwrap(cached);
+            }
+            Object value = build(name, definition, workerContext);
+            workerCache.put(name, value == null ? NULL : value);
+            counter(name).created.incrementAndGet();
+            if (definition.dispose() != null) {
+                synchronized (workerTeardown) {
+                    workerTeardown.push(() -> dispose(name, value, definition.dispose()));
+                }
+            }
+            return value;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /** Resolve for a task: worker-scoped hits the shared cache; task-scoped builds once per invocation. */
+    Object resolveForTask(TaskScope scope, String name) {
+        ResourceDefinition definition = definition(name);
+        if (definition.scope() == ResourceScope.WORKER) {
+            return resolveWorker(name);
+        }
+        Map<String, Object> cache = scope.cache();
+        Object cached = cache.get(name);
+        if (cached != null) {
+            return unwrap(cached);
+        }
+        Object value = build(name, definition, scope);
+        cache.put(name, value == null ? NULL : value);
+        counter(name).created.incrementAndGet();
+        if (definition.dispose() != null) {
+            scope.pushTeardown(() -> dispose(name, value, definition.dispose()));
+        }
+        return value;
+    }
+
+    private Object build(String name, ResourceDefinition definition, ResourceContext context) {
+        try {
+            return definition.factory().apply(context);
+        } catch (RuntimeException e) {
+            throw new ResourceException("failed to build resource '" + name + "'", e);
+        }
+    }
+
+    private void disposeWorker() {
+        synchronized (workerTeardown) {
+            while (!workerTeardown.isEmpty()) {
+                workerTeardown.pop().run();
+            }
+        }
+        workerCache.clear();
+    }
+
+    private void dispose(String name, Object value, Consumer<Object> disposer) {
+        try {
+            disposer.accept(unwrap(value));
+            counter(name).disposed.incrementAndGet();
+        } catch (RuntimeException e) {
+            // A disposer must never fail teardown — record and continue.
+            LOG.log(Level.WARNING, "disposing resource '" + name + "' failed", e);
+        }
+    }
+
+    private ResourceDefinition definition(String name) {
+        ResourceDefinition definition = definitions.get(name);
+        if (definition == null) {
+            throw new ResourceException("unknown resource '" + name + "'");
+        }
+        return definition;
+    }
+
+    private Counter counter(String name) {
+        return counters.computeIfAbsent(name, key -> new Counter());
+    }
+
+    private static Object unwrap(Object value) {
+        return value == NULL ? null : value;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T cast(Object value) {
+        return (T) value;
+    }
+
+    /** Mutable per-resource counters. */
+    private static final class Counter {
+        final AtomicLong created = new AtomicLong();
+        final AtomicLong disposed = new AtomicLong();
+    }
+}

--- a/sdks/java/src/main/java/org/byteveda/taskito/resources/ResourceRuntime.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/resources/ResourceRuntime.java
@@ -69,9 +69,11 @@ public final class ResourceRuntime {
         return new ResourceRuntime(definitions, counters);
     }
 
-    /** Register a resource under {@code name}, replacing any prior definition. */
+    /** Register a resource under {@code name}. A name may be registered only once. */
     public void register(String name, ResourceDefinition definition) {
-        definitions.put(name, definition);
+        if (definitions.putIfAbsent(name, definition) != null) {
+            throw new ResourceException("resource '" + name + "' is already registered");
+        }
         counters.computeIfAbsent(name, key -> new Counter());
     }
 

--- a/sdks/java/src/main/java/org/byteveda/taskito/resources/ResourceRuntime.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/resources/ResourceRuntime.java
@@ -14,21 +14,24 @@ import java.util.function.Consumer;
 import org.byteveda.taskito.errors.ResourceException;
 
 /**
- * Registry and lifecycle for worker resources. Holds the definitions, the
- * single shared cache of worker-scoped instances, and per-resource counters.
- * Worker-scoped resources are built at most once (under a per-name lock, so a
- * concurrent first-use does not double-build) and disposed LIFO when the last
- * worker lease is released.
+ * Registry and lifecycle for worker resources. The client-level instance holds
+ * the definitions and per-resource counters; each worker gets its own live
+ * runtime via {@link #forWorker()}, sharing those definitions/counters but with
+ * its own cache of worker-scoped instances — so a {@code WORKER}-scoped resource
+ * is one instance <em>per worker</em>, not one per client. Worker-scoped
+ * resources are built at most once per worker (under a per-name lock, so a
+ * concurrent first-use does not double-build) and disposed LIFO when that
+ * worker's last lease is released.
  */
 public final class ResourceRuntime {
     private static final Logger LOG = System.getLogger(ResourceRuntime.class.getName());
     /** Cache sentinel for a factory that legitimately returned {@code null}. */
     private static final Object NULL = new Object();
 
-    private final ConcurrentMap<String, ResourceDefinition> definitions = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, ResourceDefinition> definitions;
+    private final ConcurrentMap<String, Counter> counters;
     private final ConcurrentMap<String, Object> workerCache = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, ReentrantLock> workerLocks = new ConcurrentHashMap<>();
-    private final ConcurrentMap<String, Counter> counters = new ConcurrentHashMap<>();
     private final Deque<Runnable> workerTeardown = new ArrayDeque<>();
     private int leases; // guarded by this
 
@@ -44,6 +47,27 @@ public final class ResourceRuntime {
             return cast(resolveWorker(name));
         }
     };
+
+    /** A client-level runtime: holds definitions + counters, hands each worker a child via {@link #forWorker()}. */
+    public ResourceRuntime() {
+        this.definitions = new ConcurrentHashMap<>();
+        this.counters = new ConcurrentHashMap<>();
+    }
+
+    private ResourceRuntime(
+            ConcurrentMap<String, ResourceDefinition> definitions, ConcurrentMap<String, Counter> counters) {
+        this.definitions = definitions;
+        this.counters = counters;
+    }
+
+    /**
+     * A per-worker runtime sharing this runtime's definitions and counters but with
+     * its own worker-scoped cache, teardown stack, and lease count — so each worker
+     * builds and disposes its own {@code WORKER}-scoped instances.
+     */
+    public ResourceRuntime forWorker() {
+        return new ResourceRuntime(definitions, counters);
+    }
 
     /** Register a resource under {@code name}, replacing any prior definition. */
     public void register(String name, ResourceDefinition definition) {

--- a/sdks/java/src/main/java/org/byteveda/taskito/resources/ResourceScope.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/resources/ResourceScope.java
@@ -1,0 +1,9 @@
+package org.byteveda.taskito.resources;
+
+/** Lifetime of a worker resource. */
+public enum ResourceScope {
+    /** Built once, lazily, and shared across every task on the worker. */
+    WORKER,
+    /** Built lazily per task invocation and disposed when the task ends. */
+    TASK
+}

--- a/sdks/java/src/main/java/org/byteveda/taskito/resources/ResourceStat.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/resources/ResourceStat.java
@@ -1,0 +1,10 @@
+package org.byteveda.taskito.resources;
+
+/**
+ * Per-resource counters.
+ *
+ * @param created how many instances have been built
+ * @param disposed how many have been disposed
+ * @param active currently-live instances ({@code created - disposed})
+ */
+public record ResourceStat(long created, long disposed, long active) {}

--- a/sdks/java/src/main/java/org/byteveda/taskito/resources/Resources.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/resources/Resources.java
@@ -1,0 +1,40 @@
+package org.byteveda.taskito.resources;
+
+import org.byteveda.taskito.errors.ResourceException;
+import org.byteveda.taskito.internal.ScopeContext;
+
+/**
+ * Resolve worker resources from inside a task handler: {@code Resources.use("db")}.
+ * Valid only while a task runs on this worker; the worker binds the task's scope
+ * around the handler call.
+ */
+public final class Resources {
+    private static final ScopeContext<TaskScope> ACTIVE = new ScopeContext<>();
+
+    private Resources() {}
+
+    /** Resolve the named resource for the current task. */
+    public static <T> T use(String name) {
+        TaskScope scope = ACTIVE.get();
+        if (scope == null) {
+            throw new ResourceException("Resources.use(\"" + name + "\") called outside a task handler");
+        }
+        return scope.use(name);
+    }
+
+    /** Bind {@code scope} for the current thread (called by the worker before the handler). */
+    public static void enter(TaskScope scope) {
+        ACTIVE.set(scope);
+    }
+
+    /**
+     * Unbind the current thread's scope and dispose its task-scoped resources
+     * (called by the worker after the handler, in a {@code finally}).
+     */
+    public static void exit(TaskScope scope) {
+        ACTIVE.clear();
+        if (scope != null) {
+            scope.teardown();
+        }
+    }
+}

--- a/sdks/java/src/main/java/org/byteveda/taskito/resources/TaskScope.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/resources/TaskScope.java
@@ -1,0 +1,48 @@
+package org.byteveda.taskito.resources;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Per-invocation resource scope. Caches task-scoped resources for one task and
+ * disposes them (LIFO) when the task ends. Also serves as the
+ * {@link ResourceContext} for a task-scoped factory, which may use worker or task
+ * resources. Not thread-safe — confined to the single thread running the task.
+ */
+public final class TaskScope implements ResourceContext {
+    private final ResourceRuntime runtime;
+    private final Map<String, Object> cache = new HashMap<>();
+    private final Deque<Runnable> teardown = new ArrayDeque<>();
+
+    TaskScope(ResourceRuntime runtime) {
+        this.runtime = runtime;
+    }
+
+    @Override
+    public ResourceScope scope() {
+        return ResourceScope.TASK;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T use(String name) {
+        return (T) runtime.resolveForTask(this, name);
+    }
+
+    Map<String, Object> cache() {
+        return cache;
+    }
+
+    void pushTeardown(Runnable disposer) {
+        teardown.push(disposer);
+    }
+
+    /** Dispose this invocation's task-scoped resources in reverse build order. */
+    void teardown() {
+        while (!teardown.isEmpty()) {
+            teardown.pop().run();
+        }
+    }
+}

--- a/sdks/java/src/main/java/org/byteveda/taskito/resources/package-info.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/resources/package-info.java
@@ -1,0 +1,11 @@
+/**
+ * Worker-side dependency injection: register a resource once, resolve it inside
+ * task handlers.
+ *
+ * <p>Two scopes (mirroring the Node SDK): {@link org.byteveda.taskito.resources.ResourceScope#WORKER}
+ * resources are built lazily once and shared across every task on the worker;
+ * {@link org.byteveda.taskito.resources.ResourceScope#TASK} resources are built
+ * lazily per task invocation and disposed (LIFO) when it ends. Handlers resolve
+ * them with {@link org.byteveda.taskito.resources.Resources#use(String)}.
+ */
+package org.byteveda.taskito.resources;

--- a/sdks/java/src/main/java/org/byteveda/taskito/worker/Worker.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/worker/Worker.java
@@ -19,6 +19,7 @@ import org.byteveda.taskito.events.Emitter;
 import org.byteveda.taskito.events.EventName;
 import org.byteveda.taskito.events.OutcomeEvent;
 import org.byteveda.taskito.middleware.Middleware;
+import org.byteveda.taskito.resources.ResourceRuntime;
 import org.byteveda.taskito.serialization.Serializer;
 import org.byteveda.taskito.spi.QueueBackend;
 import org.byteveda.taskito.spi.WorkerControl;
@@ -39,17 +40,21 @@ public final class Worker implements AutoCloseable {
     private final WorkerControl control;
     private final ExecutorService executor;
     private final WorkflowTracker tracker;
+    private final ResourceRuntime resources;
     private final CountDownLatch shutdown = new CountDownLatch(1);
     private boolean closed;
 
-    private Worker(WorkerControl control, ExecutorService executor, WorkflowTracker tracker) {
+    private Worker(
+            WorkerControl control, ExecutorService executor, WorkflowTracker tracker, ResourceRuntime resources) {
         this.control = control;
         this.executor = executor;
         this.tracker = tracker;
+        this.resources = resources;
     }
 
-    public static Builder builder(QueueBackend backend, Serializer serializer, List<Middleware> middleware) {
-        return new Builder(backend, serializer, middleware);
+    public static Builder builder(
+            QueueBackend backend, Serializer serializer, List<Middleware> middleware, ResourceRuntime resources) {
+        return new Builder(backend, serializer, middleware, resources);
     }
 
     /** Stop dispatching; in-flight jobs continue to drain. */
@@ -109,6 +114,7 @@ public final class Worker implements AutoCloseable {
         if (tracker != null) {
             tracker.close(); // stop the gate-timeout scheduler
         }
+        resources.teardownWorker(); // dispose worker-scoped resources when the last lease drops
         shutdown.countDown();
     }
 
@@ -119,6 +125,7 @@ public final class Worker implements AutoCloseable {
         private final QueueBackend backend;
         private final Serializer serializer;
         private final List<Middleware> middleware;
+        private final ResourceRuntime resources;
         private final Map<String, RegisteredTask> handlers = new HashMap<>();
         private final Map<String, RetryPolicy> taskPolicies = new HashMap<>();
         private final Map<EventName, List<Consumer<OutcomeEvent>>> listeners = new EnumMap<>(EventName.class);
@@ -128,10 +135,11 @@ public final class Worker implements AutoCloseable {
         private Integer batchSize;
         private WorkflowTracker tracker;
 
-        Builder(QueueBackend backend, Serializer serializer, List<Middleware> middleware) {
+        Builder(QueueBackend backend, Serializer serializer, List<Middleware> middleware, ResourceRuntime resources) {
             this.backend = backend;
             this.serializer = serializer;
             this.middleware = middleware;
+            this.resources = resources;
         }
 
         public <T, R> Builder handle(String taskName, Class<T> payloadType, TaskFunction<T, R> handler) {
@@ -233,10 +241,12 @@ public final class Worker implements AutoCloseable {
             Emitter emitter = new Emitter();
             listeners.forEach((name, bound) -> bound.forEach(listener -> emitter.on(name, listener)));
             WorkerDispatchBridge bridge =
-                    new WorkerDispatchBridge(backend, handlers, serializer, executor, emitter, middleware);
+                    new WorkerDispatchBridge(backend, handlers, serializer, executor, emitter, middleware, resources);
             WorkerControl control = backend.startWorker(bridge, encodeOptions());
             bridge.bind(control);
-            return new Worker(control, executor, tracker);
+            // Lease worker resources only after the native worker started cleanly.
+            resources.acquireWorker();
+            return new Worker(control, executor, tracker, resources);
         }
 
         private String encodeOptions() {

--- a/sdks/java/src/main/java/org/byteveda/taskito/worker/Worker.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/worker/Worker.java
@@ -52,6 +52,10 @@ public final class Worker implements AutoCloseable {
         this.resources = resources;
     }
 
+    public static Builder builder(QueueBackend backend, Serializer serializer, List<Middleware> middleware) {
+        return new Builder(backend, serializer, middleware, new ResourceRuntime());
+    }
+
     public static Builder builder(
             QueueBackend backend, Serializer serializer, List<Middleware> middleware, ResourceRuntime resources) {
         return new Builder(backend, serializer, middleware, resources);

--- a/sdks/java/src/main/java/org/byteveda/taskito/worker/WorkerDispatchBridge.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/worker/WorkerDispatchBridge.java
@@ -14,6 +14,9 @@ import org.byteveda.taskito.events.OutcomeEvent;
 import org.byteveda.taskito.middleware.JobInfo;
 import org.byteveda.taskito.middleware.Middleware;
 import org.byteveda.taskito.middleware.TaskContext;
+import org.byteveda.taskito.resources.ResourceRuntime;
+import org.byteveda.taskito.resources.Resources;
+import org.byteveda.taskito.resources.TaskScope;
 import org.byteveda.taskito.serialization.Serializer;
 import org.byteveda.taskito.spi.QueueBackend;
 import org.byteveda.taskito.spi.WorkerBridge;
@@ -35,6 +38,7 @@ final class WorkerDispatchBridge implements WorkerBridge {
     private final ExecutorService executor;
     private final Emitter emitter;
     private final List<Middleware> middleware;
+    private final ResourceRuntime resources;
     // Resolved once startWorker returns; job tasks await it before completing.
     private final CompletableFuture<WorkerControl> control = new CompletableFuture<>();
 
@@ -44,13 +48,15 @@ final class WorkerDispatchBridge implements WorkerBridge {
             Serializer serializer,
             ExecutorService executor,
             Emitter emitter,
-            List<Middleware> middleware) {
+            List<Middleware> middleware,
+            ResourceRuntime resources) {
         this.backend = backend;
         this.handlers = handlers;
         this.serializer = serializer;
         this.executor = executor;
         this.emitter = emitter;
         this.middleware = middleware;
+        this.resources = resources;
     }
 
     void bind(WorkerControl control) {
@@ -71,6 +77,12 @@ final class WorkerDispatchBridge implements WorkerBridge {
         }
         JobInfo job = new JobInfo(jobId, taskName, () -> loadMetadata(jobId));
         TaskContext context = new TaskContext(jobId, taskName, job);
+        // Bind a per-task resource scope around the handler; skip all wiring when
+        // no resources are registered (zero overhead for the common case).
+        TaskScope scope = resources.isEmpty() ? null : resources.createTaskScope();
+        if (scope != null) {
+            Resources.enter(scope);
+        }
         try {
             for (Middleware m : middleware) {
                 m.before(context);
@@ -86,6 +98,10 @@ final class WorkerDispatchBridge implements WorkerBridge {
                 m.onError(context, t);
             }
             bound.failJob(token, describe(t));
+        } finally {
+            if (scope != null) {
+                Resources.exit(scope); // unbind the thread + dispose task-scoped resources (LIFO)
+            }
         }
     }
 

--- a/sdks/java/src/test/java/org/byteveda/taskito/ResourceTest.java
+++ b/sdks/java/src/test/java/org/byteveda/taskito/ResourceTest.java
@@ -1,0 +1,63 @@
+package org.byteveda.taskito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.byteveda.taskito.errors.ResourceException;
+import org.byteveda.taskito.resources.ResourceScope;
+import org.byteveda.taskito.resources.ResourceStat;
+import org.byteveda.taskito.resources.Resources;
+import org.byteveda.taskito.task.Task;
+import org.byteveda.taskito.worker.Worker;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+class ResourceTest {
+
+    private static final Task<Integer> TASK = Task.of("res.task", Integer.class);
+
+    @Test
+    @Timeout(30)
+    void workerResourceSharedTaskResourcePerInvocation(@TempDir Path dir) throws Exception {
+        int jobs = 3;
+        AtomicInteger taskDisposed = new AtomicInteger();
+        try (Taskito queue =
+                Taskito.builder().url(dir.resolve("r.db").toString()).open()) {
+            queue.resource("shared", ctx -> new Object()); // WORKER scope (default): built once
+            queue.resource("perTask", ResourceScope.TASK, ctx -> new Object(), value -> taskDisposed.incrementAndGet());
+
+            CountDownLatch ran = new CountDownLatch(jobs);
+            try (Worker worker = queue.worker()
+                    .handle(TASK, p -> {
+                        Resources.use("shared");
+                        Resources.use("perTask");
+                        ran.countDown();
+                        return p;
+                    })
+                    .start()) {
+                for (int i = 0; i < jobs; i++) {
+                    queue.enqueue(TASK, i);
+                }
+                assertTrue(ran.await(20, TimeUnit.SECONDS), "handlers did not all run");
+            } // worker close drains in-flight tasks, so every teardown has run
+
+            Map<String, ResourceStat> metrics = queue.resourceMetrics();
+            assertEquals(1, metrics.get("shared").created(), "worker resource built once");
+            assertEquals(jobs, metrics.get("perTask").created(), "task resource built per invocation");
+            assertEquals(jobs, metrics.get("perTask").disposed(), "task resource disposed per invocation");
+            assertEquals(jobs, taskDisposed.get());
+        }
+    }
+
+    @Test
+    void useOutsideTaskThrows() {
+        assertThrows(ResourceException.class, () -> Resources.use("anything"));
+    }
+}

--- a/sdks/java/src/test/java/org/byteveda/taskito/ResourceTest.java
+++ b/sdks/java/src/test/java/org/byteveda/taskito/ResourceTest.java
@@ -10,6 +10,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.byteveda.taskito.errors.ResourceException;
 import org.byteveda.taskito.resources.ResourceScope;
 import org.byteveda.taskito.resources.ResourceStat;
@@ -69,6 +70,36 @@ class ResourceTest {
                 Taskito.builder().url(dir.resolve("rdup.db").toString()).open()) {
             queue.resource("db", ctx -> new Object());
             assertThrows(ResourceException.class, () -> queue.resource("db", ctx -> new Object()));
+        }
+    }
+
+    @Test
+    @Timeout(30)
+    void circularResourceDependencyIsRejected(@TempDir Path dir) throws Exception {
+        try (Taskito queue =
+                Taskito.builder().url(dir.resolve("rcyc.db").toString()).open()) {
+            queue.resource("self", ctx -> {
+                ctx.use("self"); // self-reference — must fail fast, not StackOverflow
+                return new Object();
+            });
+            AtomicReference<Class<?>> thrown = new AtomicReference<>();
+            CountDownLatch ran = new CountDownLatch(1);
+            try (Worker worker = queue.worker()
+                    .handle(TASK, p -> {
+                        try {
+                            Resources.use("self");
+                        } catch (RuntimeException e) {
+                            thrown.set(e.getClass());
+                        } finally {
+                            ran.countDown();
+                        }
+                        return p;
+                    })
+                    .start()) {
+                queue.enqueue(TASK, 1);
+                assertTrue(ran.await(20, TimeUnit.SECONDS));
+            }
+            assertEquals(ResourceException.class, thrown.get());
         }
     }
 

--- a/sdks/java/src/test/java/org/byteveda/taskito/ResourceTest.java
+++ b/sdks/java/src/test/java/org/byteveda/taskito/ResourceTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.byteveda.taskito.errors.ResourceException;
@@ -14,6 +15,7 @@ import org.byteveda.taskito.resources.ResourceScope;
 import org.byteveda.taskito.resources.ResourceStat;
 import org.byteveda.taskito.resources.Resources;
 import org.byteveda.taskito.task.Task;
+import org.byteveda.taskito.task.TaskFunction;
 import org.byteveda.taskito.worker.Worker;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -59,5 +61,32 @@ class ResourceTest {
     @Test
     void useOutsideTaskThrows() {
         assertThrows(ResourceException.class, () -> Resources.use("anything"));
+    }
+
+    @Test
+    @Timeout(30)
+    void workerScopedResourceIsBuiltPerWorker(@TempDir Path dir) throws Exception {
+        try (Taskito queue =
+                Taskito.builder().url(dir.resolve("rpw.db").toString()).open()) {
+            queue.resource("perWorker", ctx -> new Object());
+            // Force exactly one job per worker so both live workers resolve the resource.
+            CyclicBarrier bothBusy = new CyclicBarrier(2);
+            CountDownLatch ran = new CountDownLatch(2);
+            TaskFunction<Integer, Integer> handler = p -> {
+                Resources.use("perWorker");
+                bothBusy.await(20, TimeUnit.SECONDS);
+                ran.countDown();
+                return p;
+            };
+            try (Worker w1 = queue.worker().concurrency(1).handle(TASK, handler).start();
+                    Worker w2 =
+                            queue.worker().concurrency(1).handle(TASK, handler).start()) {
+                queue.enqueue(TASK, 1);
+                queue.enqueue(TASK, 2);
+                assertTrue(ran.await(25, TimeUnit.SECONDS));
+            }
+            // Shared-runtime would build once (created==1); per-worker builds one each.
+            assertEquals(2, queue.resourceMetrics().get("perWorker").created());
+        }
     }
 }

--- a/sdks/java/src/test/java/org/byteveda/taskito/ResourceTest.java
+++ b/sdks/java/src/test/java/org/byteveda/taskito/ResourceTest.java
@@ -64,6 +64,15 @@ class ResourceTest {
     }
 
     @Test
+    void duplicateRegistrationThrows(@TempDir Path dir) throws Exception {
+        try (Taskito queue =
+                Taskito.builder().url(dir.resolve("rdup.db").toString()).open()) {
+            queue.resource("db", ctx -> new Object());
+            assertThrows(ResourceException.class, () -> queue.resource("db", ctx -> new Object()));
+        }
+    }
+
+    @Test
     @Timeout(30)
     void workerScopedResourceIsBuiltPerWorker(@TempDir Path dir) throws Exception {
         try (Taskito queue =


### PR DESCRIPTION
Adds worker-side dependency injection: register a resource once, resolve it
inside a task without threading it through payloads. Node-style two-scope model
(no Python-style 4-scope/pool/health).

## API
- `ResourceScope` {WORKER, TASK}; `ResourceContext` (scope + `use(name)`).
- `Taskito.resource(name, factory)` (WORKER), an overload with scope + a
  `dispose` callback, and `resourceMetrics()`.
- In a task: `Resources.use("name")` resolves the resource (task cache → worker).

## Mechanics
- `internal.ScopeContext<T>` — a thin `ThreadLocal` seam (single swap point if the
  baseline later rises to `ScopedValue`); set/cleared per task in `try/finally` so
  pooled worker threads never leak context.
- `ResourceRuntime` memoizes WORKER resources (build-once via a per-name lock,
  evict on factory failure → retryable), creates per-task scopes, and disposes
  LIFO. Lease-counted `acquireWorker`/`teardownWorker`.
- `WorkerDispatchBridge.runJob` wraps the handler in a task scope only when
  resources are registered (`isEmpty()` short-circuit → zero overhead unused).
- Resolution/disposal errors raise `ResourceException`; a disposal failure never
  fails a settled job (best-effort, logged via `System.Logger`).

## Tests
`WorkerResourceTest` covers WORKER vs TASK scope, injection at `runJob`, disposal
order, and metrics.

Pure Java, no native change. Rebased onto master.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added first-class named resource support with worker-scoped (shared) and task-scoped (per-job) lifetimes.
  * You can register resources with optional cleanup logic and resolve them during task execution.
  * Exposed resource usage metrics and improved runtime tracking of resource creation/disposal.
* **Bug Fixes**
  * Resource access outside an active task now fails with a clear error.
  * Added fail-fast validation for circular dependencies and duplicate resource registrations.
  * Resource cleanup now runs more reliably when jobs complete or workers shut down.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->