### PR TITLE
feat(node): proxy sessions with identity dedup and cleanup

### DIFF
--- a/sdks/node/src/index.ts
+++ b/sdks/node/src/index.ts
@@ -32,7 +32,7 @@ export {
   type PredicateContext,
 } from "./predicates";
 export type { ProxyHandler, ProxyRef } from "./proxies";
-export { canonicalJson, FileProxyHandler, FileReference, Proxies } from "./proxies";
+export { canonicalJson, FileProxyHandler, FileReference, Proxies, ProxySession } from "./proxies";
 export { Queue, type QueueOptions } from "./queue";
 export {
   type MockResource,

--- a/sdks/node/src/proxies/index.ts
+++ b/sdks/node/src/proxies/index.ts
@@ -1,4 +1,5 @@
 export { canonicalJson } from "./canonical";
 export { FileProxyHandler, FileReference } from "./file-handler";
 export { Proxies } from "./proxies";
+export { ProxySession } from "./proxy-session";
 export type { ProxyHandler, ProxyRef } from "./types";

--- a/sdks/node/src/proxies/proxies.ts
+++ b/sdks/node/src/proxies/proxies.ts
@@ -1,6 +1,7 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
 import { ProxyError } from "../errors";
 import { canonicalJson } from "./canonical";
+import { ProxySession } from "./proxy-session";
 import type { ProxyHandler, ProxyRef } from "./types";
 
 /**
@@ -62,11 +63,8 @@ export class Proxies {
    * its bound purpose, then reconstruct the resource.
    */
   reconstruct(ref: ProxyRef, expectedPurpose?: string): unknown {
-    const handler = this.handlers.get(ref.handler);
-    if (!handler) {
-      throw new ProxyError(`unknown proxy handler "${ref.handler}"`);
-    }
-    this.verify(ref, expectedPurpose);
+    const handler = this.handlerFor(ref.handler);
+    this.verifyRef(ref, expectedPurpose);
     return handler.reconstruct(ref.reference);
   }
 
@@ -75,7 +73,26 @@ export class Proxies {
     return this.reconstruct(ref, expectedPurpose) as T;
   }
 
-  private verify(ref: ProxyRef, expectedPurpose?: string): void {
+  /**
+   * Open a {@link ProxySession} over this registry — a unit-of-work wrapper
+   * adding identity dedup on deconstruct, memoization on reconstruct, and a
+   * LIFO cleanup lifecycle on close.
+   */
+  session(): ProxySession {
+    return new ProxySession(this);
+  }
+
+  /** Look up the handler registered under `handlerId`. @internal */
+  handlerFor(handlerId: string): ProxyHandler {
+    const handler = this.handlers.get(handlerId);
+    if (!handler) {
+      throw new ProxyError(`unknown proxy handler "${handlerId}"`);
+    }
+    return handler;
+  }
+
+  /** Verify a ref's signature, expiry, and (optionally) purpose. @internal */
+  verifyRef(ref: ProxyRef, expectedPurpose?: string): void {
     const expected = Buffer.from(
       this.sign(ref.handler, ref.reference, ref.expiresAtMs, ref.purpose),
       "utf8",

--- a/sdks/node/src/proxies/proxy-session.ts
+++ b/sdks/node/src/proxies/proxy-session.ts
@@ -1,0 +1,118 @@
+import { ProxyError } from "../errors";
+import { createLogger } from "../utils/logger";
+import type { Proxies } from "./proxies";
+import type { ProxyRef } from "./types";
+
+const log = createLogger("proxies");
+
+/**
+ * A unit-of-work wrapper over {@link Proxies} adding identity dedup and a
+ * cleanup lifecycle. Within one session:
+ *
+ * - {@link ProxySession.deconstruct} memoizes by (instance identity, purpose)
+ *   — deconstructing the same object again returns the same {@link ProxyRef}
+ *   without calling the handler twice. The first call's TTL wins per
+ *   (instance, purpose); use a new session to refresh expiry.
+ * - {@link ProxySession.reconstruct} memoizes by the ref's signature — every
+ *   ref to the same underlying resource resolves to the same instance, and
+ *   the handler reconstructs it once. Signature, expiry, and purpose are
+ *   re-verified on every call, memo hit or not, so a ref that expires
+ *   mid-session stops resolving.
+ * - {@link ProxySession.close} runs the handler's `cleanup` once per unique
+ *   reconstructed instance, in reverse reconstruction order (LIFO).
+ *
+ * Not thread-safe conceptually — a session models one producer batch or one
+ * task invocation; don't share it across concurrent work.
+ */
+export class ProxySession {
+  private readonly proxies: Proxies;
+  private readonly deconstructed = new Map<unknown, Map<string | undefined, ProxyRef>>();
+  private readonly reconstructed = new Map<string, unknown>();
+  private readonly cleanups: Array<() => void> = [];
+  private closed = false;
+
+  /** Construct via {@link Proxies.session}, not directly. */
+  constructor(proxies: Proxies) {
+    this.proxies = proxies;
+  }
+
+  /**
+   * Deconstruct `value` (optionally bound to a TTL and a purpose), deduped by
+   * (instance identity, purpose). The underlying registry deconstructs each
+   * (instance, purpose) pair once; a later call with a different `ttlMs` is
+   * silently ignored — open a new session to refresh expiry.
+   */
+  deconstruct(value: unknown, opts?: { ttlMs?: number; purpose?: string }): ProxyRef {
+    this.ensureOpen();
+    const purpose = opts?.purpose;
+    const cached = this.deconstructed.get(value)?.get(purpose);
+    if (cached) {
+      return cached;
+    }
+    // Delegate before memoizing so an invalid value (e.g. null) throws the
+    // registry's error without leaving a memo entry behind.
+    const ref = this.proxies.deconstruct(value, opts);
+    let byPurpose = this.deconstructed.get(value);
+    if (!byPurpose) {
+      byPurpose = new Map();
+      this.deconstructed.set(value, byPurpose);
+    }
+    byPurpose.set(purpose, ref);
+    return ref;
+  }
+
+  /**
+   * Verify (always — including memo hits, so a ref that expires mid-session
+   * stops resolving) and reconstruct `ref`, deduped by its signature.
+   */
+  reconstruct(ref: ProxyRef, expectedPurpose?: string): unknown {
+    this.ensureOpen();
+    const handler = this.proxies.handlerFor(ref.handler);
+    this.proxies.verifyRef(ref, expectedPurpose);
+    if (this.reconstructed.has(ref.signature)) {
+      return this.reconstructed.get(ref.signature);
+    }
+    const value = handler.reconstruct(ref.reference);
+    this.reconstructed.set(ref.signature, value);
+    this.cleanups.push(() => handler.cleanup?.(value));
+    return value;
+  }
+
+  /** {@link ProxySession.reconstruct} cast to the caller's type. */
+  resolve<T>(ref: ProxyRef, expectedPurpose?: string): T {
+    return this.reconstruct(ref, expectedPurpose) as T;
+  }
+
+  /**
+   * Run the handler's `cleanup` for every reconstructed instance in reverse
+   * order (LIFO), once each. Cleanup failures are logged and never skip the
+   * rest — close always completes and never throws (teardown convention).
+   * Idempotent.
+   */
+  close(): void {
+    if (this.closed) {
+      return;
+    }
+    this.closed = true;
+    for (let cleanup = this.cleanups.pop(); cleanup !== undefined; cleanup = this.cleanups.pop()) {
+      try {
+        cleanup();
+      } catch (error) {
+        // Cleanup must never fail the rest of the teardown — log and continue.
+        log.warn("proxy cleanup failed", error);
+      }
+    }
+    this.deconstructed.clear();
+    this.reconstructed.clear();
+  }
+
+  [Symbol.dispose](): void {
+    this.close();
+  }
+
+  private ensureOpen(): void {
+    if (this.closed) {
+      throw new ProxyError("proxy session is closed");
+    }
+  }
+}

--- a/sdks/node/src/proxies/types.ts
+++ b/sdks/node/src/proxies/types.ts
@@ -36,4 +36,10 @@ export interface ProxyHandler<T = unknown> {
   deconstruct(value: T): Record<string, unknown>;
   /** Rebuild the resource from a reference produced by {@link ProxyHandler.deconstruct}. */
   reconstruct(reference: Record<string, unknown>): T;
+  /**
+   * Release a value this handler reconstructed. Called once per reconstructed
+   * value when a `ProxySession` closes; absence means no-op. Direct
+   * {@link Proxies.reconstruct} calls have no lifecycle and never trigger it.
+   */
+  cleanup?(value: T): void;
 }

--- a/sdks/node/test/resources/proxies.test.ts
+++ b/sdks/node/test/resources/proxies.test.ts
@@ -10,6 +10,7 @@ import {
   ProxyError,
   type ProxyHandler,
   type ProxyRef,
+  type ProxySession,
 } from "../../src/index";
 
 const KEY = Buffer.from("proxy-secret-key");
@@ -177,6 +178,145 @@ describe("cross-SDK contract", () => {
     const ref = proxies.deconstruct("/tmp/data.txt");
     expect(ref.signature).toBe("FgmudNqaGsUBFsIKC4uBgtfZ+IAHrzBT+xRjUWGePyQ=");
     expect(proxies.resolve<string>(ref)).toBe("/tmp/data.txt");
+  });
+});
+
+/** Counts handler invocations and records cleaned values, for session tests. */
+class CountingFileHandler implements ProxyHandler<FileReference> {
+  private readonly delegate = new FileProxyHandler();
+  readonly id = this.delegate.id;
+  deconstructs = 0;
+  reconstructs = 0;
+  readonly cleaned: FileReference[] = [];
+
+  handles(value: unknown): boolean {
+    return this.delegate.handles(value);
+  }
+
+  deconstruct(value: FileReference): Record<string, unknown> {
+    this.deconstructs += 1;
+    return this.delegate.deconstruct(value);
+  }
+
+  reconstruct(reference: Record<string, unknown>): FileReference {
+    this.reconstructs += 1;
+    return this.delegate.reconstruct(reference);
+  }
+
+  cleanup(value: FileReference): void {
+    this.cleaned.push(value);
+  }
+}
+
+describe("ProxySession", () => {
+  it("dedups the same instance on deconstruct", () => {
+    const handler = new CountingFileHandler();
+    const proxies = new Proxies(KEY).register(handler);
+    const file = new FileReference(join(tempDir(), "dedup.txt"));
+    const session = proxies.session();
+    expect(session.deconstruct(file)).toBe(session.deconstruct(file));
+    session.close();
+    expect(handler.deconstructs).toBe(1);
+  });
+
+  it("keeps purposes distinct", () => {
+    const proxies = fileProxies();
+    const file = new FileReference(join(tempDir(), "purpose.txt"));
+    const session = proxies.session();
+    const emails = session.deconstruct(file, { purpose: "emails" });
+    const billing = session.deconstruct(file, { purpose: "billing" });
+    expect(emails).not.toBe(billing);
+    expect(proxies.resolve<FileReference>(emails, "emails").path).toBe(resolve(file.path));
+    expect(proxies.resolve<FileReference>(billing, "billing").path).toBe(resolve(file.path));
+    session.close();
+  });
+
+  it("memoizes reconstruct by signature", () => {
+    const handler = new CountingFileHandler();
+    const proxies = new Proxies(KEY).register(handler);
+    const ref = proxies.deconstruct(new FileReference(join(tempDir(), "memo.txt")));
+    const session = proxies.session();
+    expect(session.reconstruct(ref)).toBe(session.reconstruct(ref));
+    session.close();
+    expect(handler.reconstructs).toBe(1);
+  });
+
+  it("runs cleanup once per instance, LIFO", () => {
+    const handler = new CountingFileHandler();
+    const proxies = new Proxies(KEY).register(handler);
+    const dir = tempDir();
+    const refA = proxies.deconstruct(new FileReference(join(dir, "a.txt")));
+    const refB = proxies.deconstruct(new FileReference(join(dir, "b.txt")));
+    const session = proxies.session();
+    const a = session.resolve<FileReference>(refA);
+    const b = session.resolve<FileReference>(refB);
+    session.resolve(refA); // memo hit — must not add a second cleanup
+    session.close();
+    session.close(); // idempotent
+    expect(handler.cleaned).toEqual([b, a]);
+  });
+
+  it("isolates sessions from each other", () => {
+    const handler = new CountingFileHandler();
+    const proxies = new Proxies(KEY).register(handler);
+    const ref = proxies.deconstruct(new FileReference(join(tempDir(), "iso.txt")));
+    const one = proxies.session();
+    const two = proxies.session();
+    const fromOne = one.resolve<FileReference>(ref);
+    const fromTwo = two.resolve<FileReference>(ref);
+    expect(fromOne).not.toBe(fromTwo);
+    one.close();
+    expect(handler.cleaned).toEqual([fromOne]); // closing one leaves the other live
+    two.close();
+    expect(handler.cleaned).toEqual([fromOne, fromTwo]);
+  });
+
+  it("re-verifies on a memo hit", async () => {
+    const proxies = fileProxies();
+    const ref = proxies.deconstruct(new FileReference(join(tempDir(), "ttl.txt")), { ttlMs: 30 });
+    const session = proxies.session();
+    session.resolve(ref);
+    await new Promise((r) => setTimeout(r, 80));
+    expect(() => session.resolve(ref)).toThrow(ProxyError);
+    expect(() => session.resolve(ref)).toThrow(/expired/);
+    session.close();
+  });
+
+  it("drains the remaining cleanups when one throws", () => {
+    const cleaned: FileReference[] = [];
+    const delegate = new FileProxyHandler();
+    const proxies = new Proxies(KEY).register({
+      id: delegate.id,
+      handles: (value) => delegate.handles(value),
+      deconstruct: (value: FileReference) => delegate.deconstruct(value),
+      reconstruct: (reference) => delegate.reconstruct(reference),
+      cleanup: (value: FileReference) => {
+        cleaned.push(value);
+        if (value.path.endsWith("boom.txt")) {
+          throw new Error("cleanup failed");
+        }
+      },
+    });
+    const dir = tempDir();
+    const refA = proxies.deconstruct(new FileReference(join(dir, "a.txt")));
+    const refBoom = proxies.deconstruct(new FileReference(join(dir, "boom.txt")));
+    const session = proxies.session();
+    session.resolve(refA);
+    session.resolve(refBoom); // cleaned last-in-first-out → throws first
+    expect(() => session.close()).not.toThrow();
+    expect(cleaned).toHaveLength(2); // the failure must not abandon the rest
+  });
+
+  it("rejects use after close", () => {
+    const proxies = fileProxies();
+    const file = new FileReference(join(tempDir(), "closed.txt"));
+    const ref = proxies.deconstruct(file);
+    const session: ProxySession = proxies.session();
+    session.close();
+    expect(() => session.deconstruct(file)).toThrow(ProxyError);
+    expect(() => session.deconstruct(file)).toThrow(/session is closed/);
+    expect(() => session.reconstruct(ref)).toThrow(/session is closed/);
+    expect(() => session.resolve(ref)).toThrow(/session is closed/);
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds `ProxySession` to the Node SDK — a unit-of-work wrapper over the Proxies registry, matching the cross-SDK proxy-session contract.
- Deconstruct is memoized by (instance identity, purpose) with first-call-TTL-wins; reconstruct is memoized by ref signature but signature/expiry/purpose are re-verified on every call (memo hit or not), so mid-session expiry stops resolving.
- `close()` runs handler cleanup once per unique reconstructed instance, in LIFO order; logs-and-continues on a cleanup failure, is idempotent, and supports `Symbol.dispose` (`using`). Post-close use throws `ProxyError`.

## Changes
- `ProxyHandler` gains optional `cleanup(value)` — only sessions invoke it; direct `reconstruct()` calls have no lifecycle.
- Internal refactor: `Proxies.handlerFor` / `verifyRef` extracted (behavior unchanged, error precedence unknown-handler → signature → expiry → purpose preserved).
- 8 new tests in `test/resources/proxies.test.ts`: dedup, purpose distinctness, memoization, LIFO cleanup-once, session isolation, re-verify on memo hit, drain-on-throw, use-after-close.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` — full Node suite green (256 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new session-based workflow for proxy operations, making repeated conversions and lookups more efficient within a single session.
  * Added support for cleanup callbacks when session-managed values are released.

* **Bug Fixes**
  * Improved validation during reconstruction to better handle expired or mismatched references.
  * Ensured session cleanup runs in a predictable order and continues even if one cleanup fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->