### PR TITLE
fix(java): silence processor source-version warning

### DIFF
--- a/sdks/java/processor/src/main/java/org/byteveda/taskito/processor/TaskHandlerProcessor.java
+++ b/sdks/java/processor/src/main/java/org/byteveda/taskito/processor/TaskHandlerProcessor.java
@@ -9,7 +9,6 @@ import java.util.Set;
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
@@ -29,12 +28,18 @@ import javax.tools.JavaFileObject;
  * needs no dependency on the runtime module.
  */
 @SupportedAnnotationTypes(TaskHandlerProcessor.ANNOTATION)
-@SupportedSourceVersion(SourceVersion.RELEASE_11)
 public final class TaskHandlerProcessor extends AbstractProcessor {
     static final String ANNOTATION = "org.byteveda.taskito.annotation.TaskHandler";
     static final String RESOURCE = "org.byteveda.taskito.annotation.Resource";
     static final String COMPRESSED = "org.byteveda.taskito.annotation.Compressed";
     static final String ENCRYPTED = "org.byteveda.taskito.annotation.Encrypted";
+
+    // Accept whatever the compiler runs at, so building at -source 17+ doesn't warn
+    // that the processor caps out below it (structural read, version-agnostic).
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.latestSupported();
+    }
 
     @Override
     public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {


### PR DESCRIPTION
The `@TaskHandler` annotation processor declared `@SupportedSourceVersion(SourceVersion.RELEASE_11)`, so every build at `-source 17` (the SDK baseline) emitted:

```
warning: Supported source version 'RELEASE_11' from annotation processor '…TimeTrackingProcessor' less than -source '17'
```

The processor reads the annotation structurally and has no version-specific logic, so it's forward-compatible. Replaced the fixed annotation with an override of `getSupportedSourceVersion()` returning `SourceVersion.latestSupported()` — the canonical fix; the warning is gone and it won't recur on future JDKs.

Verified: clean `:compileTestJava` no longer prints the warning; processor + test compile succeed.