### PR TITLE
fix(java): drop method refs flagged by null analysis

### DIFF
--- a/sdks/java/src/main/java/org/byteveda/taskito/resources/ResourceRuntime.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/resources/ResourceRuntime.java
@@ -385,7 +385,9 @@ public final class ResourceRuntime {
     private void disposeWorker() {
         // Pools first: pooled instances may depend on worker resources, which the
         // teardown stack below disposes.
-        pools.values().forEach(ResourcePool::shutdown);
+        for (ResourcePool pool : pools.values()) {
+            pool.shutdown();
+        }
         pools.clear();
         synchronized (workerTeardown) {
             while (!workerTeardown.isEmpty()) {

--- a/sdks/java/src/main/java/org/byteveda/taskito/workflows/WorkflowAnalysis.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/workflows/WorkflowAnalysis.java
@@ -55,7 +55,7 @@ public final class WorkflowAnalysis {
             String node = ready.poll();
             order.add(node);
             for (String next : successors.getOrDefault(node, List.of())) {
-                indegree.merge(next, -1, Integer::sum);
+                indegree.merge(next, -1, (count, delta) -> count + delta);
                 if (indegree.get(next) == 0) {
                     ready.add(next);
                 }

--- a/sdks/java/src/test/java/org/byteveda/taskito/Greeter.java
+++ b/sdks/java/src/test/java/org/byteveda/taskito/Greeter.java
@@ -13,6 +13,6 @@ class Greeter {
 
     @TaskHandler
     Integer total(List<Integer> numbers) {
-        return numbers.stream().mapToInt(Integer::intValue).sum();
+        return numbers.stream().mapToInt(number -> number.intValue()).sum();
     }
 }


### PR DESCRIPTION
## Summary
Eclipse JDT null analysis flags boxed method refs passed where primitive/non-null descriptors are expected ("needs unchecked conversion"). Replace the three flagged sites with explicit forms — behavior identical:
- `ResourceRuntime.disposeWorker`: `pools.values().forEach(ResourcePool::shutdown)` → enhanced for loop.
- `WorkflowAnalysis`: `indegree.merge(next, -1, Integer::sum)` → explicit lambda.
- `Greeter` (test fixture): `mapToInt(Integer::intValue)` → explicit lambda.

## Test plan
- [x] `./gradlew spotlessApply build` green (full Java suite).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified a few internal implementation details without changing behavior.
  * Updated resource shutdown and workflow ordering logic to use explicit loops/lambdas for clarity.
  * Adjusted a test utility’s numeric mapping expression to a more explicit form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->