### PR TITLE
fix(docs): redirect base-path 404 + Java SDK in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A Rust-powered task queue with native SDKs. One engine — no broker required, j
 
 [![PyPI version](https://img.shields.io/pypi/v/taskito.svg)](https://pypi.org/project/taskito/)
 [![npm version](https://img.shields.io/npm/v/@byteveda/taskito.svg)](https://www.npmjs.com/package/@byteveda/taskito)
+[![Maven Central](https://img.shields.io/maven-central/v/org.byteveda/taskito.svg)](https://central.sonatype.com/artifact/org.byteveda/taskito)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/ByteVeda/taskito/blob/master/LICENSE)
 
 </div>
@@ -21,6 +22,7 @@ and Diesel over SQLite in WAL mode — exposed to each language through a thin n
 |----------|---------|---------|------|
 | **Python** | `pip install taskito` | [PyPI](https://pypi.org/project/taskito/) · [`sdks/python`](sdks/python) | [Python docs](https://docs.byteveda.org/taskito) |
 | **Node.js** | `npm install @byteveda/taskito` | [npm](https://www.npmjs.com/package/@byteveda/taskito) · [`sdks/node`](sdks/node) | [Node docs](https://docs.byteveda.org/taskito/node) |
+| **Java** | `org.byteveda:taskito` | [Maven Central](https://central.sonatype.com/artifact/org.byteveda/taskito) · [`sdks/java`](sdks/java) | [Java docs](https://docs.byteveda.org/taskito/java) |
 
 Each SDK is self-contained — see its README for install, quickstart, and the full API.
 
@@ -46,7 +48,7 @@ truth; the GIL/event loop is held only during task execution. `WorkerDispatcher`
 |---|---|---|---|---|---|
 | Broker required | **No** | Yes | Yes | Yes | Yes |
 | Core language | **Rust** | Python | Python | Python | Python |
-| Language SDKs | **Python, Node** | Python | Python | Python | Python |
+| Language SDKs | **Python, Node, Java** | Python | Python | Python | Python |
 | Priority queues | **Yes** | Yes | No | No | Yes |
 | Rate limiting | **Yes** | Yes | No | Yes | No |
 | Dead letter queue | **Yes** | No | Yes | No | No |

--- a/docs/app/routes/docs.$.tsx
+++ b/docs/app/routes/docs.$.tsx
@@ -41,12 +41,14 @@ export function meta({ params }: Route.MetaArgs) {
   const path = pathOf(params);
   const dest = redirectFor(path);
   if (dest) {
-    // Prerendered into the old URL's static HTML so a direct hit refreshes to
-    // the new home; canonical points search engines at the destination.
+    // Static redirect stub for a moved URL. The meta-refresh resolves against
+    // the origin, so it needs the deploy base path; SPA navigate() adds it.
+    const base = import.meta.env.BASE_URL.replace(/\/$/, "");
+    const target = `${base}${dest}`;
     return [
       { title: "Redirecting… | Taskito" },
-      { httpEquiv: "refresh", content: `0; url=${dest}` },
-      { tagName: "link", rel: "canonical", href: dest },
+      { httpEquiv: "refresh", content: `0; url=${target}` },
+      { tagName: "link", rel: "canonical", href: target },
     ];
   }
   const meta = docMeta(path);


### PR DESCRIPTION
## Redirect base-path 404 + Java SDK in README

### 1. Redirect meta-refresh dropped the deploy base path (404)

Follow-up to #391. The redirect stub's `meta-refresh` URL is resolved against the **origin**, not the router — so under the `/taskito` deploy base it emitted `url=/python/getting-started/installation` (no prefix) and the host 404'd. The SPA `navigate()` path was already basename-aware; only the static meta tag wasn't.

Fix: prefix `import.meta.env.BASE_URL` on the refresh + canonical URLs. This also repairs the pre-existing `architecture` / `more/*` / `resources` redirects, which had the same latent bug.

Verified with a production-basename build (`DOCS_BASE_PATH=/taskito`): stubs now emit `url=/taskito/…`.

### 2. Java SDK in the README

Java is published to Maven Central (`org.byteveda:taskito`) but the root README still listed only Python and Node. Added it to the SDK table, the comparison row, and a Maven Central badge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Maven Central badge to the project links section.
  * Updated the SDK comparison table to include Java support.

* **Bug Fixes**
  * Improved documentation route redirects so direct page loads respect the app’s base path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->