### PR TITLE
ci: fix flaky Postgres test-process segfault at exit

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -100,7 +100,10 @@ jobs:
       - uses: ./.github/actions/rust-prelude
 
       - name: Run Rust test suite (PostgreSQL backend)
-        run: LD_LIBRARY_PATH="$pythonLocation/lib" cargo test --workspace --features postgres,workflows
+        # Drop LD_LIBRARY_PATH + exclude taskito-python: Python's OpenSSL (on that
+        # path) and libpq's duel at-exit → flaky SIGSEGV. PG contract is in
+        # taskito-core/taskito-workflows; python's Rust tests run in the SQLite job.
+        run: cargo test --workspace --exclude taskito-python --features postgres,workflows
         env:
           TASKITO_POSTGRES_TEST_URL: postgres://postgres:test@localhost:5432/taskito_test
 


### PR DESCRIPTION
## Problem

The `Rust Tests (PostgreSQL)` job intermittently fails: all 98 lib tests pass, then the test binary crashes on exit with `signal: 11, SIGSEGV` (cargo → exit 101). The SQLite and Redis jobs — same `LD_LIBRARY_PATH` — never crash; only Postgres does.

## Cause

The step ran `cargo test --workspace --features postgres,workflows` with `LD_LIBRARY_PATH="$pythonLocation/lib"` (so `taskito-python`'s test binary finds libpython). That directory also ships Python's `libssl`/`libcrypto`, which get loaded alongside the OpenSSL that **libpq** links. Two OpenSSL copies in one process → their `atexit` cleanup handlers race at process teardown → SIGSEGV *after* the tests have all passed. It's load/teardown-order dependent, hence flaky, and only the Postgres-linked binary pulls in libpq.

## Fix

`--exclude taskito-python` (the only crate that needs libpython at runtime) and drop `LD_LIBRARY_PATH`. With Python out of the run, Python's OpenSSL is never loaded, so libpq's is the only copy and there's nothing to race at exit.

No coverage lost: the Postgres storage contract lives in `taskito-core` and `taskito-workflows` (both still run here); `taskito-python`'s Rust tests already run in the SQLite job (`cargo test --workspace`).