### PR TITLE
fix(docs): section-URL 404s + Python capabilities page

### DIFF
--- a/docs/app/lib/redirects.ts
+++ b/docs/app/lib/redirects.ts
@@ -17,6 +17,16 @@ const ARCH_PAGES = [
   "serialization",
 ];
 
+// Sections that have child pages but no landing/index page. A bare hit on the
+// section URL (e.g. from a breadcrumb crumb or an external link) would otherwise
+// 404, so send it to the section's first page.
+const SECTION_LANDINGS = ["node", "python", "java"].map(
+  (sdk): [string, string] => [
+    `/${sdk}/getting-started`,
+    `/${sdk}/getting-started/installation`,
+  ],
+);
+
 export const REDIRECTS: Record<string, string> = {
   ...Object.fromEntries(
     ARCH_PAGES.map((page) => {
@@ -24,6 +34,8 @@ export const REDIRECTS: Record<string, string> = {
       return [`/python/architecture${suffix}`, `/architecture${suffix}`];
     }),
   ),
+  ...Object.fromEntries(SECTION_LANDINGS),
+  "/resources": "/resources/comparison",
   "/python/more/comparison": "/resources/comparison",
   "/python/more/faq": "/resources/faq",
   "/python/more/changelog": "/resources/changelog",

--- a/docs/content/docs/python/getting-started/capabilities.mdx
+++ b/docs/content/docs/python/getting-started/capabilities.mdx
@@ -1,0 +1,68 @@
+---
+title: Capabilities at a glance
+description: "Everything the Python SDK can do, with a link to each guide."
+---
+
+A map of the Python SDK's features. Everything here runs over the shared Rust
+core — pick a backend, register tasks, run workers.
+
+## Core
+
+| Feature | Guide |
+|---|---|
+| Task registry, enqueue, await results | [Tasks](/python/guides/core/tasks) · [Queue API](/python/api-reference/overview) |
+| SQLite / Postgres / Redis backends | [Postgres](/python/guides/operations/postgres) |
+| Named queues, priority, pause/resume | [Queues](/python/guides/core/queues) |
+| Cron-scheduled & delayed jobs | [Scheduling](/python/guides/core/scheduling) |
+| Cooperative cancellation | [Job management](/python/guides/operations/job-management) |
+| Streaming partial results | [Streaming](/python/guides/advanced-execution/streaming) |
+| Sync & async tasks, concurrency | [Async tasks](/python/guides/advanced-execution/async-tasks) · [Execution model](/python/guides/core/execution-model) |
+| Batch enqueue, dependencies, unique tasks | [Batch enqueue](/python/guides/advanced-execution/batch-enqueue) · [Dependencies](/python/guides/advanced-execution/dependencies) · [Unique tasks](/python/guides/advanced-execution/unique-tasks) |
+| Enqueue predicates & prefork pools | [Predicates](/python/guides/core/predicates) · [Prefork](/python/guides/advanced-execution/prefork) |
+
+## Reliability
+
+| Feature | Guide |
+|---|---|
+| Retries with backoff, dead-letter queue | [Retries](/python/guides/reliability/retries) · [Error handling](/python/guides/reliability/error-handling) |
+| Concurrency caps & rate limits | [Rate limiting](/python/guides/reliability/rate-limiting) |
+| Circuit breakers | [Circuit breakers](/python/guides/reliability/circuit-breakers) |
+| Idempotent enqueue (`unique_key`) | [Idempotency](/python/guides/reliability/idempotency) |
+| Distributed locks | [Locking](/python/guides/reliability/locking) |
+| Delivery guarantees | [Guarantees](/python/guides/reliability/guarantees) |
+
+## Orchestration
+
+| Feature | Guide |
+|---|---|
+| DAG workflows: fan-out/in, conditions, gates, sub-workflows, saga | [Workflows](/python/guides/workflows) · [Sagas](/python/guides/workflows/sagas) |
+| Decentralized work-stealing mesh | [Mesh](/python/guides/operations/mesh) |
+
+## Extensibility
+
+| Feature | Guide |
+|---|---|
+| Lifecycle events & middleware | [Events & webhooks](/python/guides/extensibility/events-webhooks) · [Middleware](/python/guides/extensibility/middleware) |
+| Signed webhook delivery | [Events & webhooks](/python/guides/extensibility/events-webhooks) |
+| Resource injection, interception & proxies | [Dependency injection](/python/guides/resources/dependency-injection) · [Interception](/python/guides/resources/interception) · [Proxies](/python/guides/resources/proxies) |
+| Pluggable serializers (JSON / msgpack / signed / encrypted) | [Serializers](/python/guides/extensibility/serializers) |
+
+## Observability & ops
+
+| Feature | Guide |
+|---|---|
+| Stats, metrics, progress, worker heartbeats | [Monitoring](/python/guides/observability/monitoring) |
+| Structured logging & notes | [Logging](/python/guides/observability/logging) · [Notes](/python/guides/observability/notes) |
+| OpenTelemetry / Prometheus / Sentry | [OTel](/python/guides/integrations/otel) · [Prometheus](/python/guides/integrations/prometheus) · [Sentry](/python/guides/integrations/sentry) |
+| Dashboard + REST API + auth / SSO | [Dashboard](/python/guides/dashboard) · [REST API](/python/guides/dashboard/rest-api) · [Authentication](/python/guides/dashboard/authentication) |
+| KEDA autoscaling (queue-depth scaler) | [KEDA](/python/guides/operations/keda) · [Autoscaler](/python/guides/operations/autoscaler) |
+| Job management & CLI | [Job management](/python/guides/operations/job-management) |
+
+## Framework integrations
+
+[Django](/python/guides/integrations/django) · [FastAPI](/python/guides/integrations/fastapi) · [Flask](/python/guides/integrations/flask)
+
+<Callout type="info">
+  Workflows and mesh are optional capabilities built into the native extension.
+  See [installation](/python/getting-started/installation) to get set up.
+</Callout>

--- a/docs/content/docs/python/getting-started/meta.json
+++ b/docs/content/docs/python/getting-started/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "Getting Started",
   "root": true,
-  "pages": ["installation", "quickstart", "concepts"]
+  "pages": ["installation", "quickstart", "concepts", "capabilities"]
 }


### PR DESCRIPTION
## Fix docs "Page not found" on section URLs + add Python capabilities page

Two docs fixes.

### 1. Index-less section URLs 404

Sections that have child pages but no landing/index page — each SDK's `getting-started`, and `resources` — 404'd on a bare hit. This is reachable from the **breadcrumb**: on any `…/getting-started/quickstart` page the "Getting Started" crumb links to the bare `/<sdk>/getting-started`, which had no page → *"No documentation page matches this URL."* (affects every SDK).

Fix: redirect these bare section URLs to the section's first page via the existing static-redirect mechanism (prerendered stub + SPA client-nav):
- `/{node,python,java}/getting-started` → `…/getting-started/installation`
- `/resources` → `/resources/comparison`

### 2. Python getting-started missing "Capabilities at a glance"

The Node and Java SDKs have a `capabilities` page in getting-started; Python didn't. Added `python/getting-started/capabilities.mdx` (a feature → guide map, mapped to Python's actual guide URLs) and listed it in the section's `meta.json`.

### Verification

`biome check` + `typecheck` clean; full docs build succeeds — the four redirect stubs prerender with the correct `meta-refresh` targets, and `python/getting-started/capabilities` prerenders.
