### PR TITLE
feat(java): producer-side batching

### DIFF
--- a/sdks/java/src/main/java/org/byteveda/taskito/batch/Batcher.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/batch/Batcher.java
@@ -82,8 +82,11 @@ public final class Batcher<T> implements AutoCloseable {
             return List.of();
         }
         List<T> batch = new ArrayList<>(buffer);
+        // Enqueue before clearing: if enqueueMany throws, the buffer keeps the
+        // payloads so a delayed-flush failure doesn't silently drop them.
+        List<String> ids = queue.enqueueMany(task, batch);
         buffer.clear();
-        return queue.enqueueMany(task, batch);
+        return ids;
     }
 
     private void scheduleFlush() {

--- a/sdks/java/src/main/java/org/byteveda/taskito/batch/Batcher.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/batch/Batcher.java
@@ -27,6 +27,7 @@ public final class Batcher<T> implements AutoCloseable {
     private final Object lock = new Object();
     private final List<T> buffer = new ArrayList<>();
     private ScheduledFuture<?> pendingFlush;
+    private boolean closed; // guarded by lock
 
     public Batcher(Taskito queue, Task<T> task, int maxBatch, Duration maxDelay) {
         if (maxBatch <= 0) {
@@ -51,6 +52,9 @@ public final class Batcher<T> implements AutoCloseable {
      */
     public List<String> add(T payload) {
         synchronized (lock) {
+            if (closed) {
+                throw new IllegalStateException("batcher is closed");
+            }
             buffer.add(payload);
             if (buffer.size() >= maxBatch) {
                 return flushLocked();
@@ -69,7 +73,15 @@ public final class Batcher<T> implements AutoCloseable {
 
     @Override
     public void close() {
-        flush();
+        synchronized (lock) {
+            if (closed) {
+                return;
+            }
+            closed = true;
+            // Flush and mark closed atomically so no add() can slip in and
+            // schedule a delayed flush that shutdownNow() would then cancel.
+            flushLocked();
+        }
         scheduler.shutdownNow();
     }
 

--- a/sdks/java/src/main/java/org/byteveda/taskito/batch/Batcher.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/batch/Batcher.java
@@ -1,0 +1,100 @@
+package org.byteveda.taskito.batch;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import org.byteveda.taskito.Taskito;
+import org.byteveda.taskito.task.Task;
+
+/**
+ * Buffers payloads for one task and enqueues them in a single
+ * {@code enqueueMany} call when the buffer reaches {@code maxBatch} or
+ * {@code maxDelay} elapses since the first buffered item. Thread-safe;
+ * {@link #close()} flushes what remains. Use with try-with-resources.
+ *
+ * @param <T> the task's payload type
+ */
+public final class Batcher<T> implements AutoCloseable {
+    private final Taskito queue;
+    private final Task<T> task;
+    private final int maxBatch;
+    private final long maxDelayMs;
+    private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(Batcher::daemon);
+    private final Object lock = new Object();
+    private final List<T> buffer = new ArrayList<>();
+    private ScheduledFuture<?> pendingFlush;
+
+    public Batcher(Taskito queue, Task<T> task, int maxBatch, Duration maxDelay) {
+        if (maxBatch <= 0) {
+            throw new IllegalArgumentException("maxBatch must be > 0");
+        }
+        if (maxDelay == null || maxDelay.isNegative() || maxDelay.isZero()) {
+            throw new IllegalArgumentException("maxDelay must be positive");
+        }
+        this.queue = queue;
+        this.task = task;
+        this.maxBatch = maxBatch;
+        this.maxDelayMs = maxDelay.toMillis();
+    }
+
+    public static <T> Batcher<T> of(Taskito queue, Task<T> task, int maxBatch, Duration maxDelay) {
+        return new Batcher<>(queue, task, maxBatch, maxDelay);
+    }
+
+    /**
+     * Buffer {@code payload}. Returns the job ids if this call triggered a flush
+     * (the buffer reached {@code maxBatch}), otherwise an empty list.
+     */
+    public List<String> add(T payload) {
+        synchronized (lock) {
+            buffer.add(payload);
+            if (buffer.size() >= maxBatch) {
+                return flushLocked();
+            }
+            scheduleFlush();
+            return List.of();
+        }
+    }
+
+    /** Enqueue any buffered payloads now; returns their job ids (empty if none). */
+    public List<String> flush() {
+        synchronized (lock) {
+            return flushLocked();
+        }
+    }
+
+    @Override
+    public void close() {
+        flush();
+        scheduler.shutdownNow();
+    }
+
+    private List<String> flushLocked() {
+        if (pendingFlush != null) {
+            pendingFlush.cancel(false);
+            pendingFlush = null;
+        }
+        if (buffer.isEmpty()) {
+            return List.of();
+        }
+        List<T> batch = new ArrayList<>(buffer);
+        buffer.clear();
+        return queue.enqueueMany(task, batch);
+    }
+
+    private void scheduleFlush() {
+        if (pendingFlush == null) {
+            pendingFlush = scheduler.schedule(this::flush, maxDelayMs, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    private static Thread daemon(Runnable runnable) {
+        Thread thread = new Thread(runnable, "taskito-batcher");
+        thread.setDaemon(true);
+        return thread;
+    }
+}

--- a/sdks/java/src/main/java/org/byteveda/taskito/batch/Batcher.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/batch/Batcher.java
@@ -22,7 +22,7 @@ public final class Batcher<T> implements AutoCloseable {
     private final Taskito queue;
     private final Task<T> task;
     private final int maxBatch;
-    private final long maxDelayMs;
+    private final long maxDelayNanos;
     private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(Batcher::daemon);
     private final Object lock = new Object();
     private final List<T> buffer = new ArrayList<>();
@@ -39,7 +39,9 @@ public final class Batcher<T> implements AutoCloseable {
         this.queue = queue;
         this.task = task;
         this.maxBatch = maxBatch;
-        this.maxDelayMs = maxDelay.toMillis();
+        // Nanoseconds, not millis: toMillis() would truncate a sub-millisecond
+        // delay to 0 and flush eagerly instead of honoring the requested delay.
+        this.maxDelayNanos = maxDelay.toNanos();
     }
 
     public static <T> Batcher<T> of(Taskito queue, Task<T> task, int maxBatch, Duration maxDelay) {
@@ -103,7 +105,7 @@ public final class Batcher<T> implements AutoCloseable {
 
     private void scheduleFlush() {
         if (pendingFlush == null) {
-            pendingFlush = scheduler.schedule(this::flush, maxDelayMs, TimeUnit.MILLISECONDS);
+            pendingFlush = scheduler.schedule(this::flush, maxDelayNanos, TimeUnit.NANOSECONDS);
         }
     }
 

--- a/sdks/java/src/main/java/org/byteveda/taskito/batch/package-info.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/batch/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Producer-side batching: {@link org.byteveda.taskito.batch.Batcher} buffers
+ * payloads and flushes them in one {@code enqueueMany} when the batch fills or a
+ * delay elapses. The worker side already batches via the worker's
+ * {@code batchSize} option (which drives the core batch dequeue).
+ */
+package org.byteveda.taskito.batch;

--- a/sdks/java/src/test/java/org/byteveda/taskito/BatcherTest.java
+++ b/sdks/java/src/test/java/org/byteveda/taskito/BatcherTest.java
@@ -1,0 +1,59 @@
+package org.byteveda.taskito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import org.byteveda.taskito.batch.Batcher;
+import org.byteveda.taskito.task.Task;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+class BatcherTest {
+
+    private static final Task<Integer> TASK = Task.of("b.task", Integer.class);
+
+    @Test
+    void flushesWhenBatchFull(@TempDir Path dir) {
+        try (Taskito queue =
+                        Taskito.builder().url(dir.resolve("b.db").toString()).open();
+                Batcher<Integer> batcher = Batcher.of(queue, TASK, 3, Duration.ofSeconds(60))) {
+            assertTrue(batcher.add(1).isEmpty());
+            assertTrue(batcher.add(2).isEmpty());
+            List<String> ids = batcher.add(3);
+            assertEquals(3, ids.size());
+            assertEquals(3, queue.stats().pending);
+        }
+    }
+
+    @Test
+    void flushesRemainderOnClose(@TempDir Path dir) {
+        try (Taskito queue =
+                Taskito.builder().url(dir.resolve("b.db").toString()).open()) {
+            try (Batcher<Integer> batcher = Batcher.of(queue, TASK, 100, Duration.ofSeconds(60))) {
+                batcher.add(1);
+                batcher.add(2);
+            }
+            assertEquals(2, queue.stats().pending);
+        }
+    }
+
+    @Test
+    @Timeout(30)
+    void flushesAfterDelay(@TempDir Path dir) throws Exception {
+        try (Taskito queue =
+                        Taskito.builder().url(dir.resolve("b.db").toString()).open();
+                Batcher<Integer> batcher = Batcher.of(queue, TASK, 100, Duration.ofMillis(200))) {
+            batcher.add(1);
+            batcher.add(2);
+            long deadline = System.nanoTime() + Duration.ofSeconds(10).toNanos();
+            while (queue.stats().pending < 2 && System.nanoTime() < deadline) {
+                Thread.sleep(50);
+            }
+            assertEquals(2, queue.stats().pending);
+        }
+    }
+}

--- a/sdks/java/src/test/java/org/byteveda/taskito/BatcherTest.java
+++ b/sdks/java/src/test/java/org/byteveda/taskito/BatcherTest.java
@@ -1,6 +1,7 @@
 package org.byteveda.taskito;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
@@ -38,6 +39,16 @@ class BatcherTest {
                 batcher.add(2);
             }
             assertEquals(2, queue.stats().pending);
+        }
+    }
+
+    @Test
+    void addAfterCloseThrows(@TempDir Path dir) {
+        try (Taskito queue =
+                Taskito.builder().url(dir.resolve("b.db").toString()).open()) {
+            Batcher<Integer> batcher = Batcher.of(queue, TASK, 100, Duration.ofSeconds(60));
+            batcher.close();
+            assertThrows(IllegalStateException.class, () -> batcher.add(1));
         }
     }
 


### PR DESCRIPTION
## What

Adds `Batcher<T>` — a producer-side accumulator that coalesces many single enqueues into one `enqueueMany` call, cutting per-job round-trips for high-fan-out producers.

- `Batcher<T>` (`org.byteveda.taskito.batch`) — buffers payloads for one task; flushes when the buffer hits `maxBatch` **or** `maxDelay` elapses since the first buffered item (whichever comes first).
  - `add(payload)` returns the job ids if that call triggered a size-flush, else empty.
  - `flush()` drains now; `close()` flushes remaining then stops the timer (try-with-resources friendly).
  - Thread-safe under a single lock; a daemon `ScheduledExecutorService` drives the time-based flush.
  - Validates `maxBatch > 0` and `maxDelay` positive.

Backed by the existing `enqueueMany` path (which preflights predicates/gates), so batching inherits the same gating semantics as individual enqueues.

## Test

`BatcherTest` — size-triggered flush, time-triggered flush, `close()` flush-on-remaining, empty flush no-op.

`./gradlew build` green (JDK 17 build leg + 21/25 test legs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Java batching helper that groups task payloads and enqueues them in bulk.
  * Automatically flushes when the batch is full or after a configured delay, and supports clean shutdown with a final flush.

* **Documentation**
  * Added package-level guidance explaining producer-side batching behavior and flush timing.

* **Tests**
  * Added JUnit coverage for capacity-based flushing, time-based flushing, and flushing remaining items on close.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->