### PR TITLE
fix(java): java sdk gaps

### DIFF
--- a/sdks/java/processor/src/main/java/org/byteveda/taskito/processor/TaskHandlerProcessor.java
+++ b/sdks/java/processor/src/main/java/org/byteveda/taskito/processor/TaskHandlerProcessor.java
@@ -69,6 +69,12 @@ public final class TaskHandlerProcessor extends AbstractProcessor {
             error(method, "the first @TaskHandler parameter is the payload and must not be annotated @Resource");
             return false;
         }
+        if (params.get(0).asType().getKind().isPrimitive()) {
+            // A primitive payload would generate `new TypeReference<int>() {}` —
+            // invalid Java that only surfaces as a cryptic error in the generated file.
+            error(method, "@TaskHandler payload must be a reference type (use the boxed type, e.g. Integer)");
+            return false;
+        }
         for (int i = 1; i < params.size(); i++) {
             if (resourceName(params.get(i)) == null) {
                 error(method, "@TaskHandler parameters after the payload must be annotated @Resource");

--- a/sdks/java/src/main/java/org/byteveda/taskito/DefaultTaskito.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/DefaultTaskito.java
@@ -242,10 +242,14 @@ final class DefaultTaskito implements Taskito {
         return Optional.of(backend.enqueue(taskName, data, encode(finalOptions)));
     }
 
-    /** Apply a defer delay to the options (overriding any delay already set). */
+    /**
+     * Apply a defer delay to the options, overriding any delay already set —
+     * {@code Defer(Duration.ZERO)} (e.g. {@code deferUntil} of a past instant)
+     * means "enqueue now", not "keep the task's baked-in delay".
+     */
     private static EnqueueOptions withDelay(EnqueueOptions options, Duration delay) {
-        long delayMs = delay.toMillis();
-        return delayMs <= 0 ? options : options.toBuilder().delayMs(delayMs).build();
+        long delayMs = Math.max(delay.toMillis(), 0);
+        return options.toBuilder().delayMs(delayMs).build();
     }
 
     /** Apply a task's payload codecs in order; throws if a name is not registered. */

--- a/sdks/java/src/main/java/org/byteveda/taskito/serialization/GzipCodec.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/serialization/GzipCodec.java
@@ -10,8 +10,9 @@ import org.byteveda.taskito.errors.SerializationException;
 /**
  * A {@link PayloadCodec} that gzip-compresses payloads. Decompression is bounded
  * by {@code maxDecompressedBytes} so a small malicious payload can't expand to
- * exhaust worker memory (zip bomb). Order {@code GzipCodec} <em>after</em> a
- * signing/encryption codec in the chain to verify integrity before decompressing.
+ * exhaust worker memory (zip bomb). Order {@code GzipCodec} <em>before</em> a
+ * signing/encryption codec in the list (e.g. {@code List.of(gzip, hmac)}):
+ * codecs decode in reverse, so integrity is verified before decompressing.
  */
 public final class GzipCodec implements PayloadCodec {
     /** Default cap on decompressed output: 64 MiB. */

--- a/sdks/java/src/test/java/org/byteveda/taskito/EnqueueDecisionTest.java
+++ b/sdks/java/src/test/java/org/byteveda/taskito/EnqueueDecisionTest.java
@@ -12,6 +12,7 @@ import org.byteveda.taskito.errors.EnqueueSkippedException;
 import org.byteveda.taskito.errors.PredicateRejectedException;
 import org.byteveda.taskito.model.Job;
 import org.byteveda.taskito.predicates.EnqueueDecision;
+import org.byteveda.taskito.task.EnqueueOptions;
 import org.byteveda.taskito.task.Task;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -50,6 +51,23 @@ class EnqueueDecisionTest {
             Job job = queue.getJob(id.get()).orElseThrow();
             long delayMs = job.scheduledAt - job.createdAt;
             assertTrue(delayMs >= Duration.ofMinutes(59).toMillis(), "expected ~1h defer, got " + delayMs + "ms");
+        }
+    }
+
+    @Test
+    void zeroDeferOverridesTaskDelay(@TempDir Path dir) throws Exception {
+        try (Taskito queue = open(dir, "deferzero")) {
+            queue.gate(TASK.name(), context -> EnqueueDecision.defer(Duration.ZERO));
+
+            Task<String> delayed =
+                    TASK.withOptions(EnqueueOptions.builder().delayMs(60_000).build());
+            Optional<String> id = queue.tryEnqueue(delayed, "now");
+            assertTrue(id.isPresent());
+            Job job = queue.getJob(id.get()).orElseThrow();
+            // Defer(ZERO) means "enqueue now" — the task's baked-in delay must not survive.
+            assertTrue(
+                    job.scheduledAt - job.createdAt < 1_000,
+                    "expected immediate schedule, got " + (job.scheduledAt - job.createdAt) + "ms");
         }
     }
 

--- a/sdks/java/test-support/src/main/java/org/byteveda/taskito/test/InMemoryQueueBackend.java
+++ b/sdks/java/test-support/src/main/java/org/byteveda/taskito/test/InMemoryQueueBackend.java
@@ -73,7 +73,8 @@ public final class InMemoryQueueBackend implements QueueBackend {
             }
         }
         JobRec job = new JobRec();
-        job.id = "im-" + seq.incrementAndGet();
+        job.enqueueSeq = seq.incrementAndGet();
+        job.id = "im-" + job.enqueueSeq;
         job.taskName = taskName;
         job.payload = payload;
         job.queue = optText(opts, "queue", DEFAULT_QUEUE);
@@ -215,7 +216,8 @@ public final class InMemoryQueueBackend implements QueueBackend {
                 JobRec source = jobs.get((String) entry.get("originalJobId"));
                 dead.remove(entry);
                 JobRec job = new JobRec();
-                job.id = "im-" + seq.incrementAndGet();
+                job.enqueueSeq = seq.incrementAndGet();
+                job.id = "im-" + job.enqueueSeq;
                 job.taskName = (String) entry.get("taskName");
                 job.queue = (String) entry.get("queue");
                 job.payload = source == null ? new byte[0] : source.payload;
@@ -563,7 +565,7 @@ public final class InMemoryQueueBackend implements QueueBackend {
             if (!queues.isEmpty() && !queues.contains(job.queue)) {
                 continue;
             }
-            if (best == null || job.priority > best.priority) {
+            if (best == null || claimsBefore(job, best)) {
                 best = job;
             }
         }
@@ -572,6 +574,17 @@ public final class InMemoryQueueBackend implements QueueBackend {
             best.startedAt = now;
         }
         return best;
+    }
+
+    /** Production dequeue order: priority DESC, then FIFO (scheduled_at ASC, insertion order on ties). */
+    private static boolean claimsBefore(JobRec candidate, JobRec current) {
+        if (candidate.priority != current.priority) {
+            return candidate.priority > current.priority;
+        }
+        if (candidate.scheduledAt != current.scheduledAt) {
+            return candidate.scheduledAt < current.scheduledAt;
+        }
+        return candidate.enqueueSeq < current.enqueueSeq;
     }
 
     private synchronized void onComplete(JobRec job, byte[] result) {
@@ -690,6 +703,7 @@ public final class InMemoryQueueBackend implements QueueBackend {
     /** A stored job. */
     private static final class JobRec {
         String id;
+        long enqueueSeq;
         String queue = DEFAULT_QUEUE;
         String taskName;
         byte[] payload;

--- a/sdks/java/test-support/src/test/java/org/byteveda/taskito/test/InMemoryQueueBackendTest.java
+++ b/sdks/java/test-support/src/test/java/org/byteveda/taskito/test/InMemoryQueueBackendTest.java
@@ -4,6 +4,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import org.byteveda.taskito.Taskito;
 import org.byteveda.taskito.model.Job;
 import org.byteveda.taskito.model.JobStatus;
@@ -24,6 +27,32 @@ class InMemoryQueueBackendTest {
                 Job job = queue.awaitJob(id, Duration.ofSeconds(10)).orElseThrow();
                 assertEquals(JobStatus.COMPLETE, job.status);
                 assertEquals(42, queue.getResult(id, Integer.class).orElseThrow());
+            }
+        }
+    }
+
+    @Test
+    @Timeout(20)
+    void samePriorityJobsRunInEnqueueOrder() throws Exception {
+        Task<Integer> order = Task.of("im.order", Integer.class);
+        List<Integer> seen = Collections.synchronizedList(new ArrayList<>());
+        try (Taskito queue = InMemoryTaskito.open()) {
+            String last = null;
+            for (int i = 0; i < 5; i++) {
+                last = queue.enqueue(order, i);
+            }
+            // Single-threaded worker so claim order is observable as run order.
+            try (Worker worker = queue.worker()
+                    .concurrency(1)
+                    .handle(order, p -> {
+                        seen.add(p);
+                        return p;
+                    })
+                    .start()) {
+                queue.awaitJob(last, Duration.ofSeconds(10)).orElseThrow();
+                // Production dequeues FIFO within a priority tier; the in-memory
+                // backend must match, not follow hash-map iteration order.
+                assertEquals(List.of(0, 1, 2, 3, 4), seen);
             }
         }
     }


### PR DESCRIPTION
Fixes the last four medium-severity findings from the Java SDK audit list.

- **Zero defer overrides task delay**: `EnqueueDecision.defer(Duration.ZERO)` (e.g. `deferUntil` of a past instant) documents "enqueue now", but `withDelay` short-circuited on non-positive delays and silently kept the task's baked-in `delayMs`. The delay is now always applied, clamped to non-negative. Regression test asserts a 60s-delay task deferred by zero schedules immediately.
- **Gzip codec javadoc**: the class doc told readers to place `GzipCodec` *after* a signing codec — since codecs decode in reverse, that order decompresses attacker-controlled bytes before verifying integrity. Corrected to match the (already-correct) test and annotation-driven ordering.
- **Primitive handler payloads rejected at compile time**: a `void handle(int payload)` task handler generated `new TypeReference<int>() {}` — invalid Java surfacing as a cryptic javac error in the generated companion. The processor now reports a clear diagnostic on the offending method.
- **In-memory backend FIFO**: `claimNext` picked an arbitrary job among equal priorities (hash-map iteration order), diverging from production's `priority DESC, scheduled_at ASC`. Jobs now carry a monotonic sequence and ties break FIFO. Regression test runs five same-priority jobs on a single-thread worker and asserts enqueue order.

`./gradlew build` green across all subprojects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents invalid Java generation by rejecting task handlers that use primitive payload types.
  * Ensures zero delay means “enqueue now,” even when a task has its own built-in delay.
  * Improves job ordering so same-priority work runs predictably in enqueue order.

* **Documentation**
  * Clarified delay behavior and codec ordering guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->