### PR TITLE
fix(java): correct javadoc link to Builder idempotent

### DIFF
--- a/sdks/java/src/main/java/org/byteveda/taskito/task/Task.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/task/Task.java
@@ -80,7 +80,7 @@ public final class Task<T> {
     /**
      * A copy of this task that auto-derives a {@code uniqueKey} from the payload on every
      * enqueue, so a duplicate enqueue is a no-op while the first job is pending or running.
-     * A per-enqueue {@link EnqueueOptions#idempotent(boolean)} overrides this default.
+     * A per-enqueue {@link EnqueueOptions.Builder#idempotent(boolean)} overrides this default.
      */
     public Task<T> idempotent(boolean idempotent) {
         return new Task<>(name, payloadType, options, retryPolicy, codecs, idempotent, circuitBreaker);


### PR DESCRIPTION
Javadoc build failed in the Maven Central publish run for `java-v0.19.0`: `Task.java:83` linked `EnqueueOptions#idempotent(boolean)`, but that method lives on `EnqueueOptions.Builder`. Fixes the link so `:javadoc` passes.

Failed run: https://github.com/ByteVeda/taskito/actions/runs/28848102791

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the public API documentation to point to the correct idempotency setting reference.
  * Clarified the enqueue idempotency guidance with no impact on runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->