### PR TITLE
feat(java): dashboard Spring auto-config

### DIFF
--- a/sdks/java/spring/src/main/java/org/byteveda/taskito/spring/TaskitoDashboardAutoConfiguration.java
+++ b/sdks/java/spring/src/main/java/org/byteveda/taskito/spring/TaskitoDashboardAutoConfiguration.java
@@ -1,0 +1,37 @@
+package org.byteveda.taskito.spring;
+
+import java.io.IOException;
+import org.byteveda.taskito.Taskito;
+import org.byteveda.taskito.dashboard.DashboardServer;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Auto-starts a {@link DashboardServer} over the {@link Taskito} bean when
+ * {@code taskito.dashboard.enabled=true}. The server is stopped with the
+ * application context. Define your own {@code DashboardServer} bean to override.
+ */
+@AutoConfiguration(after = TaskitoAutoConfiguration.class)
+@ConditionalOnClass({Taskito.class, DashboardServer.class})
+@ConditionalOnProperty(prefix = "taskito.dashboard", name = "enabled", havingValue = "true")
+@EnableConfigurationProperties(TaskitoProperties.class)
+public class TaskitoDashboardAutoConfiguration {
+
+    @Bean(destroyMethod = "close")
+    @ConditionalOnBean(Taskito.class)
+    @ConditionalOnMissingBean
+    public DashboardServer taskitoDashboardServer(Taskito taskito, TaskitoProperties properties) throws IOException {
+        TaskitoProperties.Dashboard dashboard = properties.getDashboard();
+        return DashboardServer.start(
+                taskito,
+                dashboard.getPort(),
+                dashboard.getToken(),
+                dashboard.getStaticDir(),
+                dashboard.isSecureCookies());
+    }
+}

--- a/sdks/java/spring/src/main/java/org/byteveda/taskito/spring/TaskitoProperties.java
+++ b/sdks/java/spring/src/main/java/org/byteveda/taskito/spring/TaskitoProperties.java
@@ -37,4 +37,69 @@ public class TaskitoProperties {
     public void setNamespace(String namespace) {
         this.namespace = namespace;
     }
+
+    /** Dashboard server settings, bound from {@code taskito.dashboard.*}. */
+    private final Dashboard dashboard = new Dashboard();
+
+    public Dashboard getDashboard() {
+        return dashboard;
+    }
+
+    /** Auto-configuration for the bundled dashboard HTTP server. */
+    public static class Dashboard {
+        /** Whether to auto-start a {@code DashboardServer} bean. Off by default. */
+        private boolean enabled = false;
+
+        /** Port to bind (0 = ephemeral). */
+        private int port = 8080;
+
+        /** Optional shared token gating {@code /api/*}; null enables the session flow. */
+        private String token;
+
+        /** Optional unpacked SPA directory; null auto-discovers the bundled assets. */
+        private String staticDir;
+
+        /** Whether to keep the {@code Secure} cookie attribute (drop it for local HTTP). */
+        private boolean secureCookies = true;
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public int getPort() {
+            return port;
+        }
+
+        public void setPort(int port) {
+            this.port = port;
+        }
+
+        public String getToken() {
+            return token;
+        }
+
+        public void setToken(String token) {
+            this.token = token;
+        }
+
+        public String getStaticDir() {
+            return staticDir;
+        }
+
+        public void setStaticDir(String staticDir) {
+            this.staticDir = staticDir;
+        }
+
+        public boolean isSecureCookies() {
+            return secureCookies;
+        }
+
+        public void setSecureCookies(boolean secureCookies) {
+            this.secureCookies = secureCookies;
+        }
+    }
 }

--- a/sdks/java/spring/src/main/java/org/byteveda/taskito/spring/TaskitoProperties.java
+++ b/sdks/java/spring/src/main/java/org/byteveda/taskito/spring/TaskitoProperties.java
@@ -50,8 +50,11 @@ public class TaskitoProperties {
         /** Whether to auto-start a {@code DashboardServer} bean. Off by default. */
         private boolean enabled = false;
 
-        /** Port to bind (0 = ephemeral). */
-        private int port = 8080;
+        /**
+         * Port to bind (0 = ephemeral). Defaults to 8081, not 8080, so it doesn't
+         * clash with Spring Boot's own embedded server; override as needed.
+         */
+        private int port = 8081;
 
         /** Optional shared token gating {@code /api/*}; null enables the session flow. */
         private String token;

--- a/sdks/java/spring/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/sdks/java/spring/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,1 +1,2 @@
 org.byteveda.taskito.spring.TaskitoAutoConfiguration
+org.byteveda.taskito.spring.TaskitoDashboardAutoConfiguration

--- a/sdks/java/spring/src/test/java/org/byteveda/taskito/spring/TaskitoDashboardAutoConfigurationTest.java
+++ b/sdks/java/spring/src/test/java/org/byteveda/taskito/spring/TaskitoDashboardAutoConfigurationTest.java
@@ -1,0 +1,43 @@
+package org.byteveda.taskito.spring;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import org.byteveda.taskito.dashboard.DashboardServer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+class TaskitoDashboardAutoConfigurationTest {
+
+    private final ApplicationContextRunner runner = new ApplicationContextRunner()
+            .withConfiguration(
+                    AutoConfigurations.of(TaskitoAutoConfiguration.class, TaskitoDashboardAutoConfiguration.class));
+
+    @Test
+    @Timeout(30)
+    void noDashboardBeanByDefault(@TempDir Path dir) {
+        runner.withPropertyValues("taskito.url=" + dir.resolve("s.db")).run(ctx -> {
+            assertNull(ctx.getStartupFailure());
+            assertFalse(ctx.containsBean("taskitoDashboardServer"));
+        });
+    }
+
+    @Test
+    @Timeout(30)
+    void startsDashboardWhenEnabled(@TempDir Path dir) {
+        runner.withPropertyValues(
+                        "taskito.url=" + dir.resolve("s.db"),
+                        "taskito.dashboard.enabled=true",
+                        "taskito.dashboard.port=0")
+                .run(ctx -> {
+                    assertNull(ctx.getStartupFailure());
+                    DashboardServer server = ctx.getBean(DashboardServer.class);
+                    assertTrue(server.port() > 0);
+                });
+    }
+}

--- a/sdks/java/src/main/java/org/byteveda/taskito/Taskito.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/Taskito.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import org.byteveda.taskito.dashboard.DashboardServer;
 import org.byteveda.taskito.errors.ConfigurationException;
 import org.byteveda.taskito.interception.Interceptor;
 import org.byteveda.taskito.internal.JniQueueBackend;
@@ -309,6 +310,18 @@ public interface Taskito extends AutoCloseable {
 
     /** Begin building a worker over this client. */
     Worker.Builder worker();
+
+    // ── Dashboard ───────────────────────────────────────────────────
+
+    /** Start the dashboard HTTP server over this client on {@code port} (0 = ephemeral). */
+    default DashboardServer dashboard(int port) throws IOException {
+        return DashboardServer.start(this, port);
+    }
+
+    /** As {@link #dashboard(int)} but gating {@code /api/*} behind a shared {@code token}. */
+    default DashboardServer dashboard(int port, String token) throws IOException {
+        return DashboardServer.start(this, port, token);
+    }
 
     @Override
     void close();

--- a/sdks/java/src/test/java/org/byteveda/taskito/dashboard/DashboardTest.java
+++ b/sdks/java/src/test/java/org/byteveda/taskito/dashboard/DashboardTest.java
@@ -96,4 +96,15 @@ class DashboardTest {
             }
         }
     }
+
+    @Test
+    @Timeout(30)
+    void convenienceMethodStartsServer(@TempDir Path dir) throws Exception {
+        try (Taskito queue =
+                        Taskito.builder().sqlite(dir.resolve("t.db").toString()).open();
+                DashboardServer server = queue.dashboard(0, "tok")) {
+            assertTrue(server.port() > 0);
+            assertEquals(200, get(server.port(), "/api/stats?token=tok").statusCode());
+        }
+    }
 }


### PR DESCRIPTION
Makes the dashboard a one-liner for both plain and Spring Boot apps.

### Convenience API

`Taskito.dashboard()` — starts the dashboard against the queue with sensible defaults (session auth, ephemeral/bundled SPA), so callers don't reach into `DashboardServer.start(...)` and its overloads.

### Spring Boot auto-configuration (`:spring`)

- `TaskitoDashboardAutoConfiguration` (`@AutoConfiguration`) starts the dashboard when a `Taskito` bean is present, gated by `@ConditionalOnProperty(taskito.dashboard.enabled)`.
- `TaskitoProperties` gains the dashboard block — port, static dir, legacy token, secure-cookies — bound from `application.yml`/`.properties`.
- Registered via `META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports` (Boot 3 style), so it activates on classpath with zero code.

### Tests

`TaskitoDashboardAutoConfigurationTest` (context loads + conditional wiring) and a `DashboardTest` case for the convenience entrypoint. Full Java suite + `:spring:test` + checkstyle + Spotless clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional HTTP dashboard support for Spring Boot, including conditional auto-start when enabled.
  * Exposed convenient dashboard startup methods on the Taskito client, with optional token protection.
  * Introduced dashboard configuration for port, token gating, static assets, and secure cookies.

* **Tests**
  * Added Spring Boot context tests validating the dashboard does not start by default and starts when enabled.
  * Added a dashboard test covering the convenience method and token-protected `/api/stats` access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->