### PR TITLE
feat(node): payload codecs with global chain and per-task registry

### DIFF
--- a/sdks/node/src/errors.ts
+++ b/sdks/node/src/errors.ts
@@ -82,6 +82,14 @@ export class SerializationError extends TaskitoError {
   }
 }
 
+/** Thrown when a payload codec fails to decrypt or verify a payload. */
+export class CryptoError extends SerializationError {
+  constructor(message: string) {
+    super(message);
+    this.name = "CryptoError";
+  }
+}
+
 /** Thrown when a `notes` object violates the structured-notes contract. */
 export class NotesValidationError extends TaskitoError {
   constructor(message: string) {

--- a/sdks/node/src/index.ts
+++ b/sdks/node/src/index.ts
@@ -1,6 +1,7 @@
 export { currentJob, type JobContext } from "./context";
 export { type DashboardAuth, type DashboardOptions, serveDashboard } from "./dashboard";
 export {
+  CryptoError,
   JobCancelledError,
   JobFailedError,
   LockLostError,
@@ -40,9 +41,14 @@ export {
 } from "./resources";
 export { type ScalerOptions, serveScaler } from "./scaler";
 export {
+  AesGcmCodec,
+  CodecSerializer,
   EncryptedSerializer,
+  GzipCodec,
+  HmacCodec,
   JsonSerializer,
   MsgpackSerializer,
+  type PayloadCodec,
   type Serializer,
   SignedSerializer,
 } from "./serializers";

--- a/sdks/node/src/queue.ts
+++ b/sdks/node/src/queue.ts
@@ -8,6 +8,7 @@ import {
   PredicateRejectedError,
   QueueError,
   ResultTimeoutError,
+  SerializationError,
   TaskitoError,
 } from "./errors";
 import { Emitter, type EventHandler, type EventName } from "./events";
@@ -27,7 +28,7 @@ import {
   ResourceRuntime,
   type ResourceScope,
 } from "./resources";
-import { JsonSerializer, type Serializer } from "./serializers";
+import { CodecSerializer, JsonSerializer, type PayloadCodec, type Serializer } from "./serializers";
 import type {
   AnyHandler,
   DeadJob,
@@ -73,6 +74,19 @@ export interface QueueOptions {
   namespace?: string;
   /** Codec for task args/results. Defaults to {@link JsonSerializer}. */
   serializer?: Serializer;
+  /**
+   * Global payload codec chain, applied in order after serialization and in
+   * reverse before deserialization. Wraps the queue serializer, so it covers
+   * every payload and result. Jobs persisted before the chain was enabled
+   * cannot be decoded through it.
+   */
+  codec?: PayloadCodec | PayloadCodec[];
+  /**
+   * Named codec registry for per-task codecs. Tasks opt in via
+   * {@link TaskOptions.codecs}; applies to task payloads only (results stay
+   * on the queue serializer).
+   */
+  codecs?: Record<string, PayloadCodec>;
 }
 
 /**
@@ -82,6 +96,7 @@ export interface QueueOptions {
 export class Queue<TTasks extends TaskMap = TaskMap> {
   private readonly native: NativeQueue;
   private readonly serializer: Serializer;
+  private readonly codecs: ReadonlyMap<string, PayloadCodec>;
   private readonly tasks = new Map<string, RegisteredTask>();
   private readonly queueLimits = new Map<string, QueueLimits>();
   private readonly middleware: Middleware[] = [];
@@ -96,7 +111,11 @@ export class Queue<TTasks extends TaskMap = TaskMap> {
 
   constructor(options: QueueOptions = {}) {
     this.native = JsQueue.open(toOpenOptions(options));
-    this.serializer = options.serializer ?? new JsonSerializer();
+    const chain = options.codec === undefined ? [] : [options.codec].flat();
+    const baseSerializer = options.serializer ?? new JsonSerializer();
+    this.serializer =
+      chain.length > 0 ? new CodecSerializer(baseSerializer, chain) : baseSerializer;
+    this.codecs = new Map(Object.entries(options.codecs ?? {}));
     this.webhookManager = new WebhookManager(this.native, this.emitter);
   }
 
@@ -112,6 +131,7 @@ export class Queue<TTasks extends TaskMap = TaskMap> {
         this.native,
         this.serializer,
         this.trackerIfSupported(),
+        (taskName, value) => this.encodeTaskPayload(taskName, value),
       );
     }
     return this.workflowManager;
@@ -166,7 +186,7 @@ export class Queue<TTasks extends TaskMap = TaskMap> {
     cronExpr: string,
     options?: PeriodicOptions,
   ): number {
-    const args = Buffer.from(this.serializer.serialize(options?.args ?? []));
+    const args = this.encodeTaskPayload(taskName, options?.args ?? []);
     return this.native.registerPeriodic(
       name,
       taskName,
@@ -334,9 +354,25 @@ export class Queue<TTasks extends TaskMap = TaskMap> {
       }
     }
     return {
-      payload: Buffer.from(this.serializer.serialize(ctx.args)),
+      payload: this.encodeTaskPayload(name, ctx.args),
       options: toNativeEnqueueOptions(ctx.options),
     };
+  }
+
+  /**
+   * Serialize a task payload and apply the task's named codecs in order.
+   * Payload only — results stay on the queue serializer.
+   */
+  private encodeTaskPayload(taskName: string, value: unknown): Buffer {
+    let data = this.serializer.serialize(value);
+    for (const name of this.tasks.get(taskName)?.options?.codecs ?? []) {
+      const codec = this.codecs.get(name);
+      if (!codec) {
+        throw new SerializationError(`no codec registered named "${name}"`);
+      }
+      data = codec.encode(data);
+    }
+    return Buffer.from(data);
   }
 
   /** Fetch a job by id, or `null` if unknown. */
@@ -530,6 +566,7 @@ export class Queue<TTasks extends TaskMap = TaskMap> {
       tasks: this.tasks,
       queueLimits: this.queueLimits,
       serializer: this.serializer,
+      codecs: this.codecs,
       middleware: this.middleware,
       emitter: this.emitter,
       resources: this.resources,

--- a/sdks/node/src/serializers/aes-gcm.ts
+++ b/sdks/node/src/serializers/aes-gcm.ts
@@ -1,0 +1,64 @@
+import { type CipherGCMTypes, createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+import { CryptoError } from "../errors";
+import type { PayloadCodec } from "./codec";
+
+/** GCM nonce length in bytes. */
+const IV_BYTES = 12;
+/** GCM authentication-tag length in bytes. */
+const TAG_BYTES = 16;
+
+const CIPHER_BY_KEY_LENGTH: Record<number, CipherGCMTypes> = {
+  16: "aes-128-gcm",
+  24: "aes-192-gcm",
+  32: "aes-256-gcm",
+};
+
+/**
+ * AES-GCM encryption codec. Wire format: `[12-byte random IV][ciphertext ||
+ * 16-byte GCM tag]` — identical to the Java and Python SDK codecs. Note the
+ * tag trails the ciphertext, unlike {@link EncryptedSerializer}'s
+ * `[iv | tag | ciphertext]` layout — do not "align" them; this order is the
+ * cross-SDK contract.
+ *
+ * The key must be raw bytes of length 16, 24, or 32 (AES-128/192/256), shared
+ * by producers and workers.
+ */
+export class AesGcmCodec implements PayloadCodec {
+  private readonly key: Buffer;
+  private readonly cipherName: CipherGCMTypes;
+
+  constructor(key: Uint8Array) {
+    const cipherName = CIPHER_BY_KEY_LENGTH[key.length];
+    if (!cipherName) {
+      throw new CryptoError(
+        `AesGcmCodec: key must be 16, 24, or 32 bytes for AES-128/192/256, got ${key.length}`,
+      );
+    }
+    this.key = Buffer.from(key);
+    this.cipherName = cipherName;
+  }
+
+  encode(data: Uint8Array): Uint8Array {
+    const iv = randomBytes(IV_BYTES);
+    const cipher = createCipheriv(this.cipherName, this.key, iv);
+    const ciphertext = Buffer.concat([cipher.update(data), cipher.final()]);
+    return Buffer.concat([iv, ciphertext, cipher.getAuthTag()]);
+  }
+
+  decode(data: Uint8Array): Uint8Array {
+    if (data.length < IV_BYTES + TAG_BYTES) {
+      throw new CryptoError("AesGcmCodec: encrypted payload is too short");
+    }
+    const buf = Buffer.from(data);
+    const iv = buf.subarray(0, IV_BYTES);
+    const ciphertext = buf.subarray(IV_BYTES, buf.length - TAG_BYTES);
+    const tag = buf.subarray(buf.length - TAG_BYTES);
+    const decipher = createDecipheriv(this.cipherName, this.key, iv);
+    decipher.setAuthTag(tag);
+    try {
+      return Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+    } catch {
+      throw new CryptoError("AesGcmCodec: decryption failed (tampered payload or wrong key)");
+    }
+  }
+}

--- a/sdks/node/src/serializers/aes-gcm.ts
+++ b/sdks/node/src/serializers/aes-gcm.ts
@@ -15,7 +15,7 @@ const CIPHER_BY_KEY_LENGTH: Record<number, CipherGCMTypes> = {
 
 /**
  * AES-GCM encryption codec. Wire format: `[12-byte random IV][ciphertext ||
- * 16-byte GCM tag]` — identical to the Java and Python SDK codecs. Note the
+ * 16-byte GCM tag]` — the cross-SDK contract. Note the
  * tag trails the ciphertext, unlike {@link EncryptedSerializer}'s
  * `[iv | tag | ciphertext]` layout — do not "align" them; this order is the
  * cross-SDK contract.

--- a/sdks/node/src/serializers/aes-gcm.ts
+++ b/sdks/node/src/serializers/aes-gcm.ts
@@ -15,10 +15,9 @@ const CIPHER_BY_KEY_LENGTH: Record<number, CipherGCMTypes> = {
 
 /**
  * AES-GCM encryption codec. Wire format: `[12-byte random IV][ciphertext ||
- * 16-byte GCM tag]` — the cross-SDK contract. Note the
- * tag trails the ciphertext, unlike {@link EncryptedSerializer}'s
- * `[iv | tag | ciphertext]` layout — do not "align" them; this order is the
- * cross-SDK contract.
+ * 16-byte GCM tag]`. Note the tag trails the ciphertext, unlike
+ * {@link EncryptedSerializer}'s `[iv | tag | ciphertext]` layout — do not
+ * "align" them; this order is the cross-SDK contract.
  *
  * The key must be raw bytes of length 16, 24, or 32 (AES-128/192/256), shared
  * by producers and workers.

--- a/sdks/node/src/serializers/codec.ts
+++ b/sdks/node/src/serializers/codec.ts
@@ -7,9 +7,9 @@ import type { Serializer } from "./serializer";
  * `decode` reverses it on the worker before deserialization.
  *
  * Codecs compose: a chain encodes in list order and decodes in reverse, so
- * `[gzip, hmac]` verifies integrity *before* decompressing. Wire formats match
- * the Java and Python SDK codecs byte-for-byte, so codec-framed payloads are
- * cross-SDK compatible.
+ * `[gzip, hmac]` verifies integrity *before* decompressing. Wire formats are
+ * part of the cross-SDK contract, so codec-framed payloads decode from any
+ * Taskito SDK.
  */
 export interface PayloadCodec {
   /** Transform serialized bytes on the producer (compress, encrypt, sign). */

--- a/sdks/node/src/serializers/codec.ts
+++ b/sdks/node/src/serializers/codec.ts
@@ -1,0 +1,52 @@
+import { JsonSerializer } from "./json";
+import type { Serializer } from "./serializer";
+
+/**
+ * Reversible byte transform layered over a serializer — compression,
+ * encryption, signing. `encode` runs on the producer after serialization;
+ * `decode` reverses it on the worker before deserialization.
+ *
+ * Codecs compose: a chain encodes in list order and decodes in reverse, so
+ * `[gzip, hmac]` verifies integrity *before* decompressing. Wire formats match
+ * the Java and Python SDK codecs byte-for-byte, so codec-framed payloads are
+ * cross-SDK compatible.
+ */
+export interface PayloadCodec {
+  /** Transform serialized bytes on the producer (compress, encrypt, sign). */
+  encode(data: Uint8Array): Uint8Array;
+  /** Reverse the transform on the worker. */
+  decode(data: Uint8Array): Uint8Array;
+}
+
+/**
+ * Serializer decorator applying a codec chain around a delegate. `serialize`
+ * runs the delegate then encodes codecs in list order; `deserialize` decodes
+ * in reverse order then delegates. Used internally when `QueueOptions.codec`
+ * is set — the chain then covers every payload and result flowing through the
+ * queue serializer.
+ */
+export class CodecSerializer implements Serializer {
+  private readonly delegate: Serializer;
+  private readonly codecs: readonly PayloadCodec[];
+
+  constructor(delegate: Serializer = new JsonSerializer(), codecs: readonly PayloadCodec[] = []) {
+    this.delegate = delegate;
+    this.codecs = [...codecs];
+  }
+
+  serialize(value: unknown): Uint8Array {
+    let data = this.delegate.serialize(value);
+    for (const codec of this.codecs) {
+      data = codec.encode(data);
+    }
+    return data;
+  }
+
+  deserialize(bytes: Uint8Array): unknown {
+    let data = bytes;
+    for (const codec of [...this.codecs].reverse()) {
+      data = codec.decode(data);
+    }
+    return this.delegate.deserialize(data);
+  }
+}

--- a/sdks/node/src/serializers/gzip.ts
+++ b/sdks/node/src/serializers/gzip.ts
@@ -1,0 +1,41 @@
+import { gunzipSync, gzipSync } from "node:zlib";
+import { SerializationError } from "../errors";
+import type { PayloadCodec } from "./codec";
+
+/** Default decompression cap: 64 MiB. */
+const DEFAULT_MAX_DECOMPRESSED_BYTES = 64 * 1024 * 1024;
+
+/**
+ * Gzip compression codec. Decompression is capped at `maxDecompressedBytes`
+ * (default 64 MiB) so a malicious or corrupt payload cannot expand into a zip
+ * bomb. Wire format matches the Java and Python SDK gzip codecs.
+ */
+export class GzipCodec implements PayloadCodec {
+  private readonly maxDecompressedBytes: number;
+
+  constructor(maxDecompressedBytes: number = DEFAULT_MAX_DECOMPRESSED_BYTES) {
+    if (!Number.isInteger(maxDecompressedBytes) || maxDecompressedBytes <= 0) {
+      throw new SerializationError(
+        `GzipCodec: maxDecompressedBytes must be a positive integer, got ${maxDecompressedBytes}`,
+      );
+    }
+    this.maxDecompressedBytes = maxDecompressedBytes;
+  }
+
+  encode(data: Uint8Array): Uint8Array {
+    return gzipSync(data);
+  }
+
+  decode(data: Uint8Array): Uint8Array {
+    try {
+      return gunzipSync(data, { maxOutputLength: this.maxDecompressedBytes });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ERR_BUFFER_TOO_LARGE") {
+        throw new SerializationError(
+          `GzipCodec: decompressed payload exceeds the ${this.maxDecompressedBytes}-byte limit`,
+        );
+      }
+      throw new SerializationError(`GzipCodec: decompression failed (${String(error)})`);
+    }
+  }
+}

--- a/sdks/node/src/serializers/gzip.ts
+++ b/sdks/node/src/serializers/gzip.ts
@@ -8,7 +8,7 @@ const DEFAULT_MAX_DECOMPRESSED_BYTES = 64 * 1024 * 1024;
 /**
  * Gzip compression codec. Decompression is capped at `maxDecompressedBytes`
  * (default 64 MiB) so a malicious or corrupt payload cannot expand into a zip
- * bomb. Wire format matches the Java and Python SDK gzip codecs.
+ * bomb. Wire format is a standard gzip stream — the cross-SDK contract.
  */
 export class GzipCodec implements PayloadCodec {
   private readonly maxDecompressedBytes: number;

--- a/sdks/node/src/serializers/hmac.ts
+++ b/sdks/node/src/serializers/hmac.ts
@@ -1,0 +1,40 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { CryptoError } from "../errors";
+import type { PayloadCodec } from "./codec";
+
+/** HMAC-SHA256 digest length in bytes. */
+const MAC_BYTES = 32;
+
+/**
+ * HMAC-SHA256 signing codec (authenticates, does not encrypt). Wire format:
+ * `[32-byte mac][body]` — identical to the Java and Python SDK codecs. The
+ * key is raw bytes shared by producers and workers.
+ */
+export class HmacCodec implements PayloadCodec {
+  private readonly key: Buffer;
+
+  constructor(key: Uint8Array) {
+    this.key = Buffer.from(key);
+  }
+
+  encode(data: Uint8Array): Uint8Array {
+    return Buffer.concat([this.macFor(data), data]);
+  }
+
+  decode(data: Uint8Array): Uint8Array {
+    if (data.length < MAC_BYTES) {
+      throw new CryptoError("HmacCodec: signed payload is too short");
+    }
+    const buf = Buffer.from(data);
+    const mac = buf.subarray(0, MAC_BYTES);
+    const body = buf.subarray(MAC_BYTES);
+    if (!timingSafeEqual(mac, this.macFor(body))) {
+      throw new CryptoError("HmacCodec: signature mismatch (tampered or wrong key)");
+    }
+    return body;
+  }
+
+  private macFor(body: Uint8Array): Buffer {
+    return createHmac("sha256", this.key).update(body).digest();
+  }
+}

--- a/sdks/node/src/serializers/hmac.ts
+++ b/sdks/node/src/serializers/hmac.ts
@@ -7,7 +7,7 @@ const MAC_BYTES = 32;
 
 /**
  * HMAC-SHA256 signing codec (authenticates, does not encrypt). Wire format:
- * `[32-byte mac][body]` — identical to the Java and Python SDK codecs. The
+ * `[32-byte mac][body]` — the cross-SDK contract. The
  * key is raw bytes shared by producers and workers.
  */
 export class HmacCodec implements PayloadCodec {

--- a/sdks/node/src/serializers/hmac.ts
+++ b/sdks/node/src/serializers/hmac.ts
@@ -7,8 +7,8 @@ const MAC_BYTES = 32;
 
 /**
  * HMAC-SHA256 signing codec (authenticates, does not encrypt). Wire format:
- * `[32-byte mac][body]` — the cross-SDK contract. The
- * key is raw bytes shared by producers and workers.
+ * `[32-byte mac][body]` — the cross-SDK contract. The key is raw bytes shared
+ * by producers and workers.
  */
 export class HmacCodec implements PayloadCodec {
   private readonly key: Buffer;

--- a/sdks/node/src/serializers/hmac.ts
+++ b/sdks/node/src/serializers/hmac.ts
@@ -14,6 +14,9 @@ export class HmacCodec implements PayloadCodec {
   private readonly key: Buffer;
 
   constructor(key: Uint8Array) {
+    if (key.length === 0) {
+      throw new CryptoError("HmacCodec: key must not be empty");
+    }
     this.key = Buffer.from(key);
   }
 

--- a/sdks/node/src/serializers/index.ts
+++ b/sdks/node/src/serializers/index.ts
@@ -1,4 +1,8 @@
+export { AesGcmCodec } from "./aes-gcm";
+export { CodecSerializer, type PayloadCodec } from "./codec";
 export { EncryptedSerializer } from "./encrypted";
+export { GzipCodec } from "./gzip";
+export { HmacCodec } from "./hmac";
 export { JsonSerializer } from "./json";
 export { MsgpackSerializer } from "./msgpack";
 export type { Serializer } from "./serializer";

--- a/sdks/node/src/types.ts
+++ b/sdks/node/src/types.ts
@@ -81,6 +81,12 @@ export interface TaskOptions {
    * `deps` param is stripped from the typed `enqueue` args.
    */
   inject?: readonly string[];
+  /**
+   * Names of payload codecs (registered via `QueueOptions.codecs`) applied in
+   * order to this task's serialized payload on enqueue and reversed on the
+   * worker. Payload only — results stay on the queue serializer.
+   */
+  codecs?: readonly string[];
 }
 
 /** Options for {@link Queue.registerPeriodic}. */

--- a/sdks/node/src/worker.ts
+++ b/sdks/node/src/worker.ts
@@ -1,5 +1,5 @@
 import { type JobContext, runInContext } from "./context";
-import { TaskNotRegisteredError } from "./errors";
+import { SerializationError, TaskNotRegisteredError } from "./errors";
 import type { Emitter, EventName, OutcomeEvent } from "./events";
 import type { Middleware, TaskContext } from "./middleware";
 import type {
@@ -12,7 +12,7 @@ import type {
   TaskConfigInput,
 } from "./native";
 import { type ResourceRuntime, runWithResolver } from "./resources";
-import type { Serializer } from "./serializers";
+import type { PayloadCodec, Serializer } from "./serializers";
 import type { QueueLimits, RegisteredTask, WorkerRunOptions } from "./types";
 import { createLogger } from "./utils";
 import type { WorkflowTracker } from "./workflows";
@@ -36,6 +36,8 @@ export interface WorkerStartParams {
   tasks: ReadonlyMap<string, RegisteredTask>;
   queueLimits: ReadonlyMap<string, QueueLimits>;
   serializer: Serializer;
+  /** Named codec registry for per-task payload decode (see `TaskOptions.codecs`). */
+  codecs?: ReadonlyMap<string, PayloadCodec>;
   middleware: readonly Middleware[];
   emitter: Emitter;
   resources: ResourceRuntime;
@@ -58,7 +60,7 @@ export class Worker {
    * @internal
    */
   static start(queue: NativeQueue, params: WorkerStartParams): Worker {
-    const { tasks, queueLimits, serializer, middleware, emitter, resources, run } = params;
+    const { tasks, queueLimits, serializer, codecs, middleware, emitter, resources, run } = params;
 
     // Advance workflow runs as node-jobs settle, unless disabled or unsupported.
     const tracker = (run?.advanceWorkflows ?? true) ? (params.workflowTracker ?? null) : null;
@@ -73,7 +75,16 @@ export class Worker {
       if (!task) {
         throw new TaskNotRegisteredError(invocation.taskName);
       }
-      const args = serializer.deserialize(invocation.payload) as unknown[];
+      // Reverse the task's named codecs (see `TaskOptions.codecs`) before decode.
+      let payload: Uint8Array = invocation.payload;
+      for (const codecName of [...(task.options?.codecs ?? [])].reverse()) {
+        const codec = codecs?.get(codecName);
+        if (!codec) {
+          throw new SerializationError(`no codec registered named "${codecName}"`);
+        }
+        payload = codec.decode(payload);
+      }
+      const args = serializer.deserialize(payload) as unknown[];
       const ctx: TaskContext = { jobId: invocation.id, taskName: invocation.taskName, args };
 
       // Cooperative cancel signal + job context exposed to the handler.

--- a/sdks/node/src/workflows/manager.ts
+++ b/sdks/node/src/workflows/manager.ts
@@ -43,6 +43,11 @@ export class WorkflowManager {
     private readonly serializer: Serializer,
     /** The queue's shared tracker, so gate resolution clears the worker's timers. */
     private readonly tracker?: WorkflowTracker,
+    /** Per-task payload encoder (serializer + named codecs); defaults to the bare serializer. */
+    private readonly encodePayload: (taskName: string, value: unknown) => Uint8Array = (
+      _taskName,
+      value,
+    ) => this.serializer.serialize(value),
   ) {
     if (typeof this.native.submitWorkflow !== "function") {
       throw new WorkflowError("the native addon was built without the 'workflows' feature");
@@ -183,9 +188,9 @@ export class WorkflowManager {
       if (!base) {
         throw new WorkflowError(`workflow step '${name}' is missing metadata`);
       }
-      const b64 = Buffer.from(this.serializer.serialize(spec.stepArgs[name] ?? [])).toString(
-        "base64",
-      );
+      const b64 = Buffer.from(
+        this.encodePayload(base.task_name, spec.stepArgs[name] ?? []),
+      ).toString("base64");
       nodePayloads[name] = b64;
       const meta: StepMetadataJson = { ...base };
       if (deferred.has(name)) {

--- a/sdks/node/test/core/codecs.test.ts
+++ b/sdks/node/test/core/codecs.test.ts
@@ -1,5 +1,8 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { gunzipSync } from "node:zlib";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import {
   AesGcmCodec,
   CodecSerializer,
@@ -9,8 +12,12 @@ import {
   JsonSerializer,
   MsgpackSerializer,
   type PayloadCodec,
+  Queue,
   SerializationError,
+  type Worker,
 } from "../../src/index";
+
+let worker: Worker | undefined;
 
 const HMAC_KEY = Buffer.from("codec-hmac-secret");
 const AES_KEY = Buffer.from("0123456789abcdef0123456789abcdef"); // 32 bytes -> AES-256
@@ -166,5 +173,79 @@ describe("CodecSerializer", () => {
     const serializer = new CodecSerializer(new JsonSerializer(), []);
     const value = [1, "two", [3]];
     expect(serializer.deserialize(serializer.serialize(value))).toEqual(value);
+  });
+});
+
+describe("Queue codec integration", () => {
+  function tempDb(): string {
+    return join(mkdtempSync(join(tmpdir(), "taskito-codecs-")), "queue.db");
+  }
+
+  async function waitFor<T>(read: () => T | undefined, timeoutMs = 10_000): Promise<T> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const value = read();
+      if (value !== undefined) {
+        return value;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    throw new Error("timed out waiting for job result");
+  }
+
+  afterEach(() => {
+    worker?.stop();
+    worker = undefined;
+  });
+
+  it("global chain round-trips payload and result through a worker", async () => {
+    const queue = new Queue({
+      dbPath: tempDb(),
+      codec: [new GzipCodec(), new HmacCodec(HMAC_KEY)],
+    }).task("codecs.double", (x: number) => x * 2);
+
+    const id = queue.enqueue("codecs.double", [21]);
+    worker = queue.runWorker();
+    await expect(waitFor(() => queue.getResult(id))).resolves.toBe(42);
+
+    // The stored result is codec-framed: [32B mac][gzip(json)].
+    const stored = queue.getJob(id)?.result;
+    expect(stored).toBeDefined();
+    const body = gunzipSync(Buffer.from(new HmacCodec(HMAC_KEY).decode(stored as Buffer)));
+    expect(JSON.parse(body.toString("utf8"))).toBe(42);
+  });
+
+  it("per-task named codecs round-trip; results skip them", async () => {
+    const queue = new Queue({
+      dbPath: tempDb(),
+      codecs: { gzip: new GzipCodec() },
+    }).task("codecs.shout", (text: string) => text.toUpperCase(), { codecs: ["gzip"] });
+
+    const id = queue.enqueue("codecs.shout", ["hello"]);
+    worker = queue.runWorker();
+    await expect(waitFor(() => queue.getResult(id))).resolves.toBe("HELLO");
+
+    // The result is plain serializer output — per-task codecs never touch it.
+    const stored = queue.getJob(id)?.result;
+    expect(JSON.parse(Buffer.from(stored as Buffer).toString("utf8"))).toBe("HELLO");
+  });
+
+  it("enqueueMany applies per-task codecs to every entry", async () => {
+    const queue = new Queue({
+      dbPath: tempDb(),
+      codecs: { gzip: new GzipCodec() },
+    }).task("codecs.add", (a: number, b: number) => a + b, { codecs: ["gzip"] });
+
+    const ids = queue.enqueueMany("codecs.add", [{ args: [1, 2] }, { args: [3, 4] }]);
+    worker = queue.runWorker();
+    await expect(waitFor(() => queue.getResult(ids[0] as string))).resolves.toBe(3);
+    await expect(waitFor(() => queue.getResult(ids[1] as string))).resolves.toBe(7);
+  });
+
+  it("throws at enqueue for an unregistered codec name", () => {
+    const queue = new Queue({ dbPath: tempDb() }).task("codecs.orphan", () => null, {
+      codecs: ["nope"],
+    });
+    expect(() => queue.enqueue("codecs.orphan", [])).toThrow(/no codec registered named "nope"/);
   });
 });

--- a/sdks/node/test/core/codecs.test.ts
+++ b/sdks/node/test/core/codecs.test.ts
@@ -1,0 +1,170 @@
+import { gunzipSync } from "node:zlib";
+import { describe, expect, it } from "vitest";
+import {
+  AesGcmCodec,
+  CodecSerializer,
+  CryptoError,
+  GzipCodec,
+  HmacCodec,
+  JsonSerializer,
+  MsgpackSerializer,
+  type PayloadCodec,
+  SerializationError,
+} from "../../src/index";
+
+const HMAC_KEY = Buffer.from("codec-hmac-secret");
+const AES_KEY = Buffer.from("0123456789abcdef0123456789abcdef"); // 32 bytes -> AES-256
+
+function flipLastByte(bytes: Uint8Array): Buffer {
+  const buf = Buffer.from(bytes);
+  buf.writeUInt8(buf.readUInt8(buf.length - 1) ^ 0xff, buf.length - 1);
+  return buf;
+}
+
+describe("GzipCodec", () => {
+  it("round-trips and compresses", () => {
+    const codec = new GzipCodec();
+    const data = Buffer.from("hello codec world".repeat(100));
+    const encoded = codec.encode(data);
+    expect(encoded.length).toBeLessThan(data.length);
+    expect(Buffer.from(codec.decode(encoded)).equals(data)).toBe(true);
+  });
+
+  it("round-trips an empty payload", () => {
+    const codec = new GzipCodec();
+    expect(codec.decode(codec.encode(Buffer.alloc(0))).length).toBe(0);
+  });
+
+  it("rejects decompression exceeding the cap", () => {
+    const encoded = new GzipCodec().encode(Buffer.alloc(1024, "a"));
+    expect(() => new GzipCodec(16).decode(encoded)).toThrow(SerializationError);
+    expect(() => new GzipCodec(16).decode(encoded)).toThrow(/exceeds the 16-byte limit/);
+  });
+
+  it("decodes a payload exactly at the cap", () => {
+    const data = Buffer.alloc(64, "a");
+    const encoded = new GzipCodec().encode(data);
+    expect(Buffer.from(new GzipCodec(64).decode(encoded)).equals(data)).toBe(true);
+  });
+
+  it("rejects a corrupt stream", () => {
+    expect(() => new GzipCodec().decode(Buffer.from("not gzip data"))).toThrow(SerializationError);
+  });
+
+  it("rejects a non-positive cap", () => {
+    expect(() => new GzipCodec(0)).toThrow(SerializationError);
+    expect(() => new GzipCodec(-1)).toThrow(SerializationError);
+  });
+});
+
+describe("AesGcmCodec", () => {
+  it("round-trips and hides the plaintext", () => {
+    const codec = new AesGcmCodec(AES_KEY);
+    const data = Buffer.from("secret payload");
+    const encoded = Buffer.from(codec.encode(data));
+    expect(encoded.includes(data)).toBe(false);
+    expect(Buffer.from(codec.decode(encoded)).equals(data)).toBe(true);
+  });
+
+  it("lays out [iv | ciphertext | tag] — the cross-SDK contract", () => {
+    const codec = new AesGcmCodec(AES_KEY);
+    const encoded = codec.encode(Buffer.alloc(10, "x"));
+    expect(encoded.length).toBe(12 + 10 + 16);
+  });
+
+  it("uses a fresh IV per call", () => {
+    const codec = new AesGcmCodec(AES_KEY);
+    const a = Buffer.from(codec.encode(Buffer.from("same")));
+    const b = Buffer.from(codec.encode(Buffer.from("same")));
+    expect(a.equals(b)).toBe(false);
+  });
+
+  it("supports AES-128 and AES-192 key lengths", () => {
+    for (const length of [16, 24]) {
+      const codec = new AesGcmCodec(Buffer.alloc(length, 7));
+      const data = Buffer.from("payload");
+      expect(Buffer.from(codec.decode(codec.encode(data))).equals(data)).toBe(true);
+    }
+  });
+
+  it("rejects a tampered payload", () => {
+    const codec = new AesGcmCodec(AES_KEY);
+    const encoded = flipLastByte(codec.encode(Buffer.from("secret payload")));
+    expect(() => codec.decode(encoded)).toThrow(CryptoError);
+  });
+
+  it("rejects a short payload", () => {
+    expect(() => new AesGcmCodec(AES_KEY).decode(Buffer.from("short"))).toThrow(/too short/);
+  });
+
+  it("rejects a bad key length", () => {
+    expect(() => new AesGcmCodec(Buffer.from("short-key"))).toThrow(/16, 24, or 32/);
+  });
+});
+
+describe("HmacCodec", () => {
+  it("round-trips with the mac prefixed", () => {
+    const codec = new HmacCodec(HMAC_KEY);
+    const data = Buffer.from("authenticated payload");
+    const encoded = Buffer.from(codec.encode(data));
+    expect(encoded.subarray(32).equals(data)).toBe(true); // [32B mac][body]
+    expect(Buffer.from(codec.decode(encoded)).equals(data)).toBe(true);
+  });
+
+  it("rejects a tampered payload", () => {
+    const codec = new HmacCodec(HMAC_KEY);
+    const encoded = flipLastByte(codec.encode(Buffer.from("authenticated payload")));
+    expect(() => codec.decode(encoded)).toThrow(CryptoError);
+  });
+
+  it("rejects a wrong key", () => {
+    const encoded = new HmacCodec(HMAC_KEY).encode(Buffer.from("payload"));
+    expect(() => new HmacCodec(Buffer.from("different-key")).decode(encoded)).toThrow(
+      /signature mismatch/,
+    );
+  });
+
+  it("rejects a short payload", () => {
+    expect(() => new HmacCodec(HMAC_KEY).decode(Buffer.from("short"))).toThrow(/too short/);
+  });
+});
+
+describe("CodecSerializer", () => {
+  it.each([
+    ["json", new JsonSerializer()],
+    ["msgpack", new MsgpackSerializer()],
+  ])("chain [gzip, aes, hmac] is reversible over %s", (_name, delegate) => {
+    const chain: PayloadCodec[] = [
+      new GzipCodec(),
+      new AesGcmCodec(AES_KEY),
+      new HmacCodec(HMAC_KEY),
+    ];
+    const serializer = new CodecSerializer(delegate, chain);
+    const value = { numbers: [1, 2, 3], text: "hello".repeat(50) };
+    expect(serializer.deserialize(serializer.serialize(value))).toEqual(value);
+  });
+
+  it("frames the encoded bytes with the codec output", () => {
+    const serializer = new CodecSerializer(new JsonSerializer(), [new GzipCodec()]);
+    const encoded = Buffer.from(serializer.serialize({ key: "value" }));
+    expect(encoded.subarray(0, 2).equals(Buffer.from([0x1f, 0x8b]))).toBe(true); // gzip magic
+    expect(
+      gunzipSync(encoded).equals(Buffer.from(new JsonSerializer().serialize({ key: "value" }))),
+    ).toBe(true);
+  });
+
+  it("detects tampering before decompression (decode runs in reverse)", () => {
+    const serializer = new CodecSerializer(new JsonSerializer(), [
+      new GzipCodec(),
+      new HmacCodec(HMAC_KEY),
+    ]);
+    const encoded = flipLastByte(serializer.serialize("payload"));
+    expect(() => serializer.deserialize(encoded)).toThrow(/signature mismatch/);
+  });
+
+  it("is transparent with an empty chain", () => {
+    const serializer = new CodecSerializer(new JsonSerializer(), []);
+    const value = [1, "two", [3]];
+    expect(serializer.deserialize(serializer.serialize(value))).toEqual(value);
+  });
+});

--- a/sdks/node/test/core/codecs.test.ts
+++ b/sdks/node/test/core/codecs.test.ts
@@ -134,6 +134,10 @@ describe("HmacCodec", () => {
   it("rejects a short payload", () => {
     expect(() => new HmacCodec(HMAC_KEY).decode(Buffer.from("short"))).toThrow(/too short/);
   });
+
+  it("rejects an empty key", () => {
+    expect(() => new HmacCodec(new Uint8Array())).toThrow(/must not be empty/);
+  });
 });
 
 describe("CodecSerializer", () => {


### PR DESCRIPTION
## Summary

Adds a payload-codec layer to the Node SDK with wire formats that are part of the cross-SDK contract, so codec-framed payloads interoperate across SDKs (the Python counterpart is #365).

- New codecs under `src/serializers/`: `PayloadCodec` interface, `GzipCodec` (zip-bomb-guarded decode via `maxOutputLength`, 64 MiB default cap), `AesGcmCodec` (`[12B IV][ciphertext||16B tag]` — tag trails the ciphertext, deliberately unlike `EncryptedSerializer`'s `[iv|tag|ct]`, because the cross-SDK contract puts it last), `HmacCodec` (`[32B mac][body]`, timing-safe compare), and `CodecSerializer` (encode in list order, decode in reverse).
- `QueueOptions.codec` global chain wraps the queue serializer, covering payloads and results everywhere it flows (enqueue, worker, workflows, periodic). `QueueOptions.codecs` + `TaskOptions.codecs` applies named codecs per task — payload only; results stay on the queue serializer.
- Per-task encode is centralized in `Queue.encodeTaskPayload` and used by `prepareEnqueue`, `registerPeriodic`, and workflow node payloads; the worker reverse-decodes named codecs before deserializing.
- New `CryptoError extends SerializationError` for decrypt/verify failures.

Jobs persisted before enabling a codec chain cannot be decoded through it — drain the queue first.

## Tests

26 tests in `test/core/codecs.test.ts`: unit round-trips, tamper/short/cap rejection, chain reversibility over JSON and msgpack, wire-layout assertions, worker e2e for the global chain (payload + result framing checked in storage) and per-task codecs (including `enqueueMany` and results skipping per-task codecs). Full suite: 218 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configurable payload codecs for queues, workers, and workflows.
  * Introduced built-in codecs for encryption, authentication, compression, and codec chaining.
  * Added new task-level codec settings so payload handling can be customized per task.

* **Bug Fixes**
  * Improved error handling for invalid, tampered, or corrupted payloads.
  * Added safeguards for decompression size limits to help prevent oversized payload issues.

* **Chores**
  * Updated public exports so the new codec APIs are available from the main package entry points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->