### PR TITLE
chore(java): publish pipeline hardening

### DIFF
--- a/.github/actions/setup-java/action.yml
+++ b/.github/actions/setup-java/action.yml
@@ -2,8 +2,8 @@ name: Set up Java
 description: >-
   Installs a Temurin JDK and enables Gradle build caching. Used by every
   Java-touching job so toolchain setup lives in one place. The SDK targets Java
-  17 bytecode via `--release 17`, so any JDK >= 17 works; we use 21 to match the
-  publish workflow.
+  17 bytecode via `--release 17`, so any JDK >= 17 works; the publish workflow
+  builds on 25 so the FFM overlay ships.
 
 inputs:
   java-version:

--- a/.github/workflows/publish-java.yml
+++ b/.github/workflows/publish-java.yml
@@ -150,11 +150,30 @@ jobs:
 
       # The cargo/copyNative tasks build only the host platform; skip them since
       # every platform's binary is already staged in resources from the matrix.
-      # Dry-run only assembles the JAR — keep publishing secrets out of it.
-      - name: Assemble JAR (dry-run)
+      # Dry-run assembles all publish artifacts so javadoc/doclint failures
+      # surface here, not during the live publish; secrets stay out of it.
+      - name: Assemble publish artifacts (dry-run)
         if: inputs.dry-run
         working-directory: sdks/java
-        run: ./gradlew jar -x cargoBuild -x copyNative --no-daemon
+        run: ./gradlew jar sourcesJar plainJavadocJar -x cargoBuild -x copyNative --no-daemon
+
+      # MR-jar layout + native bundling only come together here — assert them.
+      - name: Verify jar contents (dry-run)
+        if: inputs.dry-run
+        working-directory: sdks/java
+        run: |
+          jar=$(ls build/libs/taskito-*[0-9].jar)
+          echo "checking $jar"
+          unzip -p "$jar" META-INF/MANIFEST.MF | grep -q "Multi-Release: true"
+          unzip -l "$jar" | grep -q "META-INF/versions/22/org/byteveda/taskito/internal/FfmTransport.class"
+          for platform in linux-x86_64 linux-aarch64 osx-x86_64 osx-aarch64 windows-x86_64; do
+            unzip -l "$jar" | grep -q "org/byteveda/taskito/native/$platform/" \
+              || { echo "missing native library for $platform"; exit 1; }
+          done
+          sources=$(ls build/libs/taskito-*-sources.jar)
+          if unzip -l "$sources" | grep -qE "org/byteveda/taskito/(native|dashboard)/"; then
+            echo "sources jar must not bundle natives or dashboard assets"; exit 1
+          fi
 
       - name: Publish to Maven Central
         if: ${{ !inputs.dry-run }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,8 @@ openssl-sys = { version = "0.9", features = ["vendored"] }
 pyo3 = { version = "0.29", features = ["multiple-pymethods"] }
 async-trait = "0.1"
 dagron-core = { git = "https://github.com/ByteVeda/dagron.git", rev = "d1b61aaf2ed2d516b9a239f089a55b143cb05f65" }
+
+# Release cdylibs ship inside SDK packages; strip + thin-LTO keep them small.
+[profile.release]
+strip = true
+lto = "thin"

--- a/sdks/java/README.md
+++ b/sdks/java/README.md
@@ -18,7 +18,8 @@ no separate install.
 
 ```kotlin
 // Gradle
-implementation("org.byteveda:taskito:0.19.0")
+implementation("org.byteveda:taskito:0.18.0")
+annotationProcessor("org.byteveda:taskito-processor:0.18.0") // compile-time TaskHandler bindings
 ```
 
 ```xml
@@ -26,14 +27,29 @@ implementation("org.byteveda:taskito:0.19.0")
 <dependency>
   <groupId>org.byteveda</groupId>
   <artifactId>taskito</artifactId>
-  <version>0.19.0</version>
+  <version>0.18.0</version>
 </dependency>
 ```
 
-Companion artifacts: `org.byteveda:taskito-processor` (compile-time
-`TaskHandler` bindings, add via `annotationProcessor`), `org.byteveda:taskito-test`
-(in-memory backend for unit tests), `org.byteveda:taskito-spring` (Boot 3
-starter).
+```xml
+<!-- Maven: the processor is wired through the compiler plugin, not a dependency -->
+<plugin>
+  <groupId>org.apache.maven.plugins</groupId>
+  <artifactId>maven-compiler-plugin</artifactId>
+  <configuration>
+    <annotationProcessorPaths>
+      <path>
+        <groupId>org.byteveda</groupId>
+        <artifactId>taskito-processor</artifactId>
+        <version>0.18.0</version>
+      </path>
+    </annotationProcessorPaths>
+  </configuration>
+</plugin>
+```
+
+Companion artifacts: `org.byteveda:taskito-test` (in-memory backend for unit
+tests) and `org.byteveda:taskito-spring` (Boot 3 starter).
 
 ## Migration
 

--- a/sdks/java/README.md
+++ b/sdks/java/README.md
@@ -3,16 +3,37 @@
 A typed Java 17+ client over the Taskito Rust core, via a hand-written JNI shell
 (`crates/taskito-java`).
 
-> Status: **build-out**. Producer + inspection + admin + logs, worker task
-> execution, middleware, JSON/signed/encrypted/MessagePack serializers,
-> dashboard, webhooks, CLI, distributed locks, periodic/cron, and the full
-> workflow engine (DAG, fan-out/fan-in, gates, conditions, sub-workflows, sagas,
-> analysis + visualization, canvas) are implemented and verified end-to-end.
-> Also: worker resources (DI), enqueue predicates, a KEDA scaler endpoint,
-> producer batching, in-process autoscaling, observability middleware
-> (Micrometer Observation + Sentry), and a Spring Boot 3 starter. Baseline:
-> **Java 17** (`--release 17`). Spring Boot 3 apps can adopt it directly;
-> native `.so` is JDK-independent.
+Feature-complete: producer + inspection + admin + logs, worker task execution,
+middleware, JSON/signed/encrypted/MessagePack serializers, dashboard, webhooks,
+CLI, distributed locks, periodic/cron, and the full workflow engine (DAG,
+fan-out/fan-in, gates, conditions, sub-workflows, sagas, analysis +
+visualization, canvas). Also: worker resources (DI), enqueue predicates, a KEDA
+scaler endpoint, producer batching, in-process autoscaling, observability
+middleware (Micrometer Observation + Sentry), and a Spring Boot 3 starter.
+Baseline: **Java 17** (`--release 17`); on JDK 22+ hot byte ops take a Panama
+(FFM) fast path automatically. The native library is bundled per platform —
+no separate install.
+
+## Install
+
+```kotlin
+// Gradle
+implementation("org.byteveda:taskito:0.19.0")
+```
+
+```xml
+<!-- Maven -->
+<dependency>
+  <groupId>org.byteveda</groupId>
+  <artifactId>taskito</artifactId>
+  <version>0.19.0</version>
+</dependency>
+```
+
+Companion artifacts: `org.byteveda:taskito-processor` (compile-time
+`TaskHandler` bindings, add via `annotationProcessor`), `org.byteveda:taskito-test`
+(in-memory backend for unit tests), `org.byteveda:taskito-spring` (Boot 3
+starter).
 
 ## Migration
 

--- a/sdks/java/build.gradle.kts
+++ b/sdks/java/build.gradle.kts
@@ -135,6 +135,10 @@ tasks.named("processResources") { dependsOn(copyNative) }
 // resource srcDirs, so any Jar task reads the staged native dir. Wire the
 // dependency lazily — sourcesJar is registered after this script evaluates.
 tasks.withType<Jar>().configureEach { dependsOn(copyNative) }
+// Sources jar ships sources only — cdylibs + dashboard already ship in the main jar.
+tasks.withType<Jar>().matching { it.name == "sourcesJar" }.configureEach {
+    exclude("org/byteveda/taskito/native/**", "org/byteveda/taskito/dashboard/**")
+}
 
 // --- FFM fast-path overlay (Multi-Release JAR) ----------------------------
 // Base classes target 17 (JNI transport + the fallback). On a build JDK >= 22 we


### PR DESCRIPTION
Release-prep items from the Java SDK audit (all but the version bump).

- **Sources jar slimmed**: excluded bundled natives and dashboard SPA assets — a sources classifier now ships sources only. Verified locally: zero native/dashboard entries.
- **Release binaries stripped + thin-LTO**: workspace `[profile.release]` now sets `strip = true`, `lto = "thin"`; the five bundled cdylibs shrink accordingly.
- **Publish dry-run widened**: dry-run now assembles main + sources + javadoc jars (so doclint failures surface before the live publish) and asserts jar contents — `Multi-Release: true` manifest, FFM overlay under `META-INF/versions/22`, all five platform natives present, and no binaries in the sources jar.
- **README**: dropped the stale "build-out" status, added Maven/Gradle install snippets and companion-artifact pointers.
- **Stale CI comment**: `setup-java` action description now reflects the JDK 25 publish build.

`./gradlew build` green with the new release profile.

Remaining before tagging: version bump to 0.19.0, Central Portal namespace check for `org.byteveda`, and one `workflow_dispatch` dry-run of `publish-java.yml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Java SDK README to reflect a feature-complete status, clearer runtime notes (Java 17 baseline plus JDK 22+ fast path), and step-by-step Gradle/Maven install examples.
  * Added companion artifact guidance for testing and Spring integration.

* **Bug Fixes**
  * Source archives now exclude bundled native libraries and dashboard assets.

* **Build & Release**
  * Improved publish dry-run checks to validate the full artifact set, multi-release JAR layout, and expected native bundles before publishing.
  * Release builds now enable size-optimizing settings for distributed native artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->