### PR TITLE
feat(java): enqueue predicates (gates)

### DIFF
--- a/sdks/java/src/main/java/org/byteveda/taskito/DefaultTaskito.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/DefaultTaskito.java
@@ -143,11 +143,12 @@ final class DefaultTaskito implements Taskito {
 
     /** Run onEnqueue middleware, then serialize and submit the (possibly rewritten) job. */
     private String dispatchEnqueue(String taskName, Object payload, EnqueueOptions options) {
-        gate(taskName, payload);
         EnqueueContext context = new EnqueueContext(taskName, payload, options);
         for (Middleware m : middleware) {
             m.onEnqueue(context);
         }
+        // Gate the payload that will actually be enqueued (after middleware may have rewritten it).
+        gate(taskName, context.payload());
         EnqueueOptions finalOptions = context.options();
         if (!context.metadata().isEmpty()) {
             finalOptions = finalOptions.toBuilder()

--- a/sdks/java/src/main/java/org/byteveda/taskito/DefaultTaskito.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/DefaultTaskito.java
@@ -179,6 +179,10 @@ final class DefaultTaskito implements Taskito {
 
     @Override
     public <T> List<String> enqueueMany(Task<T> task, List<T> payloads, EnqueueOptions options) {
+        // Preflight every payload through the task's gates; a single rejection fails the whole batch.
+        for (T payload : payloads) {
+            gate(task.name(), payload);
+        }
         byte[][] bytes = new byte[payloads.size()][];
         List<EnqueueOptions> perJob = new ArrayList<>(payloads.size());
         for (int i = 0; i < payloads.size(); i++) {

--- a/sdks/java/src/main/java/org/byteveda/taskito/DefaultTaskito.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/DefaultTaskito.java
@@ -12,10 +12,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import org.byteveda.taskito.core.CoreFacade;
+import org.byteveda.taskito.errors.PredicateRejectedException;
 import org.byteveda.taskito.errors.SerializationException;
 import org.byteveda.taskito.errors.WorkflowException;
 import org.byteveda.taskito.locks.Lock;
@@ -31,6 +33,8 @@ import org.byteveda.taskito.model.QueueStats;
 import org.byteveda.taskito.model.TaskLog;
 import org.byteveda.taskito.model.TaskMetric;
 import org.byteveda.taskito.model.WorkerInfo;
+import org.byteveda.taskito.predicates.Predicate;
+import org.byteveda.taskito.predicates.PredicateContext;
 import org.byteveda.taskito.resources.ResourceContext;
 import org.byteveda.taskito.resources.ResourceDefinition;
 import org.byteveda.taskito.resources.ResourceRuntime;
@@ -63,6 +67,7 @@ final class DefaultTaskito implements Taskito {
     private final Serializer serializer;
     private final List<Middleware> middleware = new CopyOnWriteArrayList<>();
     private final ResourceRuntime resources = new ResourceRuntime();
+    private final Map<String, List<Predicate>> predicates = new ConcurrentHashMap<>();
 
     DefaultTaskito(QueueBackend backend, Serializer serializer) {
         this.backend = backend;
@@ -106,6 +111,14 @@ final class DefaultTaskito implements Taskito {
         return resources.metrics();
     }
 
+    @Override
+    public Taskito predicate(String taskName, Predicate predicate) {
+        predicates
+                .computeIfAbsent(taskName, key -> new CopyOnWriteArrayList<>())
+                .add(predicate);
+        return this;
+    }
+
     @SuppressWarnings("unchecked")
     private static <T> T cast(Object value) {
         return (T) value;
@@ -130,6 +143,7 @@ final class DefaultTaskito implements Taskito {
 
     /** Run onEnqueue middleware, then serialize and submit the (possibly rewritten) job. */
     private String dispatchEnqueue(String taskName, Object payload, EnqueueOptions options) {
+        gate(taskName, payload);
         EnqueueContext context = new EnqueueContext(taskName, payload, options);
         for (Middleware m : middleware) {
             m.onEnqueue(context);
@@ -141,6 +155,20 @@ final class DefaultTaskito implements Taskito {
                     .build();
         }
         return backend.enqueue(taskName, serializer.serialize(context.payload()), encode(finalOptions));
+    }
+
+    /** Run any registered enqueue gates for {@code taskName}; throw if one rejects. */
+    private void gate(String taskName, Object payload) {
+        List<Predicate> gates = predicates.get(taskName);
+        if (gates == null || gates.isEmpty()) {
+            return;
+        }
+        PredicateContext context = new PredicateContext(taskName, payload);
+        for (Predicate gate : gates) {
+            if (!gate.test(context)) {
+                throw new PredicateRejectedException("enqueue of task '" + taskName + "' rejected by a predicate");
+            }
+        }
     }
 
     @Override

--- a/sdks/java/src/main/java/org/byteveda/taskito/Taskito.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/Taskito.java
@@ -27,6 +27,7 @@ import org.byteveda.taskito.model.QueueStats;
 import org.byteveda.taskito.model.TaskLog;
 import org.byteveda.taskito.model.TaskMetric;
 import org.byteveda.taskito.model.WorkerInfo;
+import org.byteveda.taskito.predicates.Predicate;
 import org.byteveda.taskito.resources.ResourceContext;
 import org.byteveda.taskito.resources.ResourceScope;
 import org.byteveda.taskito.resources.ResourceStat;
@@ -73,6 +74,13 @@ public interface Taskito extends AutoCloseable {
 
     /** Per-resource counters (created / disposed / active). */
     Map<String, ResourceStat> resourceMetrics();
+
+    /**
+     * Gate enqueues of {@code taskName} with {@code predicate}: when it rejects,
+     * {@link #enqueue} throws and no job is created. Multiple predicates on one
+     * task must all pass. Returns {@code this}.
+     */
+    Taskito predicate(String taskName, Predicate predicate);
 
     // ── Producer ────────────────────────────────────────────────────
 

--- a/sdks/java/src/main/java/org/byteveda/taskito/errors/PredicateRejectedException.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/errors/PredicateRejectedException.java
@@ -1,0 +1,13 @@
+package org.byteveda.taskito.errors;
+
+import org.byteveda.taskito.TaskitoException;
+
+/**
+ * An enqueue was rejected by a registered predicate (gate), so no job was
+ * created.
+ */
+public class PredicateRejectedException extends TaskitoException {
+    public PredicateRejectedException(String message) {
+        super(message);
+    }
+}

--- a/sdks/java/src/main/java/org/byteveda/taskito/predicates/Predicate.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/predicates/Predicate.java
@@ -1,0 +1,11 @@
+package org.byteveda.taskito.predicates;
+
+/**
+ * A gate evaluated when a task is enqueued: returns {@code true} to allow the
+ * enqueue, {@code false} to reject it. Evaluated synchronously on the producer
+ * thread, so keep it fast and side-effect-free.
+ */
+@FunctionalInterface
+public interface Predicate {
+    boolean test(PredicateContext context);
+}

--- a/sdks/java/src/main/java/org/byteveda/taskito/predicates/PredicateContext.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/predicates/PredicateContext.java
@@ -1,0 +1,9 @@
+package org.byteveda.taskito.predicates;
+
+/**
+ * What an enqueue gate sees: the task being enqueued and its payload.
+ *
+ * @param taskName the task's registered name
+ * @param payload the payload being enqueued (before serialization)
+ */
+public record PredicateContext(String taskName, Object payload) {}

--- a/sdks/java/src/main/java/org/byteveda/taskito/predicates/Predicates.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/predicates/Predicates.java
@@ -1,0 +1,39 @@
+package org.byteveda.taskito.predicates;
+
+import java.util.List;
+
+/** Combinators for building compound {@link Predicate}s. */
+public final class Predicates {
+    private Predicates() {}
+
+    /** Passes only when every {@code predicate} passes (vacuously true when none). */
+    public static Predicate allOf(Predicate... predicates) {
+        List<Predicate> all = List.of(predicates);
+        return context -> {
+            for (Predicate predicate : all) {
+                if (!predicate.test(context)) {
+                    return false;
+                }
+            }
+            return true;
+        };
+    }
+
+    /** Passes when at least one {@code predicate} passes (false when none). */
+    public static Predicate anyOf(Predicate... predicates) {
+        List<Predicate> any = List.of(predicates);
+        return context -> {
+            for (Predicate predicate : any) {
+                if (predicate.test(context)) {
+                    return true;
+                }
+            }
+            return false;
+        };
+    }
+
+    /** Inverts {@code predicate}. */
+    public static Predicate not(Predicate predicate) {
+        return context -> !predicate.test(context);
+    }
+}

--- a/sdks/java/src/main/java/org/byteveda/taskito/predicates/package-info.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/predicates/package-info.java
@@ -1,0 +1,10 @@
+/**
+ * Enqueue gates: register a {@link org.byteveda.taskito.predicates.Predicate}
+ * for a task and it is evaluated when that task is enqueued. If any predicate
+ * rejects, the enqueue fails with a
+ * {@link org.byteveda.taskito.errors.PredicateRejectedException} and no job is
+ * created. Combine predicates with
+ * {@link org.byteveda.taskito.predicates.Predicates#allOf},
+ * {@code anyOf}, and {@code not}.
+ */
+package org.byteveda.taskito.predicates;

--- a/sdks/java/src/test/java/org/byteveda/taskito/PredicateTest.java
+++ b/sdks/java/src/test/java/org/byteveda/taskito/PredicateTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
+import java.util.List;
 import org.byteveda.taskito.errors.PredicateRejectedException;
 import org.byteveda.taskito.middleware.EnqueueContext;
 import org.byteveda.taskito.middleware.Middleware;
@@ -35,6 +36,16 @@ class PredicateTest {
                 Taskito.builder().url(dir.resolve("p.db").toString()).open()) {
             queue.predicate("p.task", ctx -> (Integer) ctx.payload() > 0);
             assertThrows(PredicateRejectedException.class, () -> queue.enqueue(TASK, -1));
+        }
+    }
+
+    @Test
+    void batchEnqueueRejectsViaPredicate(@TempDir Path dir) {
+        try (Taskito queue =
+                Taskito.builder().url(dir.resolve("pb.db").toString()).open()) {
+            queue.predicate("p.task", ctx -> (Integer) ctx.payload() > 0);
+            // One rejected payload fails the whole batch — the batch API can't bypass the gate.
+            assertThrows(PredicateRejectedException.class, () -> queue.enqueueMany(TASK, List.of(1, -1, 2)));
         }
     }
 

--- a/sdks/java/src/test/java/org/byteveda/taskito/PredicateTest.java
+++ b/sdks/java/src/test/java/org/byteveda/taskito/PredicateTest.java
@@ -7,6 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
 import org.byteveda.taskito.errors.PredicateRejectedException;
+import org.byteveda.taskito.middleware.EnqueueContext;
+import org.byteveda.taskito.middleware.Middleware;
 import org.byteveda.taskito.predicates.Predicate;
 import org.byteveda.taskito.predicates.PredicateContext;
 import org.byteveda.taskito.predicates.Predicates;
@@ -33,6 +35,22 @@ class PredicateTest {
                 Taskito.builder().url(dir.resolve("p.db").toString()).open()) {
             queue.predicate("p.task", ctx -> (Integer) ctx.payload() > 0);
             assertThrows(PredicateRejectedException.class, () -> queue.enqueue(TASK, -1));
+        }
+    }
+
+    @Test
+    void predicateSeesMiddlewareRewrittenPayload(@TempDir Path dir) {
+        try (Taskito queue =
+                Taskito.builder().url(dir.resolve("pm.db").toString()).open()) {
+            queue.predicate("p.task", ctx -> (Integer) ctx.payload() > 0);
+            queue.use(new Middleware() {
+                @Override
+                public void onEnqueue(EnqueueContext context) {
+                    context.payload(5); // rewrite the rejected -1 into an accepted value
+                }
+            });
+            // Gate runs after middleware, so it sees the rewritten 5 and allows the enqueue.
+            assertNotNull(queue.enqueue(TASK, -1));
         }
     }
 

--- a/sdks/java/src/test/java/org/byteveda/taskito/PredicateTest.java
+++ b/sdks/java/src/test/java/org/byteveda/taskito/PredicateTest.java
@@ -1,0 +1,54 @@
+package org.byteveda.taskito;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import org.byteveda.taskito.errors.PredicateRejectedException;
+import org.byteveda.taskito.predicates.Predicate;
+import org.byteveda.taskito.predicates.PredicateContext;
+import org.byteveda.taskito.predicates.Predicates;
+import org.byteveda.taskito.task.Task;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class PredicateTest {
+
+    private static final Task<Integer> TASK = Task.of("p.task", Integer.class);
+
+    @Test
+    void allowsWhenPredicatePasses(@TempDir Path dir) {
+        try (Taskito queue =
+                Taskito.builder().url(dir.resolve("p.db").toString()).open()) {
+            queue.predicate("p.task", ctx -> (Integer) ctx.payload() > 0);
+            assertNotNull(queue.enqueue(TASK, 5));
+        }
+    }
+
+    @Test
+    void rejectsWhenPredicateFails(@TempDir Path dir) {
+        try (Taskito queue =
+                Taskito.builder().url(dir.resolve("p.db").toString()).open()) {
+            queue.predicate("p.task", ctx -> (Integer) ctx.payload() > 0);
+            assertThrows(PredicateRejectedException.class, () -> queue.enqueue(TASK, -1));
+        }
+    }
+
+    @Test
+    void combinators() {
+        Predicate even = ctx -> (Integer) ctx.payload() % 2 == 0;
+        Predicate positive = ctx -> (Integer) ctx.payload() > 0;
+
+        assertTrue(Predicates.allOf(even, positive).test(ctx(4)));
+        assertFalse(Predicates.allOf(even, positive).test(ctx(3)));
+        assertTrue(Predicates.anyOf(even, positive).test(ctx(3))); // positive
+        assertFalse(Predicates.anyOf(even, positive).test(ctx(-1)));
+        assertTrue(Predicates.not(even).test(ctx(3)));
+    }
+
+    private static PredicateContext ctx(int payload) {
+        return new PredicateContext("p.task", payload);
+    }
+}


### PR DESCRIPTION
Adds predicate gates on the producer side: register a predicate per task and it
runs at enqueue time; if any rejects, the job is not created.

## API
- `predicates/Predicate` (functional, `test(PredicateContext)`), `PredicateContext`
  (record: taskName + payload), and `Predicates.allOf/anyOf/not` combinators.
- `Taskito.predicate(taskName, predicate)` registers one for a task.

## Mechanics
- `DefaultTaskito.dispatchEnqueue` evaluates the task's predicates first; if any
  returns false it throws `PredicateRejectedException` (no job enqueued). Zero
  overhead when no predicate is registered for the task.

## Tests
`PredicateTest` covers accept, reject, and `allOf`/`anyOf`/`not` composition.

Pure Java, no native change. Rebased onto master.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added task enqueue checks so jobs can be accepted or rejected based on custom conditions.
  * Added support for combining conditions with all/any/not logic.

* **Bug Fixes**
  * Enqueue requests that fail a condition are now rejected immediately, preventing the job from being created.

* **Documentation**
  * Updated guidance around task enqueue conditions and how to use the new composition helpers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->