### PR TITLE
docs: use a static MIT license badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Rust-powered task queue with native SDKs. One engine — no broker required, j
 
 [![PyPI version](https://img.shields.io/pypi/v/taskito.svg)](https://pypi.org/project/taskito/)
 [![npm version](https://img.shields.io/npm/v/@byteveda/taskito.svg)](https://www.npmjs.com/package/@byteveda/taskito)
-[![License](https://img.shields.io/github/license/ByteVeda/taskito.svg)](https://github.com/ByteVeda/taskito/blob/master/LICENSE)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/ByteVeda/taskito/blob/master/LICENSE)
 
 </div>
 


### PR DESCRIPTION
## What

The root README license badge used `img.shields.io/github/license/...`, which resolves the label by calling GitHub's license-detection API through shields.io. When that call is rate-limited (or the license is momentarily undetected), shields renders **`license invalid`** — and GitHub's camo image proxy caches that stale render, so the README shows "invalid" even though GitHub detects the repo as MIT (`spdx_id: MIT`) and the live badge resolves to MIT.

Swaps it for a static `badge/license-MIT-blue` badge. The license is fixed (MIT), so there's no need to query GitHub's API — the badge can no longer flake to "invalid". The link still points at `LICENSE`.

Docs-only, root README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the license badge in the project README to point to the MIT license file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->