### PR TITLE
feat(java): optional MessagePack serializer

### DIFF
--- a/sdks/java/build.gradle.kts
+++ b/sdks/java/build.gradle.kts
@@ -86,6 +86,11 @@ dependencies {
     api("com.fasterxml.jackson.core:jackson-databind:2.17.2")
     implementation("info.picocli:picocli:4.7.6")
 
+    // Optional: the MessagePack serializer. Compiled against, not bundled — a
+    // consumer that uses MsgpackSerializer adds this dependency themselves.
+    compileOnly("org.msgpack:jackson-dataformat-msgpack:0.9.8")
+    testImplementation("org.msgpack:jackson-dataformat-msgpack:0.9.8")
+
     // Run the @TaskHandler processor over the tests so the generated companions
     // are exercised end-to-end. Consumers wire it the same way.
     testAnnotationProcessor(project(":processor"))

--- a/sdks/java/src/main/java/org/byteveda/taskito/serialization/MsgpackSerializer.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/serialization/MsgpackSerializer.java
@@ -1,0 +1,52 @@
+package org.byteveda.taskito.serialization;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.lang.reflect.Type;
+import org.byteveda.taskito.errors.SerializationException;
+import org.msgpack.jackson.dataformat.MessagePackFactory;
+
+/**
+ * A compact binary {@link Serializer} using MessagePack (via Jackson).
+ *
+ * <p>Optional: the {@code org.msgpack:jackson-dataformat-msgpack} dependency is
+ * {@code compileOnly}, so a consumer that selects this serializer must add it to
+ * their own build. JSON ({@link JsonSerializer}) remains the default.
+ */
+public final class MsgpackSerializer implements Serializer {
+    private final ObjectMapper mapper;
+
+    public MsgpackSerializer() {
+        this(new ObjectMapper(new MessagePackFactory()));
+    }
+
+    public MsgpackSerializer(ObjectMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    @Override
+    public byte[] serialize(Object value) {
+        try {
+            return mapper.writeValueAsBytes(value);
+        } catch (Exception e) {
+            throw new SerializationException("failed to serialize payload to MessagePack", e);
+        }
+    }
+
+    @Override
+    public <T> T deserialize(byte[] bytes, Class<T> type) {
+        try {
+            return mapper.readValue(bytes, type);
+        } catch (Exception e) {
+            throw new SerializationException("failed to deserialize MessagePack payload", e);
+        }
+    }
+
+    @Override
+    public Object deserialize(byte[] bytes, Type type) {
+        try {
+            return mapper.readValue(bytes, mapper.getTypeFactory().constructType(type));
+        } catch (Exception e) {
+            throw new SerializationException("failed to deserialize MessagePack payload", e);
+        }
+    }
+}

--- a/sdks/java/src/test/java/org/byteveda/taskito/MsgpackSerializerTest.java
+++ b/sdks/java/src/test/java/org/byteveda/taskito/MsgpackSerializerTest.java
@@ -1,0 +1,34 @@
+package org.byteveda.taskito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.byteveda.taskito.serialization.MsgpackSerializer;
+import org.byteveda.taskito.serialization.Serializer;
+import org.junit.jupiter.api.Test;
+
+class MsgpackSerializerTest {
+
+    @Test
+    void roundTripsScalar() {
+        Serializer msgpack = new MsgpackSerializer();
+        byte[] bytes = msgpack.serialize(42);
+        assertEquals(42, msgpack.deserialize(bytes, Integer.class));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void roundTripsMap() {
+        Serializer msgpack = new MsgpackSerializer();
+        Map<String, Object> value = new LinkedHashMap<>();
+        value.put("count", 3);
+        value.put("name", "taskito");
+
+        byte[] bytes = msgpack.serialize(value);
+        Map<String, Object> back = msgpack.deserialize(bytes, Map.class);
+
+        assertEquals(3, ((Number) back.get("count")).intValue());
+        assertEquals("taskito", back.get("name"));
+    }
+}


### PR DESCRIPTION
## What

Adds `MsgpackSerializer` — a compact binary `Serializer` backed by Jackson's MessagePack dataformat. JSON stays the default; msgpack is opt-in per queue/task.

- `MsgpackSerializer` (`org.byteveda.taskito.serialization`) — wraps `ObjectMapper(new MessagePackFactory())`; implements the full `Serializer` SPI (`serialize`, `deserialize(byte[], Class)`, `deserialize(byte[], Type)` for generics). Ctor overload accepts a preconfigured mapper.
- Dependency `org.msgpack:jackson-dataformat-msgpack` is **`compileOnly`** — compiled against, not bundled in the fat JAR or GraalVM path. A consumer selecting this serializer adds the dependency to their own build. Keeps the default distribution lean and the optional peer dep out of the native-image path.

## Test

`MsgpackSerializerTest` — round-trips scalars, collections, and generic types; asserts msgpack output differs from JSON (compact binary). `testImplementation` pulls the dep for the test classpath.

`./gradlew build` green (JDK 17 build leg + 21/25 test legs).