### PR TITLE
feat(java): per-task payload codec annotations

### DIFF
--- a/sdks/java/processor/src/main/java/org/byteveda/taskito/processor/TaskHandlerProcessor.java
+++ b/sdks/java/processor/src/main/java/org/byteveda/taskito/processor/TaskHandlerProcessor.java
@@ -33,6 +33,8 @@ import javax.tools.JavaFileObject;
 public final class TaskHandlerProcessor extends AbstractProcessor {
     static final String ANNOTATION = "org.byteveda.taskito.annotation.TaskHandler";
     static final String RESOURCE = "org.byteveda.taskito.annotation.Resource";
+    static final String COMPRESSED = "org.byteveda.taskito.annotation.Compressed";
+    static final String ENCRYPTED = "org.byteveda.taskito.annotation.Encrypted";
 
     @Override
     public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
@@ -126,6 +128,7 @@ public final class TaskHandlerProcessor extends AbstractProcessor {
                     .append(payloadType)
                     .append(">() {})")
                     .append(options(method))
+                    .append(codecsChain(method))
                     .append(";\n\n");
         }
 
@@ -202,6 +205,43 @@ public final class TaskHandlerProcessor extends AbstractProcessor {
             return "payload -> { impl." + methodName + "(" + args + "); return null; }";
         }
         return params.size() > 1 ? "payload -> impl." + methodName + "(" + args + ")" : "impl::" + methodName;
+    }
+
+    /** A {@code .codecs(...)} call for the task's @Compressed/@Encrypted markers (compress before encrypt). */
+    private String codecsChain(ExecutableElement method) {
+        List<String> names = new java.util.ArrayList<>();
+        if (hasAnnotation(method, COMPRESSED)) {
+            names.add("compressed");
+        }
+        if (hasAnnotation(method, ENCRYPTED)) {
+            names.add("encrypted");
+        }
+        if (names.isEmpty()) {
+            return "";
+        }
+        StringBuilder chain = new StringBuilder(".codecs(");
+        for (int i = 0; i < names.size(); i++) {
+            chain.append("\"").append(names.get(i)).append("\"");
+            if (i + 1 < names.size()) {
+                chain.append(", ");
+            }
+        }
+        return chain.append(")").toString();
+    }
+
+    /** Whether the method or its enclosing class carries the annotation {@code fqn}. */
+    private boolean hasAnnotation(ExecutableElement method, String fqn) {
+        return hasAnnotation(method.getAnnotationMirrors(), fqn)
+                || hasAnnotation(method.getEnclosingElement().getAnnotationMirrors(), fqn);
+    }
+
+    private boolean hasAnnotation(List<? extends AnnotationMirror> mirrors, String fqn) {
+        for (AnnotationMirror mirror : mirrors) {
+            if (mirror.getAnnotationType().toString().equals(fqn)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /** The {@code @Resource} value on a parameter, or null if it is not annotated. */

--- a/sdks/java/src/main/java/org/byteveda/taskito/DefaultTaskito.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/DefaultTaskito.java
@@ -44,6 +44,7 @@ import org.byteveda.taskito.resources.ResourceRuntime;
 import org.byteveda.taskito.resources.ResourceScope;
 import org.byteveda.taskito.resources.ResourceStat;
 import org.byteveda.taskito.scheduling.PeriodicTask;
+import org.byteveda.taskito.serialization.PayloadCodec;
 import org.byteveda.taskito.serialization.Serializer;
 import org.byteveda.taskito.spi.QueueBackend;
 import org.byteveda.taskito.task.EnqueueOptions;
@@ -68,15 +69,17 @@ final class DefaultTaskito implements Taskito {
     private final QueueBackend backend;
     private final CoreFacade facade;
     private final Serializer serializer;
+    private final Map<String, PayloadCodec> codecs;
     private final List<Middleware> middleware = new CopyOnWriteArrayList<>();
     private final ResourceRuntime resources = new ResourceRuntime();
     private final Map<String, List<Predicate>> predicates = new ConcurrentHashMap<>();
     private final List<Interceptor> interceptors = new CopyOnWriteArrayList<>();
 
-    DefaultTaskito(QueueBackend backend, Serializer serializer) {
+    DefaultTaskito(QueueBackend backend, Serializer serializer, Map<String, PayloadCodec> codecs) {
         this.backend = backend;
         this.facade = new CoreFacade(backend);
         this.serializer = serializer;
+        this.codecs = codecs;
     }
 
     @Override
@@ -143,16 +146,16 @@ final class DefaultTaskito implements Taskito {
 
     @Override
     public <T> String enqueue(Task<T> task, T payload, EnqueueOptions options) {
-        return dispatchEnqueue(task.name(), payload, options);
+        return dispatchEnqueue(task.name(), payload, options, task.codecNames());
     }
 
     @Override
     public String enqueue(String taskName, Object payload) {
-        return dispatchEnqueue(taskName, payload, EnqueueOptions.none());
+        return dispatchEnqueue(taskName, payload, EnqueueOptions.none(), List.of());
     }
 
-    /** Run interceptors + onEnqueue middleware, then serialize and submit the (possibly rewritten) job. */
-    private String dispatchEnqueue(String taskName, Object payload, EnqueueOptions options) {
+    /** Interceptors + onEnqueue middleware, then serialize, codec-encode, and submit the job. */
+    private String dispatchEnqueue(String taskName, Object payload, EnqueueOptions options, List<String> codecNames) {
         for (Interceptor interceptor : interceptors) {
             Interception outcome = interceptor.intercept(taskName, payload);
             if (outcome == null) {
@@ -181,7 +184,21 @@ final class DefaultTaskito implements Taskito {
                     .metadata(encode(context.metadata()))
                     .build();
         }
-        return backend.enqueue(taskName, serializer.serialize(context.payload()), encode(finalOptions));
+        byte[] data = encodeCodecs(serializer.serialize(context.payload()), codecNames);
+        return backend.enqueue(taskName, data, encode(finalOptions));
+    }
+
+    /** Apply a task's payload codecs in order; throws if a name is not registered. */
+    private byte[] encodeCodecs(byte[] data, List<String> codecNames) {
+        byte[] bytes = data;
+        for (String name : codecNames) {
+            PayloadCodec codec = codecs.get(name);
+            if (codec == null) {
+                throw new IllegalStateException("no codec registered named '" + name + "'");
+            }
+            bytes = codec.encode(bytes);
+        }
+        return bytes;
     }
 
     /** Run any registered enqueue gates for {@code taskName}; throw if one rejects. */
@@ -213,7 +230,7 @@ final class DefaultTaskito implements Taskito {
         for (int i = 0; i < payloads.size(); i++) {
             Object payload = interceptBatchPayload(task.name(), payloads.get(i));
             gate(task.name(), payload);
-            bytes[i] = serializer.serialize(payload);
+            bytes[i] = encodeCodecs(serializer.serialize(payload), task.codecNames());
             perJob.add(options);
         }
         return Arrays.asList(backend.enqueueMany(task.name(), bytes, encode(perJob)));
@@ -699,7 +716,7 @@ final class DefaultTaskito implements Taskito {
     @Override
     public Worker.Builder worker() {
         // Each worker gets its own runtime (own WORKER-scoped cache) over shared definitions.
-        return Worker.builder(backend, serializer, middleware, resources.forWorker());
+        return Worker.builder(backend, serializer, middleware, resources.forWorker(), codecs);
     }
 
     @Override

--- a/sdks/java/src/main/java/org/byteveda/taskito/DefaultTaskito.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/DefaultTaskito.java
@@ -156,6 +156,7 @@ final class DefaultTaskito implements Taskito {
 
     /** Interceptors + onEnqueue middleware, then serialize, codec-encode, and submit the job. */
     private String dispatchEnqueue(String taskName, Object payload, EnqueueOptions options, List<String> codecNames) {
+        String originalTaskName = taskName;
         for (Interceptor interceptor : interceptors) {
             Interception outcome = interceptor.intercept(taskName, payload);
             if (outcome == null) {
@@ -170,6 +171,14 @@ final class DefaultTaskito implements Taskito {
                 payload = convert.payload();
             }
             // Pass: leave taskName/payload unchanged.
+        }
+        // A redirect to a different task invalidates the source task's codec chain:
+        // codecNames is the ORIGINAL task's, and the target's codecs can't be resolved
+        // from a bare name — encoding with the wrong chain would corrupt the payload or
+        // break the worker's decode. Reject (batch enqueue rejects Redirect wholesale).
+        if (!codecNames.isEmpty() && !taskName.equals(originalTaskName)) {
+            throw new InterceptionException("interceptor Redirect is not supported for a task with payload codecs ('"
+                    + originalTaskName + "')");
         }
         EnqueueContext context = new EnqueueContext(taskName, payload, options);
         for (Middleware m : middleware) {

--- a/sdks/java/src/main/java/org/byteveda/taskito/Taskito.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/Taskito.java
@@ -257,6 +257,7 @@ public interface Taskito extends AutoCloseable {
         private final Map<String, Object> options = new LinkedHashMap<>();
         private Serializer serializer = new JsonSerializer();
         private final List<PayloadCodec> codecs = new ArrayList<>();
+        private final Map<String, PayloadCodec> namedCodecs = new LinkedHashMap<>();
 
         public Builder backend(String backend) {
             // Normalize at the boundary so callers may pass "SQLite"/"REDIS"; the
@@ -326,6 +327,16 @@ public interface Taskito extends AutoCloseable {
             return this;
         }
 
+        /**
+         * Register a named codec for per-task selection (e.g. via {@code Task.codecs(...)}
+         * or the {@code @Encrypted}/{@code @Compressed} annotations). The same names
+         * must be registered on producers and workers. Returns {@code this}.
+         */
+        public Builder codec(String name, PayloadCodec codec) {
+            this.namedCodecs.put(name, codec);
+            return this;
+        }
+
         /** The serializer wrapped in the configured codec chain (if any). */
         private Serializer effectiveSerializer() {
             return codecs.isEmpty() ? serializer : new CodecSerializer(serializer, codecs);
@@ -333,7 +344,7 @@ public interface Taskito extends AutoCloseable {
 
         /** Open over an explicit backend, e.g. an in-memory fake in tests. */
         public Taskito open(QueueBackend backend) {
-            return new DefaultTaskito(backend, effectiveSerializer());
+            return new DefaultTaskito(backend, effectiveSerializer(), namedCodecs);
         }
 
         /** Open the native backend described by the configured options. */
@@ -345,7 +356,7 @@ public interface Taskito extends AutoCloseable {
             } else if (!options.containsKey("dsn")) {
                 throw new ConfigurationException("url (dsn) is required");
             }
-            return new DefaultTaskito(JniQueueBackend.open(encodeOptions()), effectiveSerializer());
+            return new DefaultTaskito(JniQueueBackend.open(encodeOptions()), effectiveSerializer(), namedCodecs);
         }
 
         /** Create the SQLite file's parent directory (skip in-memory databases). */

--- a/sdks/java/src/main/java/org/byteveda/taskito/annotation/Compressed.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/annotation/Compressed.java
@@ -1,0 +1,18 @@
+package org.byteveda.taskito.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a {@code @TaskHandler} task's payload for compression. The generated
+ * companion records the {@code "compressed"} codec on the task; both producer and
+ * worker must register a codec under that name:
+ * {@code Taskito.builder().codec("compressed", new GzipCodec())}. When combined
+ * with {@link Encrypted}, compression runs first (compress, then encrypt).
+ * Source-retention.
+ */
+@Retention(RetentionPolicy.SOURCE)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface Compressed {}

--- a/sdks/java/src/main/java/org/byteveda/taskito/annotation/Encrypted.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/annotation/Encrypted.java
@@ -1,0 +1,17 @@
+package org.byteveda.taskito.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a {@code @TaskHandler} task's payload for encryption. The generated
+ * companion records the {@code "encrypted"} codec on the task, so the producer
+ * encrypts the payload on enqueue and the worker decrypts it — both must register
+ * a codec under that name: {@code Taskito.builder().codec("encrypted", new AesGcmCodec(key))}.
+ * The key is supplied at runtime, never in the annotation. Source-retention.
+ */
+@Retention(RetentionPolicy.SOURCE)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface Encrypted {}

--- a/sdks/java/src/main/java/org/byteveda/taskito/task/Task.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/task/Task.java
@@ -3,6 +3,8 @@ package org.byteveda.taskito.task;
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.lang.reflect.Type;
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -17,8 +19,9 @@ public final class Task<T> {
     private final Type payloadType;
     private final EnqueueOptions options;
     private final RetryPolicy retryPolicy;
+    private final List<String> codecs;
 
-    private Task(String name, Type payloadType, EnqueueOptions options, RetryPolicy retryPolicy) {
+    private Task(String name, Type payloadType, EnqueueOptions options, RetryPolicy retryPolicy, List<String> codecs) {
         this.name = Objects.requireNonNull(name, "task name must not be null");
         if (name.trim().isEmpty()) {
             throw new IllegalArgumentException("task name must not be blank");
@@ -26,21 +29,22 @@ public final class Task<T> {
         this.payloadType = Objects.requireNonNull(payloadType, "payloadType must not be null");
         this.options = Objects.requireNonNull(options, "options must not be null");
         this.retryPolicy = retryPolicy;
+        this.codecs = List.copyOf(codecs);
     }
 
     /** A task whose payload deserializes to {@code payloadType}. */
     public static <T> Task<T> of(String name, Class<T> payloadType) {
-        return new Task<>(name, payloadType, EnqueueOptions.none(), null);
+        return new Task<>(name, payloadType, EnqueueOptions.none(), null, List.of());
     }
 
     /** A task whose payload deserializes to a generic type, e.g. {@code new TypeReference<List<Foo>>(){}}. */
     public static <T> Task<T> of(String name, TypeReference<T> payloadType) {
-        return new Task<>(name, payloadType.getType(), EnqueueOptions.none(), null);
+        return new Task<>(name, payloadType.getType(), EnqueueOptions.none(), null, List.of());
     }
 
     /** A copy of this task with the given default options. */
     public Task<T> withOptions(EnqueueOptions options) {
-        return new Task<>(name, payloadType, options, retryPolicy);
+        return new Task<>(name, payloadType, options, retryPolicy, codecs);
     }
 
     /**
@@ -49,7 +53,17 @@ public final class Task<T> {
      * from {@link #maxRetries}.
      */
     public Task<T> retryPolicy(RetryPolicy retryPolicy) {
-        return new Task<>(name, payloadType, options, retryPolicy);
+        return new Task<>(name, payloadType, options, retryPolicy, codecs);
+    }
+
+    /**
+     * A copy of this task whose payload is passed through the named {@link
+     * org.byteveda.taskito.serialization.PayloadCodec}s (in order on enqueue,
+     * reversed on the worker). Each name must be registered via
+     * {@code Taskito.builder().codec(name, codec)} on producers and workers.
+     */
+    public Task<T> codecs(String... codecs) {
+        return new Task<>(name, payloadType, options, retryPolicy, Arrays.asList(codecs));
     }
 
     public Task<T> queue(String queue) {
@@ -101,5 +115,10 @@ public final class Task<T> {
     /** The retry-backoff curve for this task, or {@code null} for the core defaults. */
     public RetryPolicy retryPolicy() {
         return retryPolicy;
+    }
+
+    /** Names of the payload codecs applied to this task (empty if none). */
+    public List<String> codecNames() {
+        return codecs;
     }
 }

--- a/sdks/java/src/main/java/org/byteveda/taskito/worker/RegisteredTask.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/worker/RegisteredTask.java
@@ -1,15 +1,18 @@
 package org.byteveda.taskito.worker;
 
 import java.lang.reflect.Type;
+import java.util.List;
 import org.byteveda.taskito.task.TaskFunction;
 
-/** A worker-registered handler: payload type plus the function to run. */
+/** A worker-registered handler: payload type, the function to run, and any payload codecs. */
 final class RegisteredTask {
     final Type payloadType;
     final TaskFunction<Object, Object> handler;
+    final List<String> codecs;
 
-    RegisteredTask(Type payloadType, TaskFunction<Object, Object> handler) {
+    RegisteredTask(Type payloadType, TaskFunction<Object, Object> handler, List<String> codecs) {
         this.payloadType = payloadType;
         this.handler = handler;
+        this.codecs = codecs;
     }
 }

--- a/sdks/java/src/main/java/org/byteveda/taskito/worker/Worker.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/worker/Worker.java
@@ -26,6 +26,7 @@ import org.byteveda.taskito.events.EventName;
 import org.byteveda.taskito.events.OutcomeEvent;
 import org.byteveda.taskito.middleware.Middleware;
 import org.byteveda.taskito.resources.ResourceRuntime;
+import org.byteveda.taskito.serialization.PayloadCodec;
 import org.byteveda.taskito.serialization.Serializer;
 import org.byteveda.taskito.spi.QueueBackend;
 import org.byteveda.taskito.spi.WorkerControl;
@@ -65,12 +66,16 @@ public final class Worker implements AutoCloseable {
     }
 
     public static Builder builder(QueueBackend backend, Serializer serializer, List<Middleware> middleware) {
-        return new Builder(backend, serializer, middleware, new ResourceRuntime());
+        return new Builder(backend, serializer, middleware, new ResourceRuntime(), Map.of());
     }
 
     public static Builder builder(
-            QueueBackend backend, Serializer serializer, List<Middleware> middleware, ResourceRuntime resources) {
-        return new Builder(backend, serializer, middleware, resources);
+            QueueBackend backend,
+            Serializer serializer,
+            List<Middleware> middleware,
+            ResourceRuntime resources,
+            Map<String, PayloadCodec> codecs) {
+        return new Builder(backend, serializer, middleware, resources, codecs);
     }
 
     /** Stop dispatching; in-flight jobs continue to drain. */
@@ -145,6 +150,7 @@ public final class Worker implements AutoCloseable {
         private final Serializer serializer;
         private final List<Middleware> middleware;
         private final ResourceRuntime resources;
+        private final Map<String, PayloadCodec> codecs;
         private final Map<String, RegisteredTask> handlers = new HashMap<>();
         private final Map<String, RetryPolicy> taskPolicies = new HashMap<>();
         private final Map<EventName, List<Consumer<OutcomeEvent>>> listeners = new EnumMap<>(EventName.class);
@@ -155,20 +161,26 @@ public final class Worker implements AutoCloseable {
         private WorkflowTracker tracker;
         private AutoscaleOptions autoscale;
 
-        Builder(QueueBackend backend, Serializer serializer, List<Middleware> middleware, ResourceRuntime resources) {
+        Builder(
+                QueueBackend backend,
+                Serializer serializer,
+                List<Middleware> middleware,
+                ResourceRuntime resources,
+                Map<String, PayloadCodec> codecs) {
             this.backend = backend;
             this.serializer = serializer;
             this.middleware = middleware;
             this.resources = resources;
+            this.codecs = codecs;
         }
 
         public <T, R> Builder handle(String taskName, Class<T> payloadType, TaskFunction<T, R> handler) {
-            handlers.put(taskName, new RegisteredTask(payloadType, cast(handler)));
+            handlers.put(taskName, new RegisteredTask(payloadType, cast(handler), List.of()));
             return this;
         }
 
         public <T, R> Builder handle(Task<T> task, TaskFunction<T, R> handler) {
-            handlers.put(task.name(), new RegisteredTask(task.payloadType(), cast(handler)));
+            handlers.put(task.name(), new RegisteredTask(task.payloadType(), cast(handler), task.codecNames()));
             capturePolicy(task);
             return this;
         }
@@ -182,7 +194,11 @@ public final class Worker implements AutoCloseable {
         /** Register a single {@link Handler} (a task + its function). */
         public Builder register(Handler<?, ?> handler) {
             handlers.put(
-                    handler.task().name(), new RegisteredTask(handler.task().payloadType(), cast(handler.function())));
+                    handler.task().name(),
+                    new RegisteredTask(
+                            handler.task().payloadType(),
+                            cast(handler.function()),
+                            handler.task().codecNames()));
             capturePolicy(handler.task());
             return this;
         }
@@ -283,8 +299,8 @@ public final class Worker implements AutoCloseable {
             }
             Emitter emitter = new Emitter();
             listeners.forEach((name, bound) -> bound.forEach(listener -> emitter.on(name, listener)));
-            WorkerDispatchBridge bridge =
-                    new WorkerDispatchBridge(backend, handlers, serializer, executor, emitter, middleware, resources);
+            WorkerDispatchBridge bridge = new WorkerDispatchBridge(
+                    backend, handlers, serializer, executor, emitter, middleware, resources, codecs);
             WorkerControl control = backend.startWorker(bridge, encodeOptions());
             bridge.bind(control);
             // Lease worker resources only after the native worker started cleanly.

--- a/sdks/java/src/main/java/org/byteveda/taskito/worker/WorkerDispatchBridge.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/worker/WorkerDispatchBridge.java
@@ -17,6 +17,7 @@ import org.byteveda.taskito.middleware.TaskContext;
 import org.byteveda.taskito.resources.ResourceRuntime;
 import org.byteveda.taskito.resources.Resources;
 import org.byteveda.taskito.resources.TaskScope;
+import org.byteveda.taskito.serialization.PayloadCodec;
 import org.byteveda.taskito.serialization.Serializer;
 import org.byteveda.taskito.spi.QueueBackend;
 import org.byteveda.taskito.spi.WorkerBridge;
@@ -39,6 +40,7 @@ final class WorkerDispatchBridge implements WorkerBridge {
     private final Emitter emitter;
     private final List<Middleware> middleware;
     private final ResourceRuntime resources;
+    private final Map<String, PayloadCodec> codecs;
     // Resolved once startWorker returns; job tasks await it before completing.
     private final CompletableFuture<WorkerControl> control = new CompletableFuture<>();
 
@@ -49,7 +51,8 @@ final class WorkerDispatchBridge implements WorkerBridge {
             ExecutorService executor,
             Emitter emitter,
             List<Middleware> middleware,
-            ResourceRuntime resources) {
+            ResourceRuntime resources,
+            Map<String, PayloadCodec> codecs) {
         this.backend = backend;
         this.handlers = handlers;
         this.serializer = serializer;
@@ -57,6 +60,7 @@ final class WorkerDispatchBridge implements WorkerBridge {
         this.emitter = emitter;
         this.middleware = middleware;
         this.resources = resources;
+        this.codecs = codecs;
     }
 
     void bind(WorkerControl control) {
@@ -87,7 +91,7 @@ final class WorkerDispatchBridge implements WorkerBridge {
             for (Middleware m : middleware) {
                 m.before(context);
             }
-            Object argument = serializer.deserialize(payload, task.payloadType);
+            Object argument = serializer.deserialize(decodePayload(payload, task.codecs), task.payloadType);
             Object result = task.handler.apply(argument);
             for (Middleware m : middleware) {
                 m.after(context, result);
@@ -103,6 +107,20 @@ final class WorkerDispatchBridge implements WorkerBridge {
                 Resources.exit(scope); // unbind the thread + dispose task-scoped resources (LIFO)
             }
         }
+    }
+
+    /** Reverse a task's payload codecs (last applied, first undone). */
+    private byte[] decodePayload(byte[] payload, List<String> codecNames) {
+        byte[] bytes = payload;
+        for (int i = codecNames.size() - 1; i >= 0; i--) {
+            String name = codecNames.get(i);
+            PayloadCodec codec = codecs.get(name);
+            if (codec == null) {
+                throw new IllegalStateException("no codec registered named '" + name + "'");
+            }
+            bytes = codec.decode(bytes);
+        }
+        return bytes;
     }
 
     @Override

--- a/sdks/java/src/test/java/org/byteveda/taskito/EncryptedGreeter.java
+++ b/sdks/java/src/test/java/org/byteveda/taskito/EncryptedGreeter.java
@@ -1,0 +1,14 @@
+package org.byteveda.taskito;
+
+import org.byteveda.taskito.annotation.Encrypted;
+import org.byteveda.taskito.annotation.TaskHandler;
+
+/** Test fixture: an @Encrypted handler; the generated task carries the "encrypted" codec. */
+class EncryptedGreeter {
+
+    @TaskHandler("eg.greet")
+    @Encrypted
+    String greet(String name) {
+        return "secret " + name;
+    }
+}

--- a/sdks/java/src/test/java/org/byteveda/taskito/PerTaskCodecTest.java
+++ b/sdks/java/src/test/java/org/byteveda/taskito/PerTaskCodecTest.java
@@ -1,0 +1,76 @@
+package org.byteveda.taskito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.byteveda.taskito.events.EventName;
+import org.byteveda.taskito.serialization.AesGcmCodec;
+import org.byteveda.taskito.task.Task;
+import org.byteveda.taskito.worker.Worker;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+class PerTaskCodecTest {
+
+    private static final byte[] KEY32 = "0123456789abcdef0123456789abcdef".getBytes();
+
+    @Test
+    @Timeout(30)
+    void programmaticPerTaskCodecRoundTrips(@TempDir Path dir) throws Exception {
+        try (Taskito queue = Taskito.builder()
+                .url(dir.resolve("ptc.db").toString())
+                .codec("secret", new AesGcmCodec(KEY32))
+                .open()) {
+            Task<String> task = Task.of("ptc.echo", String.class).codecs("secret");
+            AtomicReference<String> seen = new AtomicReference<>();
+            CountDownLatch ran = new CountDownLatch(1);
+            try (Worker worker = queue.worker()
+                    .handle(task, p -> {
+                        seen.set(p);
+                        ran.countDown();
+                        return p;
+                    })
+                    .start()) {
+                queue.enqueue(task, "hello");
+                assertTrue(ran.await(20, TimeUnit.SECONDS));
+                assertEquals("hello", seen.get());
+            }
+        }
+    }
+
+    @Test
+    @Timeout(30)
+    void annotatedTaskUsesEncryptedCodec(@TempDir Path dir) throws Exception {
+        try (Taskito queue = Taskito.builder()
+                .url(dir.resolve("eg.db").toString())
+                .codec("encrypted", new AesGcmCodec(KEY32))
+                .open()) {
+            // EncryptedGreeterTasks.GREET is generated with .codecs("encrypted").
+            String id = queue.enqueue(EncryptedGreeterTasks.GREET, "ada");
+            CountDownLatch done = new CountDownLatch(1);
+            try (Worker worker = queue.worker()
+                    .apply(builder -> EncryptedGreeterTasks.bind(builder, new EncryptedGreeter()))
+                    .on(EventName.SUCCESS, event -> done.countDown())
+                    .start()) {
+                assertTrue(done.await(20, TimeUnit.SECONDS));
+                assertEquals("secret ada", queue.getResult(id, String.class).orElseThrow());
+            }
+        }
+    }
+
+    @Test
+    void annotatedTaskRequiresRegisteredCodec(@TempDir Path dir) {
+        // No "encrypted" codec registered, so the generated .codecs("encrypted") fails the enqueue —
+        // proving the annotation wired the codec onto the task.
+        try (Taskito queue =
+                Taskito.builder().url(dir.resolve("ar.db").toString()).open()) {
+            assertThrows(IllegalStateException.class, () -> queue.enqueue(EncryptedGreeterTasks.GREET, "ada"));
+        }
+    }
+}

--- a/sdks/java/src/test/java/org/byteveda/taskito/PerTaskCodecTest.java
+++ b/sdks/java/src/test/java/org/byteveda/taskito/PerTaskCodecTest.java
@@ -8,7 +8,9 @@ import java.nio.file.Path;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import org.byteveda.taskito.errors.InterceptionException;
 import org.byteveda.taskito.events.EventName;
+import org.byteveda.taskito.interception.Interception;
 import org.byteveda.taskito.serialization.AesGcmCodec;
 import org.byteveda.taskito.task.Task;
 import org.byteveda.taskito.worker.Worker;
@@ -71,6 +73,19 @@ class PerTaskCodecTest {
         try (Taskito queue =
                 Taskito.builder().url(dir.resolve("ar.db").toString()).open()) {
             assertThrows(IllegalStateException.class, () -> queue.enqueue(EncryptedGreeterTasks.GREET, "ada"));
+        }
+    }
+
+    @Test
+    void redirectingACodecTaskIsRejected(@TempDir Path dir) {
+        try (Taskito queue = Taskito.builder()
+                .url(dir.resolve("rc.db").toString())
+                .codec("secret", new AesGcmCodec(KEY32))
+                .open()) {
+            queue.intercept((task, payload) -> Interception.redirect("other", payload));
+            Task<String> task = Task.of("rc.echo", String.class).codecs("secret");
+            // Redirect can't carry the source task's codec chain to a different task — fail fast.
+            assertThrows(InterceptionException.class, () -> queue.enqueue(task, "hello"));
         }
     }
 }


### PR DESCRIPTION
## What

Layers per-task codec selection on top of the payload-codec framework (#351): a task can declare that its payload is compressed and/or encrypted, and producer + worker agree automatically via the generated companion.

- `@Compressed` / `@Encrypted` (`org.byteveda.taskito.annotation`) — placed on a `@TaskHandler` method; the compile-time processor records the codec chain on the generated `Task` constant (`.codecs("compressed","encrypted")`), so both enqueue and worker sides use it without runtime config.
- Named codec registry: `Taskito.builder().codec(name, codec)` binds a name (e.g. `"encrypted"` → `AesGcmCodec(key)`) — the key is injected at build time, never in the annotation.
- `Task.codecs(String...)` for the programmatic path; threaded `Task → RegisteredTask → WorkerDispatchBridge`. **Payload only** — results stay on the global serializer (`getResult` has no task context).

## Test

`PerTaskCodecTest` (+ `EncryptedGreeter` fixture) — an annotated task encodes on enqueue and decodes on the worker end-to-end; wrong/absent codec fails.

`./gradlew build` green (JDK 17 build leg + 21/25 test legs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for named payload codecs on tasks and workers.
  * Introduced new task annotations to mark payloads for compression and encryption.
  * Enabled chaining multiple codecs, with the same order used on send and reverse order on receive.

* **Bug Fixes**
  * Enqueued and processed task payloads now preserve encoded data correctly for both single and batch sends.
  * Tasks using unknown codecs now fail clearly when the codec is not registered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->