### PR TITLE
feat(java): webhooks dashboard (CRUD, deliveries, SSRF guard)

### DIFF
--- a/sdks/java/src/main/java/org/byteveda/taskito/dashboard/DashboardServer.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/dashboard/DashboardServer.java
@@ -20,6 +20,7 @@ import org.byteveda.taskito.dashboard.api.MetricsHandlers;
 import org.byteveda.taskito.dashboard.api.OpsHandlers;
 import org.byteveda.taskito.dashboard.api.OverridesHandlers;
 import org.byteveda.taskito.dashboard.api.SettingsHandlers;
+import org.byteveda.taskito.dashboard.api.WebhooksHandlers;
 import org.byteveda.taskito.dashboard.api.WorkflowsHandlers;
 import org.byteveda.taskito.dashboard.auth.AuthHandlers;
 import org.byteveda.taskito.dashboard.auth.AuthStore;
@@ -264,6 +265,7 @@ public final class DashboardServer implements AutoCloseable {
         OverridesHandlers overrides = new OverridesHandlers(queue, new OverridesStore(settings));
         MetricsHandlers metrics = new MetricsHandlers(queue);
         WorkflowsHandlers workflows = new WorkflowsHandlers(queue);
+        WebhooksHandlers webhooks = new WebhooksHandlers(queue);
         long ttl = AuthStore.DEFAULT_SESSION_TTL_SECONDS;
         Router r = new Router();
 
@@ -321,6 +323,21 @@ public final class DashboardServer implements AutoCloseable {
         r.get("/api/queues/([^/]+)/override", req -> overrides.getQueueOverride(req.param(0)));
         r.put("/api/queues/([^/]+)/override", req -> overrides.putQueueOverride(req.param(0), req.jsonBody()));
         r.delete("/api/queues/([^/]+)/override", req -> overrides.deleteQueueOverride(req.param(0)));
+
+        // Webhooks (CRUD + test/replay + delivery history). Specific paths first
+        // so the single-segment catch-alls don't shadow the sub-resources.
+        r.get("/api/webhooks", req -> webhooks.list());
+        r.post("/api/webhooks", req -> webhooks.create(req.jsonBody()));
+        r.post("/api/webhooks/([^/]+)/test", req -> webhooks.test(req.param(0)));
+        r.post("/api/webhooks/([^/]+)/rotate-secret", req -> webhooks.rotateSecret(req.param(0)));
+        r.get("/api/webhooks/([^/]+)/deliveries", req -> webhooks.deliveries(req.param(0), req.query()));
+        r.get("/api/webhooks/([^/]+)/deliveries/([^/]+)", req -> webhooks.delivery(req.param(0), req.param(1)));
+        r.post(
+                "/api/webhooks/([^/]+)/deliveries/([^/]+)/replay",
+                req -> webhooks.replayDelivery(req.param(0), req.param(1)));
+        r.get("/api/webhooks/([^/]+)", req -> webhooks.get(req.param(0)));
+        r.put("/api/webhooks/([^/]+)", req -> webhooks.update(req.param(0), req.jsonBody()));
+        r.delete("/api/webhooks/([^/]+)", req -> webhooks.delete(req.param(0)));
 
         // Action
         r.post("/api/jobs/([^/]+)/replay", req -> core.replayJob(req.param(0)));

--- a/sdks/java/src/main/java/org/byteveda/taskito/dashboard/api/Contract.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/dashboard/api/Contract.java
@@ -13,6 +13,8 @@ import org.byteveda.taskito.model.ReplayEntry;
 import org.byteveda.taskito.model.TaskLog;
 import org.byteveda.taskito.model.WorkerInfo;
 import org.byteveda.taskito.model.WorkflowRunInfo;
+import org.byteveda.taskito.webhooks.Delivery;
+import org.byteveda.taskito.webhooks.Webhook;
 import org.byteveda.taskito.workflows.NodeSnapshot;
 
 /**
@@ -155,6 +157,62 @@ final class Contract {
         m.put("parent_node_name", r.parentNodeName);
         m.put("created_at", r.createdAt);
         return m;
+    }
+
+    /**
+     * Map a webhook to the SPA contract. The raw secret is NEVER emitted — only a
+     * {@code has_secret} flag — and every header VALUE is masked, since headers
+     * routinely carry outbound credentials. Use {@link #webhookWithSecret} for the
+     * create/rotate responses that surface the secret exactly once.
+     */
+    static Map<String, Object> webhook(Webhook w) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("id", w.id);
+        m.put("url", w.url);
+        m.put("events", w.events);
+        m.put("task_filter", w.taskFilter);
+        m.put("headers", maskHeaderValues(w.headers));
+        m.put("has_secret", w.secret != null);
+        m.put("max_retries", w.maxRetries);
+        m.put("timeout_seconds", w.timeoutMs / 1000.0);
+        m.put("retry_backoff", 2.0);
+        m.put("enabled", w.enabled);
+        m.put("description", w.description);
+        m.put("created_at", w.createdAt);
+        m.put("updated_at", w.updatedAt);
+        return m;
+    }
+
+    /** As {@link #webhook} but with the raw secret surfaced once (create/rotate only). */
+    static Map<String, Object> webhookWithSecret(Webhook w) {
+        Map<String, Object> m = webhook(w);
+        m.put("secret", w.secret);
+        return m;
+    }
+
+    static Map<String, Object> delivery(Delivery d) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("id", d.id());
+        m.put("subscription_id", d.subscriptionId());
+        m.put("event", d.event());
+        m.put("task_name", d.taskName());
+        m.put("job_id", d.jobId());
+        m.put("status", d.status());
+        m.put("attempts", d.attempts());
+        m.put("response_code", d.responseCode());
+        m.put("response_body", d.responseBody());
+        m.put("latency_ms", d.latencyMs());
+        m.put("error", d.error());
+        m.put("created_at", d.createdAt());
+        m.put("completed_at", d.completedAt());
+        return m;
+    }
+
+    /** Replace every header value with a mask so outbound credentials aren't exposed. */
+    private static Map<String, Object> maskHeaderValues(Map<String, String> headers) {
+        Map<String, Object> masked = new LinkedHashMap<>();
+        headers.forEach((name, value) -> masked.put(name, "***"));
+        return masked;
     }
 
     static Map<String, Object> workflowNode(NodeSnapshot n) {

--- a/sdks/java/src/main/java/org/byteveda/taskito/dashboard/api/WebhooksHandlers.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/dashboard/api/WebhooksHandlers.java
@@ -1,0 +1,258 @@
+package org.byteveda.taskito.dashboard.api;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.byteveda.taskito.Taskito;
+import org.byteveda.taskito.dashboard.support.DashboardError;
+import org.byteveda.taskito.errors.WebhookException;
+import org.byteveda.taskito.events.EventName;
+import org.byteveda.taskito.webhooks.Webhook;
+import org.byteveda.taskito.webhooks.WebhookManager;
+import org.byteveda.taskito.webhooks.WebhookUpdate;
+import org.byteveda.taskito.webhooks.WebhookUrlValidator;
+
+/**
+ * Webhook subscription CRUD + test/replay + delivery history for the dashboard.
+ *
+ * <p>Uses a middleware-free {@link WebhookManager} — all state lives in the
+ * shared settings KV, so this works without a running worker. Every response is
+ * secret-safe: {@link Contract#webhook} masks header values and never emits the
+ * raw secret; only {@link #create} and {@link #rotateSecret} surface it, once.
+ */
+public final class WebhooksHandlers {
+    private static final int DEFAULT_DELIVERY_LIMIT = 50;
+    private static final int MAX_DELIVERY_LIMIT = 200;
+
+    private final WebhookManager manager;
+
+    public WebhooksHandlers(Taskito queue) {
+        this.manager = WebhookManager.forQueue(queue);
+    }
+
+    public Object list() {
+        return manager.list().stream().map(Contract::webhook).collect(Collectors.toList());
+    }
+
+    public Object get(String id) {
+        return manager.get(id).map(Contract::webhook).orElse(null);
+    }
+
+    public Object create(Map<String, Object> body) {
+        String url = requireString(body, "url");
+        validateUrl(url);
+        Webhook.Builder spec = Webhook.builder(url);
+        List<EventName> events = parseEvents(body.get("events"));
+        spec.on(events.toArray(new EventName[0]));
+        headers(body.get("headers")).forEach(spec::header);
+        String taskFilter = optionalString(body, "task_filter");
+        if (taskFilter != null) {
+            spec.taskFilter(taskFilter);
+        }
+        spec.maxRetries(intOr(body.get("max_retries"), "max_retries", 3));
+        spec.timeoutMs(timeoutMs(body.get("timeout_seconds"), 10_000));
+        if (body.containsKey("enabled")) {
+            spec.enabled(bool(body.get("enabled"), "enabled"));
+        }
+        String description = optionalString(body, "description");
+        if (description != null) {
+            spec.description(description);
+        }
+        spec.secret(resolveSecret(body));
+        return Contract.webhookWithSecret(manager.create(spec));
+    }
+
+    public Object update(String id, Map<String, Object> body) {
+        WebhookUpdate.Builder update = WebhookUpdate.builder();
+        if (body.containsKey("url")) {
+            String url = requireString(body, "url");
+            validateUrl(url);
+            update.url(url);
+        }
+        if (body.containsKey("events")) {
+            update.events(parseEvents(body.get("events")).stream()
+                    .map(WebhooksHandlers::wireName)
+                    .collect(Collectors.toList()));
+        }
+        if (body.containsKey("task_filter")) {
+            update.taskFilter(optionalString(body, "task_filter"));
+        }
+        if (body.containsKey("headers")) {
+            update.headers(headers(body.get("headers")));
+        }
+        if (body.containsKey("max_retries")) {
+            update.maxRetries(intOr(body.get("max_retries"), "max_retries", 3));
+        }
+        if (body.containsKey("timeout_seconds")) {
+            update.timeoutMs(timeoutMs(body.get("timeout_seconds"), 10_000));
+        }
+        if (body.containsKey("enabled")) {
+            update.enabled(bool(body.get("enabled"), "enabled"));
+        }
+        if (body.containsKey("description")) {
+            update.description(optionalString(body, "description"));
+        }
+        if (body.containsKey("secret")) {
+            update.secret(optionalString(body, "secret"));
+        }
+        return manager.update(id, update.build()).map(Contract::webhook).orElse(null);
+    }
+
+    public Object delete(String id) {
+        return manager.delete(id) ? Map.of("deleted", true) : null;
+    }
+
+    public Object rotateSecret(String id) {
+        return manager.rotateSecret(id).map(Contract::webhookWithSecret).orElse(null);
+    }
+
+    public Object test(String id) {
+        if (manager.get(id).isEmpty()) {
+            return null;
+        }
+        return Map.of("delivered", manager.test(id));
+    }
+
+    public Object deliveries(String id, Map<String, String> query) {
+        int limit = Math.min(intQuery(query, "limit", DEFAULT_DELIVERY_LIMIT), MAX_DELIVERY_LIMIT);
+        int offset = intQuery(query, "offset", 0);
+        return manager.deliveries(id, query.get("status"), query.get("event"), limit, offset).stream()
+                .map(Contract::delivery)
+                .collect(Collectors.toList());
+    }
+
+    public Object delivery(String id, String deliveryId) {
+        return manager.delivery(id, deliveryId).map(Contract::delivery).orElse(null);
+    }
+
+    public Object replayDelivery(String id, String deliveryId) {
+        if (manager.get(id).isEmpty() || manager.delivery(id, deliveryId).isEmpty()) {
+            return null;
+        }
+        return Map.of("replayed", manager.replay(id, deliveryId));
+    }
+
+    // ---- body parsing ------------------------------------------------------
+
+    private static void validateUrl(String url) {
+        try {
+            WebhookUrlValidator.validate(url);
+        } catch (WebhookException e) {
+            throw DashboardError.badRequest("unsafe_webhook_url");
+        }
+    }
+
+    private static String resolveSecret(Map<String, Object> body) {
+        if (isTruthy(body.get("generate_secret"))) {
+            return WebhookManager.generateSecret();
+        }
+        return optionalString(body, "secret");
+    }
+
+    private static List<EventName> parseEvents(Object raw) {
+        if (raw == null) {
+            return List.of();
+        }
+        if (!(raw instanceof List<?> list)) {
+            throw DashboardError.badRequest("events_must_be_list");
+        }
+        List<EventName> events = new ArrayList<>();
+        for (Object item : list) {
+            if (!(item instanceof String name)) {
+                throw DashboardError.badRequest("events_must_be_strings");
+            }
+            try {
+                events.add(EventName.valueOf(name.toUpperCase(Locale.ROOT)));
+            } catch (IllegalArgumentException e) {
+                throw DashboardError.badRequest("unknown_event");
+            }
+        }
+        return events;
+    }
+
+    private static Map<String, String> headers(Object raw) {
+        if (raw == null) {
+            return Map.of();
+        }
+        if (!(raw instanceof Map<?, ?> map)) {
+            throw DashboardError.badRequest("headers_must_be_object");
+        }
+        Map<String, String> out = new LinkedHashMap<>();
+        for (Map.Entry<?, ?> entry : map.entrySet()) {
+            if (!(entry.getKey() instanceof String key) || !(entry.getValue() instanceof String value)) {
+                throw DashboardError.badRequest("headers_must_be_strings");
+            }
+            out.put(key, value);
+        }
+        return out;
+    }
+
+    private static String requireString(Map<String, Object> body, String key) {
+        Object value = body.get(key);
+        if (!(value instanceof String string) || string.isEmpty()) {
+            throw DashboardError.badRequest("missing_" + key);
+        }
+        return string;
+    }
+
+    private static String optionalString(Map<String, Object> body, String key) {
+        Object value = body.get(key);
+        if (value == null) {
+            return null;
+        }
+        if (!(value instanceof String string)) {
+            throw DashboardError.badRequest("invalid_" + key);
+        }
+        return string;
+    }
+
+    private static int intOr(Object value, String name, int fallback) {
+        if (value == null) {
+            return fallback;
+        }
+        if (value instanceof Boolean || !(value instanceof Number number) || number.intValue() < 0) {
+            throw DashboardError.badRequest("invalid_" + name);
+        }
+        return number.intValue();
+    }
+
+    private static long timeoutMs(Object seconds, long fallbackMs) {
+        if (seconds == null) {
+            return fallbackMs;
+        }
+        if (seconds instanceof Boolean || !(seconds instanceof Number number) || number.doubleValue() <= 0) {
+            throw DashboardError.badRequest("invalid_timeout_seconds");
+        }
+        return Math.round(number.doubleValue() * 1000);
+    }
+
+    private static boolean bool(Object value, String name) {
+        if (!(value instanceof Boolean flag)) {
+            throw DashboardError.badRequest("invalid_" + name);
+        }
+        return flag;
+    }
+
+    private static boolean isTruthy(Object value) {
+        return value instanceof Boolean flag && flag;
+    }
+
+    private static int intQuery(Map<String, String> query, String key, int fallback) {
+        String value = query.get(key);
+        if (value == null || value.isEmpty()) {
+            return fallback;
+        }
+        try {
+            return Math.max(0, Integer.parseInt(value));
+        } catch (NumberFormatException e) {
+            throw DashboardError.badRequest("invalid_" + key);
+        }
+    }
+
+    private static String wireName(EventName name) {
+        return name.name().toLowerCase(Locale.ROOT);
+    }
+}

--- a/sdks/java/src/main/java/org/byteveda/taskito/webhooks/Deliverer.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/webhooks/Deliverer.java
@@ -1,5 +1,6 @@
 package org.byteveda.taskito.webhooks;
 
+import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -13,12 +14,15 @@ import javax.crypto.spec.SecretKeySpec;
 import org.byteveda.taskito.errors.WebhookException;
 import org.byteveda.taskito.logging.TaskitoLogger;
 
-/** Delivers webhook payloads over HTTP with an optional HMAC signature and retries. */
+/**
+ * Delivers webhook payloads over HTTP with an optional HMAC signature and
+ * retries, recording the outcome of each attempt in the {@link DeliveryStore}.
+ */
 final class Deliverer {
     private static final TaskitoLogger LOG = TaskitoLogger.create("webhooks");
     private static final String ALGORITHM = "HmacSHA256";
     private static final char[] HEX = "0123456789abcdef".toCharArray();
-    // Exponential backoff matching the Node SDK: 500ms, 1s, 2s, ... capped at 30s.
+    // Exponential backoff matching the cross-SDK contract: 500ms, 1s, 2s, ... capped at 30s.
     private static final long BASE_BACKOFF_MS = 500;
     private static final long MAX_BACKOFF_MS = 30_000;
     // 500ms << 6 = 32s > cap, so larger shifts can never change the delay.
@@ -26,8 +30,68 @@ final class Deliverer {
 
     private final HttpClient client = HttpClient.newHttpClient();
 
-    /** Send {@code body} to the hook (non-blocking). Retries server errors with backoff. */
-    void deliver(Webhook hook, byte[] body) {
+    /**
+     * Send {@code body} to the hook without blocking, retrying server errors
+     * with backoff. Records the terminal outcome (delivered on 2xx, else failed)
+     * once retries are exhausted.
+     */
+    void deliver(Webhook hook, byte[] body, DeliveryContext ctx, DeliveryStore store) {
+        sendWithRetry(hook, buildRequest(hook, body), 0, ctx, store, System.currentTimeMillis());
+    }
+
+    /**
+     * Send {@code body} synchronously with a single attempt and record the
+     * result. Returns the HTTP status code, or {@code -1} on a transport error.
+     * Used by dashboard test-ping and replay actions, which must report inline
+     * without blocking a request thread on backoff.
+     */
+    int deliverSync(Webhook hook, byte[] body, DeliveryContext ctx, DeliveryStore store) {
+        long start = System.currentTimeMillis();
+        try {
+            HttpResponse<String> response = client.send(buildRequest(hook, body), HttpResponse.BodyHandlers.ofString());
+            int code = response.statusCode();
+            record(store, hook, ctx, 1, code, response.body(), System.currentTimeMillis() - start);
+            return code;
+        } catch (IOException e) {
+            recordError(store, hook, ctx, 1, System.currentTimeMillis() - start, e);
+            return -1;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            recordError(store, hook, ctx, 1, System.currentTimeMillis() - start, e);
+            return -1;
+        }
+    }
+
+    private void sendWithRetry(
+            Webhook hook, HttpRequest request, int attempt, DeliveryContext ctx, DeliveryStore store, long start) {
+        client.sendAsync(request, HttpResponse.BodyHandlers.ofString()).whenComplete((response, error) -> {
+            boolean retryable = error != null || response.statusCode() >= 500;
+            if (retryable && attempt < hook.maxRetries) {
+                // Clamp the exponent before shifting: an unbounded shift overflows and
+                // would schedule negative delays for very large maxRetries.
+                long delayMs = Math.min(MAX_BACKOFF_MS, BASE_BACKOFF_MS << Math.min(attempt, MAX_BACKOFF_SHIFT));
+                CompletableFuture.delayedExecutor(delayMs, TimeUnit.MILLISECONDS)
+                        .execute(() -> sendWithRetry(hook, request, attempt + 1, ctx, store, start));
+                return;
+            }
+            int attempts = attempt + 1;
+            long latency = System.currentTimeMillis() - start;
+            if (error != null) {
+                recordError(store, hook, ctx, attempts, latency, error);
+                LOG.warn("webhook delivery to " + redact(request.uri()) + " failed after " + attempts + " attempt(s): "
+                        + error.getClass().getSimpleName());
+            } else {
+                int code = response.statusCode();
+                record(store, hook, ctx, attempts, code, response.body(), latency);
+                if (code >= 500) {
+                    LOG.warn("webhook delivery to " + redact(request.uri()) + " failed after " + attempts
+                            + " attempt(s): HTTP " + code);
+                }
+            }
+        });
+    }
+
+    private static HttpRequest buildRequest(Webhook hook, byte[] body) {
         HttpRequest.Builder request = HttpRequest.newBuilder(URI.create(hook.url))
                 .timeout(Duration.ofMillis(hook.timeoutMs))
                 .header("Content-Type", "application/json")
@@ -36,26 +100,40 @@ final class Deliverer {
             request.header("X-Taskito-Signature", "sha256=" + sign(hook.secret, body));
         }
         hook.headers.forEach(request::header);
-        sendWithRetry(request.build(), 0, hook.maxRetries);
+        return request.build();
     }
 
-    private void sendWithRetry(HttpRequest request, int attempt, int maxRetries) {
-        client.sendAsync(request, HttpResponse.BodyHandlers.discarding()).whenComplete((response, error) -> {
-            boolean failed = error != null || response.statusCode() >= 500;
-            if (!failed) {
-                return;
-            }
-            if (attempt >= maxRetries) {
-                LOG.warn("webhook delivery to " + redact(request.uri()) + " failed after " + (attempt + 1)
-                        + " attempt(s)" + (error != null ? ": " + error : ": HTTP " + response.statusCode()));
-                return;
-            }
-            // Clamp the exponent before shifting: an unbounded shift overflows and
-            // would schedule negative delays for very large maxRetries.
-            long delayMs = Math.min(MAX_BACKOFF_MS, BASE_BACKOFF_MS << Math.min(attempt, MAX_BACKOFF_SHIFT));
-            CompletableFuture.delayedExecutor(delayMs, TimeUnit.MILLISECONDS)
-                    .execute(() -> sendWithRetry(request, attempt + 1, maxRetries));
-        });
+    private static void record(
+            DeliveryStore store, Webhook hook, DeliveryContext ctx, int attempts, int code, String body, long latency) {
+        boolean ok = code >= 200 && code < 300;
+        String status = ok ? Delivery.DELIVERED : Delivery.FAILED;
+        String error = ok ? null : "HTTP " + code;
+        persist(store, Delivery.of(hook.id, ctx, status, attempts, code, body, latency, error));
+    }
+
+    private static void recordError(
+            DeliveryStore store, Webhook hook, DeliveryContext ctx, int attempts, long latency, Throwable error) {
+        // The class name only — transport error messages can echo the URL's tokens.
+        persist(
+                store,
+                Delivery.of(
+                        hook.id,
+                        ctx,
+                        Delivery.FAILED,
+                        attempts,
+                        null,
+                        null,
+                        latency,
+                        error.getClass().getSimpleName()));
+    }
+
+    private static void persist(DeliveryStore store, Delivery delivery) {
+        try {
+            store.record(delivery);
+        } catch (RuntimeException e) {
+            // Recording is best-effort — a log write failure must not sink the delivery.
+            LOG.warn("failed to record webhook delivery: " + e.getClass().getSimpleName());
+        }
     }
 
     /** Origin only (scheme://host:port) — path segments and queries can carry tokens. */

--- a/sdks/java/src/main/java/org/byteveda/taskito/webhooks/Delivery.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/webhooks/Delivery.java
@@ -1,0 +1,80 @@
+package org.byteveda.taskito.webhooks;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+/**
+ * One attempted webhook delivery, persisted in the per-subscription delivery
+ * log. Timestamps are Unix milliseconds. {@code status} is one of
+ * {@code pending}, {@code delivered}, {@code failed}, or {@code dead}.
+ *
+ * <p>Jackson maps this record by component name; unknown fields are ignored so
+ * a log written by a newer build still loads.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record Delivery(
+        String id,
+        String subscriptionId,
+        String event,
+        String taskName,
+        String jobId,
+        String status,
+        int attempts,
+        Integer responseCode,
+        String responseBody,
+        Long latencyMs,
+        String error,
+        long createdAt,
+        Long completedAt) {
+
+    static final String DELIVERED = "delivered";
+    static final String FAILED = "failed";
+
+    private static final int RESPONSE_BODY_MAX_BYTES = 2048;
+
+    /**
+     * Build a completed (or {@code pending}) delivery, minting an id and
+     * stamping the timestamps. The response body is truncated to
+     * {@value #RESPONSE_BODY_MAX_BYTES} UTF-8 bytes so a chatty endpoint can't
+     * bloat the log; {@code completedAt} is set unless the status is pending.
+     */
+    static Delivery of(
+            String subscriptionId,
+            DeliveryContext ctx,
+            String status,
+            int attempts,
+            Integer responseCode,
+            String responseBody,
+            Long latencyMs,
+            String error) {
+        long now = System.currentTimeMillis();
+        return new Delivery(
+                UUID.randomUUID().toString(),
+                subscriptionId,
+                ctx.event(),
+                ctx.taskName(),
+                ctx.jobId(),
+                status,
+                attempts,
+                responseCode,
+                truncate(responseBody),
+                latencyMs,
+                error,
+                now,
+                "pending".equals(status) ? null : now);
+    }
+
+    private static String truncate(String body) {
+        if (body == null) {
+            return null;
+        }
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        if (bytes.length <= RESPONSE_BODY_MAX_BYTES) {
+            return body;
+        }
+        // Decoding a byte-boundary cut may drop a partial trailing code point;
+        // the replacement behaviour matches the cross-SDK truncation contract.
+        return new String(bytes, 0, RESPONSE_BODY_MAX_BYTES, StandardCharsets.UTF_8) + "…";
+    }
+}

--- a/sdks/java/src/main/java/org/byteveda/taskito/webhooks/DeliveryContext.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/webhooks/DeliveryContext.java
@@ -1,0 +1,9 @@
+package org.byteveda.taskito.webhooks;
+
+/**
+ * The provenance of a webhook delivery — threaded from the outcome (or a test /
+ * replay) into the {@link Deliverer} so each recorded {@link Delivery} carries
+ * the event and the originating job. All fields may be {@code null} for
+ * synthetic events (e.g. a dashboard test ping).
+ */
+record DeliveryContext(String event, String taskName, String jobId) {}

--- a/sdks/java/src/main/java/org/byteveda/taskito/webhooks/DeliveryStore.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/webhooks/DeliveryStore.java
@@ -1,0 +1,94 @@
+package org.byteveda.taskito.webhooks;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.CollectionType;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.byteveda.taskito.Taskito;
+import org.byteveda.taskito.errors.WebhookException;
+
+/**
+ * Per-subscription webhook delivery log, persisted in the queue's settings KV.
+ *
+ * <p>Each subscription gets its own JSON list under
+ * {@code webhooks:deliveries:<subscriptionId>}, append-only with FIFO eviction
+ * once the per-webhook cap is hit — enough to debug recent activity without
+ * unbounded growth. Records are stored oldest-first; {@link #listFor} reverses
+ * for newest-first paging.
+ */
+final class DeliveryStore {
+    static final String KEY_PREFIX = "webhooks:deliveries:";
+    private static final int MAX_PER_WEBHOOK = 200;
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    private final Taskito queue;
+
+    DeliveryStore(Taskito queue) {
+        this.queue = queue;
+    }
+
+    /** Append {@code delivery} to its subscription's log, trimming to the cap. */
+    void record(Delivery delivery) {
+        List<Delivery> rows = load(delivery.subscriptionId());
+        rows.add(delivery);
+        if (rows.size() > MAX_PER_WEBHOOK) {
+            rows = new ArrayList<>(rows.subList(rows.size() - MAX_PER_WEBHOOK, rows.size()));
+        }
+        save(delivery.subscriptionId(), rows);
+    }
+
+    /** Newest-first, optionally filtered by status/event, then paged. */
+    List<Delivery> listFor(String subscriptionId, String statusFilter, String eventFilter, int limit, int offset) {
+        List<Delivery> rows = load(subscriptionId);
+        List<Delivery> out = new ArrayList<>();
+        for (int i = rows.size() - 1; i >= 0; i--) {
+            Delivery row = rows.get(i);
+            if (statusFilter != null && !statusFilter.equals(row.status())) {
+                continue;
+            }
+            if (eventFilter != null && !eventFilter.equals(row.event())) {
+                continue;
+            }
+            out.add(row);
+        }
+        int from = Math.min(Math.max(offset, 0), out.size());
+        int to = limit < 0 ? out.size() : Math.min(from + limit, out.size());
+        return new ArrayList<>(out.subList(from, to));
+    }
+
+    Optional<Delivery> get(String subscriptionId, String deliveryId) {
+        return load(subscriptionId).stream()
+                .filter(row -> row.id().equals(deliveryId))
+                .findFirst();
+    }
+
+    /** Drop the whole log for a subscription (called when the webhook is deleted). */
+    void deleteFor(String subscriptionId) {
+        queue.deleteSetting(KEY_PREFIX + subscriptionId);
+    }
+
+    private List<Delivery> load(String subscriptionId) {
+        return queue.getSetting(KEY_PREFIX + subscriptionId)
+                .map(DeliveryStore::parse)
+                .orElseGet(ArrayList::new);
+    }
+
+    private void save(String subscriptionId, List<Delivery> rows) {
+        try {
+            queue.setSetting(KEY_PREFIX + subscriptionId, JSON.writeValueAsString(rows));
+        } catch (Exception e) {
+            throw new WebhookException("failed to persist webhook deliveries", e);
+        }
+    }
+
+    private static List<Delivery> parse(String json) {
+        try {
+            CollectionType type = JSON.getTypeFactory().constructCollectionType(List.class, Delivery.class);
+            return JSON.readValue(json, type);
+        } catch (Exception e) {
+            // A corrupt log must not wedge the dashboard — start fresh.
+            return new ArrayList<>();
+        }
+    }
+}

--- a/sdks/java/src/main/java/org/byteveda/taskito/webhooks/WebhookManager.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/webhooks/WebhookManager.java
@@ -1,7 +1,9 @@
 package org.byteveda.taskito.webhooks;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.security.SecureRandom;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -16,12 +18,18 @@ import org.byteveda.taskito.middleware.Middleware;
 
 /**
  * Manages webhook subscriptions and dispatches matching job outcomes to them.
- * {@link #attach} registers the manager as queue middleware so outcomes are
- * delivered automatically. Persisted via the queue's settings store.
+ *
+ * <p>{@link #attach} registers the manager as queue middleware so outcomes are
+ * delivered automatically. {@link #forQueue} builds a standalone manager (no
+ * middleware) for CRUD, test, and delivery-history reads — all durable state
+ * lives in the shared settings store, so it works without a running worker.
+ * Persisted via the queue's settings store.
  */
 public final class WebhookManager implements Middleware {
     private static final TaskitoLogger LOG = TaskitoLogger.create("webhooks");
     private static final ObjectMapper JSON = new ObjectMapper();
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+    private static final int SECRET_BYTES = 32;
     // Dispatch runs on the worker's single outcome-drain thread for every job, so
     // it must not re-read + re-parse the settings blob per outcome. Local
     // create/delete invalidate immediately; the TTL bounds staleness from writers
@@ -29,11 +37,13 @@ public final class WebhookManager implements Middleware {
     private static final long CACHE_TTL_MS = 30_000;
 
     private final WebhookStore store;
+    private final DeliveryStore deliveryStore;
     private final Deliverer deliverer = new Deliverer();
     private volatile CachedHooks cached;
 
     private WebhookManager(Taskito queue) {
         this.store = new WebhookStore(queue);
+        this.deliveryStore = new DeliveryStore(queue);
     }
 
     /** Create a manager and register it on {@code queue} for automatic dispatch. */
@@ -43,7 +53,26 @@ public final class WebhookManager implements Middleware {
         return manager;
     }
 
+    /**
+     * Build a manager WITHOUT registering middleware. The dashboard uses this for
+     * CRUD, test-ping, replay, and delivery history — none of which need the
+     * worker-side dispatch hook, and all of which read/write the shared KV store.
+     */
+    public static WebhookManager forQueue(Taskito queue) {
+        return new WebhookManager(queue);
+    }
+
+    /** Mint a fresh URL-safe signing secret (32 random bytes, base64url, no padding). */
+    public static String generateSecret() {
+        byte[] bytes = new byte[SECRET_BYTES];
+        SECURE_RANDOM.nextBytes(bytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+
     public synchronized Webhook create(Webhook.Builder spec) {
+        // The programmatic API is trusted developer code (it may target internal
+        // services). The SSRF guard runs on untrusted dashboard input (see
+        // WebhooksHandlers) and again at delivery time.
         long now = System.currentTimeMillis();
         Webhook hook = new Webhook(
                 UUID.randomUUID().toString(),
@@ -73,14 +102,82 @@ public final class WebhookManager implements Middleware {
         return store.load().stream().filter(hook -> hook.id.equals(id)).findFirst();
     }
 
+    /**
+     * Apply {@code updates} to the webhook with {@code id} (null fields left
+     * unchanged), re-stamp {@code updatedAt}, and persist. Re-validates the
+     * (possibly new) URL. Empty if no such webhook exists.
+     */
+    public synchronized Optional<Webhook> update(String id, WebhookUpdate updates) {
+        List<Webhook> all = store.load();
+        for (int i = 0; i < all.size(); i++) {
+            Webhook current = all.get(i);
+            if (!current.id.equals(id)) {
+                continue;
+            }
+            Webhook merged = applyUpdate(current, updates);
+            all.set(i, merged);
+            store.save(all);
+            cached = null;
+            return Optional.of(merged);
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Replace the webhook's secret with a freshly minted one. Returns the updated
+     * hook WITH the new secret so the caller can surface it exactly once.
+     */
+    public synchronized Optional<Webhook> rotateSecret(String id) {
+        return update(id, WebhookUpdate.builder().secret(generateSecret()).build());
+    }
+
     public synchronized boolean delete(String id) {
         List<Webhook> all = store.load();
         boolean removed = all.removeIf(hook -> hook.id.equals(id));
         if (removed) {
             store.save(all);
+            deliveryStore.deleteFor(id);
             cached = null;
         }
         return removed;
+    }
+
+    /**
+     * Synchronously POST a synthetic {@code test} event to the hook and record
+     * the delivery. Returns whether the endpoint accepted it (2xx). {@code false}
+     * if the webhook is missing or its URL fails the SSRF guard.
+     */
+    public boolean test(String id) {
+        Optional<Webhook> hook = get(id);
+        if (hook.isEmpty()) {
+            return false;
+        }
+        DeliveryContext ctx = new DeliveryContext("test", null, null);
+        return sendSynthetic(hook.get(), ctx, testPayload(id));
+    }
+
+    /**
+     * Re-send a recorded delivery's payload as a fresh attempt, preserving the
+     * original in the log. Returns whether the resend was accepted (2xx).
+     * {@code false} if the webhook or delivery is missing, or the URL is unsafe.
+     */
+    public boolean replay(String id, String deliveryId) {
+        Optional<Webhook> hook = get(id);
+        Optional<Delivery> original = deliveryStore.get(id, deliveryId);
+        if (hook.isEmpty() || original.isEmpty()) {
+            return false;
+        }
+        Delivery source = original.get();
+        DeliveryContext ctx = new DeliveryContext(source.event(), source.taskName(), source.jobId());
+        return sendSynthetic(hook.get(), ctx, replayPayload(source));
+    }
+
+    public List<Delivery> deliveries(String id, String statusFilter, String eventFilter, int limit, int offset) {
+        return deliveryStore.listFor(id, statusFilter, eventFilter, limit, offset);
+    }
+
+    public Optional<Delivery> delivery(String id, String deliveryId) {
+        return deliveryStore.get(id, deliveryId);
     }
 
     @Override
@@ -110,18 +207,58 @@ public final class WebhookManager implements Middleware {
         }
         String wire = event.name.name().toLowerCase(Locale.ROOT);
         byte[] body = payload(event, wire);
+        DeliveryContext ctx = new DeliveryContext(wire, event.taskName, event.jobId);
         for (Webhook hook : hooks) {
             if (hook.enabled && hook.events.contains(wire) && matches(hook.taskFilter, event.taskName)) {
-                try {
-                    deliverer.deliver(hook, body);
-                } catch (RuntimeException e) {
-                    // A bad hook (e.g. malformed URL) must not block the rest. Log the
-                    // class only — URI parse messages can echo the URL's tokens.
-                    LOG.warn("webhook " + hook.id + " delivery failed: "
-                            + e.getClass().getSimpleName());
-                }
+                deliverOne(hook, body, ctx);
             }
         }
+    }
+
+    private void deliverOne(Webhook hook, byte[] body, DeliveryContext ctx) {
+        // Re-validate on every attempt (DNS-rebinding defense): a name that was
+        // safe at create time could now resolve to a private address. A failure
+        // is recorded and skipped so one bad hook never blocks the rest.
+        try {
+            WebhookUrlValidator.validate(hook.url);
+        } catch (WebhookException e) {
+            deliveryStore.record(Delivery.of(hook.id, ctx, Delivery.FAILED, 0, null, null, null, e.getMessage()));
+            return;
+        }
+        try {
+            deliverer.deliver(hook, body, ctx, deliveryStore);
+        } catch (RuntimeException e) {
+            // A bad hook (e.g. malformed URL) must not block the rest. Log the
+            // class only — URI parse messages can echo the URL's tokens.
+            LOG.warn("webhook " + hook.id + " delivery failed: " + e.getClass().getSimpleName());
+        }
+    }
+
+    private boolean sendSynthetic(Webhook hook, DeliveryContext ctx, byte[] body) {
+        try {
+            WebhookUrlValidator.validate(hook.url);
+        } catch (WebhookException e) {
+            deliveryStore.record(Delivery.of(hook.id, ctx, Delivery.FAILED, 0, null, null, null, e.getMessage()));
+            return false;
+        }
+        int status = deliverer.deliverSync(hook, body, ctx, deliveryStore);
+        return status >= 200 && status < 300;
+    }
+
+    private static Webhook applyUpdate(Webhook current, WebhookUpdate updates) {
+        return new Webhook(
+                current.id,
+                updates.url() != null ? updates.url() : current.url,
+                updates.events() != null ? new ArrayList<>(updates.events()) : current.events,
+                updates.taskFilter() != null ? updates.taskFilter() : current.taskFilter,
+                updates.headers() != null ? new LinkedHashMap<>(updates.headers()) : current.headers,
+                updates.secret() != null ? updates.secret() : current.secret,
+                updates.maxRetries() != null ? updates.maxRetries() : current.maxRetries,
+                updates.timeoutMs() != null ? updates.timeoutMs() : current.timeoutMs,
+                updates.enabled() != null ? updates.enabled() : current.enabled,
+                updates.description() != null ? updates.description() : current.description,
+                current.createdAt,
+                System.currentTimeMillis());
     }
 
     private List<Webhook> activeHooks() {
@@ -149,6 +286,26 @@ public final class WebhookManager implements Middleware {
         body.put("error", event.error);
         body.put("retry_count", event.retryCount);
         body.put("timed_out", event.timedOut);
+        return encode(body);
+    }
+
+    private static byte[] testPayload(String webhookId) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("event", "test");
+        body.put("webhook_id", webhookId);
+        return encode(body);
+    }
+
+    private static byte[] replayPayload(Delivery source) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("event", source.event());
+        body.put("task_name", source.taskName());
+        body.put("job_id", source.jobId());
+        body.put("replay_of", source.id());
+        return encode(body);
+    }
+
+    private static byte[] encode(Map<String, Object> body) {
         try {
             return JSON.writeValueAsBytes(body);
         } catch (Exception e) {

--- a/sdks/java/src/main/java/org/byteveda/taskito/webhooks/WebhookUpdate.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/webhooks/WebhookUpdate.java
@@ -1,0 +1,91 @@
+package org.byteveda.taskito.webhooks;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A partial webhook edit. Every field is nullable: {@code null} leaves the
+ * corresponding webhook field unchanged, while a provided value replaces it
+ * wholesale (for {@code events} and {@code headers} the whole collection is
+ * swapped, not merged). Consumed by {@link WebhookManager#update}.
+ */
+public record WebhookUpdate(
+        String url,
+        List<String> events,
+        String taskFilter,
+        Map<String, String> headers,
+        String secret,
+        Integer maxRetries,
+        Long timeoutMs,
+        Boolean enabled,
+        String description) {
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** Fluent builder so callers set only the fields they intend to change. */
+    public static final class Builder {
+        private String url;
+        private List<String> events;
+        private String taskFilter;
+        private Map<String, String> headers;
+        private String secret;
+        private Integer maxRetries;
+        private Long timeoutMs;
+        private Boolean enabled;
+        private String description;
+
+        private Builder() {}
+
+        public Builder url(String url) {
+            this.url = url;
+            return this;
+        }
+
+        public Builder events(List<String> events) {
+            this.events = events;
+            return this;
+        }
+
+        public Builder taskFilter(String taskFilter) {
+            this.taskFilter = taskFilter;
+            return this;
+        }
+
+        public Builder headers(Map<String, String> headers) {
+            this.headers = headers;
+            return this;
+        }
+
+        public Builder secret(String secret) {
+            this.secret = secret;
+            return this;
+        }
+
+        public Builder maxRetries(Integer maxRetries) {
+            this.maxRetries = maxRetries;
+            return this;
+        }
+
+        public Builder timeoutMs(Long timeoutMs) {
+            this.timeoutMs = timeoutMs;
+            return this;
+        }
+
+        public Builder enabled(Boolean enabled) {
+            this.enabled = enabled;
+            return this;
+        }
+
+        public Builder description(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public WebhookUpdate build() {
+            return new WebhookUpdate(
+                    url, events, taskFilter, headers, secret, maxRetries, timeoutMs, enabled, description);
+        }
+    }
+}

--- a/sdks/java/src/main/java/org/byteveda/taskito/webhooks/WebhookUrlValidator.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/webhooks/WebhookUrlValidator.java
@@ -1,0 +1,170 @@
+package org.byteveda.taskito.webhooks;
+
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.UnknownHostException;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import org.byteveda.taskito.errors.WebhookException;
+
+/**
+ * Outbound URL safety check for dashboard-configured webhooks (SSRF guard).
+ *
+ * <p>An operator who can write to the settings store could otherwise point a
+ * webhook at {@code http://169.254.169.254/...} and turn the worker into an SSRF
+ * proxy for cloud metadata, loopback services, or the RFC1918 intranet. We
+ * refuse to deliver to loopback, link-local, RFC1918, CGNAT, and ULA addresses
+ * by default. Set {@code TASKITO_WEBHOOKS_ALLOW_PRIVATE} (truthy) to disable the
+ * guard for local development against {@code http://localhost}.
+ *
+ * <p>Mirrors the cross-SDK {@code validate_webhook_url} contract. Java's
+ * {@link InetAddress} lacks the CGNAT / ULA / IPv4-mapped-IPv6 predicates the
+ * reference relies on implicitly, so those three ranges are checked by hand.
+ */
+public final class WebhookUrlValidator {
+    private static final String ALLOW_ENV_VAR = "TASKITO_WEBHOOKS_ALLOW_PRIVATE";
+
+    // Names that never leave this host regardless of DNS, which a raw IP check
+    // (run only after resolution) would otherwise miss for unresolvable names.
+    private static final Set<String> BLOCKED_HOSTNAMES =
+            Set.of("localhost", "localhost.localdomain", "ip6-localhost", "ip6-loopback");
+    private static final List<String> BLOCKED_SUFFIXES =
+            List.of(".localhost", ".local", ".internal", ".intranet", ".lan", ".private");
+
+    private WebhookUrlValidator() {}
+
+    /** Validate {@code url}, reading the allow-private bypass from the environment. */
+    public static void validate(String url) {
+        validate(url, allowPrivateFromEnv());
+    }
+
+    /**
+     * Validate {@code url}, rejecting private/loopback destinations unless
+     * {@code allowPrivate}. The {@code allowPrivate} seam keeps tests independent
+     * of process environment.
+     *
+     * @throws WebhookException on a non-http(s) scheme, a missing host, an
+     *     unresolvable host, or a host that resolves to an unsafe address.
+     */
+    public static void validate(String url, boolean allowPrivate) {
+        URI uri;
+        try {
+            uri = URI.create(url);
+        } catch (IllegalArgumentException e) {
+            throw new WebhookException("webhook URL is not a valid URI");
+        }
+        String scheme = uri.getScheme();
+        if (scheme == null || !(scheme.equalsIgnoreCase("http") || scheme.equalsIgnoreCase("https"))) {
+            throw new WebhookException("webhook URL scheme must be http or https");
+        }
+        String host = uri.getHost();
+        if (host == null || host.isEmpty()) {
+            throw new WebhookException("webhook URL must include a host");
+        }
+
+        // Scheme/host are validated even when the guard is bypassed, matching the
+        // reference: an operator gets the same "bad URL" feedback either way.
+        if (allowPrivate) {
+            return;
+        }
+
+        String bareHost = stripBrackets(host);
+        if (isBlockedHostname(bareHost)) {
+            throw new WebhookException("webhook URL host resolves to a private network");
+        }
+
+        InetAddress[] addresses;
+        try {
+            addresses = InetAddress.getAllByName(bareHost);
+        } catch (UnknownHostException e) {
+            throw new WebhookException("could not resolve webhook host");
+        }
+        for (InetAddress address : addresses) {
+            if (isBlockedAddress(address)) {
+                throw new WebhookException("webhook URL resolves to a private or loopback address");
+            }
+        }
+    }
+
+    private static boolean allowPrivateFromEnv() {
+        return isTruthy(System.getenv(ALLOW_ENV_VAR));
+    }
+
+    /** Truthy = non-empty and not one of the common falsy strings. */
+    static boolean isTruthy(String value) {
+        if (value == null) {
+            return false;
+        }
+        String normalized = value.trim().toLowerCase(Locale.ROOT);
+        return !(normalized.isEmpty()
+                || normalized.equals("0")
+                || normalized.equals("false")
+                || normalized.equals("no")
+                || normalized.equals("off"));
+    }
+
+    /** {@code URI.getHost} keeps the brackets around IPv6 literals; strip them for resolution. */
+    private static String stripBrackets(String host) {
+        if (host.length() >= 2 && host.charAt(0) == '[' && host.charAt(host.length() - 1) == ']') {
+            return host.substring(1, host.length() - 1);
+        }
+        return host;
+    }
+
+    private static boolean isBlockedHostname(String host) {
+        String lowered = host.toLowerCase(Locale.ROOT);
+        if (BLOCKED_HOSTNAMES.contains(lowered)) {
+            return true;
+        }
+        for (String suffix : BLOCKED_SUFFIXES) {
+            if (lowered.endsWith(suffix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isBlockedAddress(InetAddress address) {
+        if (address.isLoopbackAddress()
+                || address.isAnyLocalAddress()
+                || address.isLinkLocalAddress()
+                || address.isSiteLocalAddress()
+                || address.isMulticastAddress()) {
+            return true;
+        }
+        byte[] bytes = address.getAddress();
+        if (bytes.length == 16) {
+            // IPv6 unique-local addresses fc00::/7 (first byte 1111110x).
+            if ((bytes[0] & 0xFE) == 0xFC) {
+                return true;
+            }
+            // IPv4-mapped IPv6 (::ffff:a.b.c.d): re-check the embedded v4. Most JVMs
+            // already fold these to an Inet4Address, but a raw 16-byte form can slip
+            // through, so unwrap defensively.
+            if (isV4Mapped(bytes)) {
+                byte[] v4 = {bytes[12], bytes[13], bytes[14], bytes[15]};
+                try {
+                    return isBlockedAddress(InetAddress.getByAddress(v4)) || isCgnat(v4);
+                } catch (UnknownHostException e) {
+                    return true;
+                }
+            }
+        }
+        return bytes.length == 4 && isCgnat(bytes);
+    }
+
+    private static boolean isV4Mapped(byte[] bytes) {
+        for (int i = 0; i < 10; i++) {
+            if (bytes[i] != 0) {
+                return false;
+            }
+        }
+        return (bytes[10] & 0xFF) == 0xFF && (bytes[11] & 0xFF) == 0xFF;
+    }
+
+    /** Carrier-grade NAT 100.64.0.0/10 (first octet 100, second octet 64-127). */
+    private static boolean isCgnat(byte[] v4) {
+        return (v4[0] & 0xFF) == 100 && (v4[1] & 0xC0) == 0x40;
+    }
+}

--- a/sdks/java/src/test/java/org/byteveda/taskito/dashboard/DashboardWebhookTest.java
+++ b/sdks/java/src/test/java/org/byteveda/taskito/dashboard/DashboardWebhookTest.java
@@ -1,0 +1,90 @@
+package org.byteveda.taskito.dashboard;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.http.HttpResponse;
+import java.nio.file.Path;
+import java.util.Map;
+import org.byteveda.taskito.Taskito;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+/** End-to-end coverage of the webhook dashboard surface: CRUD, rotate, deliveries, and secret safety. */
+@Timeout(30)
+class DashboardWebhookTest {
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> parse(String body) throws Exception {
+        return JSON.readValue(body, Map.class);
+    }
+
+    @Test
+    void webhookLifecycleNeverLeaksSecrets(@TempDir Path dir) throws Exception {
+        try (Taskito queue =
+                        Taskito.builder().sqlite(dir.resolve("t.db").toString()).open();
+                DashboardServer server = DashboardServer.start(queue, 0)) {
+            DashboardClient client = new DashboardClient(server.port()).as(DashboardClient.seedAdmin(queue));
+
+            // Create — the response reveals the secret exactly once and masks header values.
+            String createBody = "{\"url\":\"https://example.com/hook\",\"events\":[\"success\"],"
+                    + "\"generate_secret\":true,\"headers\":{\"X-Api-Key\":\"topsecret\"}}";
+            HttpResponse<String> created = client.post("/api/webhooks", createBody);
+            assertEquals(200, created.statusCode());
+            Map<String, Object> createdJson = parse(created.body());
+            String id = (String) createdJson.get("id");
+            assertNotNull(id);
+            assertEquals(Boolean.TRUE, createdJson.get("has_secret"));
+            String secret = (String) createdJson.get("secret");
+            assertNotNull(secret);
+            assertFalse(secret.isEmpty());
+            assertEquals("***", ((Map<?, ?>) createdJson.get("headers")).get("X-Api-Key"));
+
+            // List — the hook is present, the raw secret and header value NEVER leak.
+            HttpResponse<String> list = client.get("/api/webhooks");
+            assertEquals(200, list.statusCode());
+            assertTrue(list.body().contains(id));
+            assertTrue(list.body().contains("\"has_secret\":true"));
+            assertFalse(list.body().contains("\"secret\""));
+            assertFalse(list.body().contains("topsecret"));
+            assertFalse(list.body().contains(secret));
+
+            // Get — same masking; the header value is ***.
+            HttpResponse<String> got = client.get("/api/webhooks/" + id);
+            assertEquals(200, got.statusCode());
+            Map<String, Object> gotJson = parse(got.body());
+            assertNull(gotJson.get("secret"));
+            assertEquals("***", ((Map<?, ?>) gotJson.get("headers")).get("X-Api-Key"));
+
+            // Update — disable it.
+            HttpResponse<String> updated = client.put("/api/webhooks/" + id, "{\"enabled\":false}");
+            assertEquals(200, updated.statusCode());
+            assertEquals(Boolean.FALSE, parse(updated.body()).get("enabled"));
+
+            // Rotate — a fresh secret is returned once, and it differs from the original.
+            HttpResponse<String> rotated = client.post("/api/webhooks/" + id + "/rotate-secret", "{}");
+            assertEquals(200, rotated.statusCode());
+            String rotatedSecret = (String) parse(rotated.body()).get("secret");
+            assertNotNull(rotatedSecret);
+            assertNotEquals(secret, rotatedSecret);
+
+            // Deliveries — an empty log is a 200 array.
+            HttpResponse<String> deliveries = client.get("/api/webhooks/" + id + "/deliveries");
+            assertEquals(200, deliveries.statusCode());
+            assertEquals("[]", deliveries.body());
+
+            // Delete — then the hook is gone.
+            HttpResponse<String> deleted = client.delete("/api/webhooks/" + id);
+            assertEquals(200, deleted.statusCode());
+            assertTrue(deleted.body().contains("\"deleted\":true"));
+            assertEquals(404, client.get("/api/webhooks/" + id).statusCode());
+        }
+    }
+}

--- a/sdks/java/src/test/java/org/byteveda/taskito/webhooks/DeliveryStoreTest.java
+++ b/sdks/java/src/test/java/org/byteveda/taskito/webhooks/DeliveryStoreTest.java
@@ -1,0 +1,68 @@
+package org.byteveda.taskito.webhooks;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.List;
+import org.byteveda.taskito.Taskito;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+/** The per-subscription delivery log: newest-first paging, filtering, FIFO cap, and clear. */
+@Timeout(30)
+class DeliveryStoreTest {
+
+    private static Delivery delivery(String sub, String event, String status) {
+        return Delivery.of(sub, new DeliveryContext(event, "task", "job"), status, 1, 200, "ok", 5L, null);
+    }
+
+    @Test
+    void recordsNewestFirstAndFilters(@TempDir Path dir) throws Exception {
+        try (Taskito queue =
+                Taskito.builder().sqlite(dir.resolve("t.db").toString()).open()) {
+            DeliveryStore store = new DeliveryStore(queue);
+            store.record(delivery("sub", "success", "delivered"));
+            store.record(delivery("sub", "retry", "failed"));
+
+            List<Delivery> all = store.listFor("sub", null, null, 50, 0);
+            assertEquals(2, all.size());
+            assertEquals("retry", all.get(0).event()); // newest first
+
+            assertEquals(1, store.listFor("sub", "failed", null, 50, 0).size());
+            assertEquals(1, store.listFor("sub", null, "success", 50, 0).size());
+            assertTrue(store.listFor("sub", "dead", null, 50, 0).isEmpty());
+
+            String newestId = all.get(0).id();
+            assertTrue(store.get("sub", newestId).isPresent());
+            assertTrue(store.get("sub", "missing").isEmpty());
+        }
+    }
+
+    @Test
+    void capsAtTwoHundredDroppingOldest(@TempDir Path dir) throws Exception {
+        try (Taskito queue =
+                Taskito.builder().sqlite(dir.resolve("t.db").toString()).open()) {
+            DeliveryStore store = new DeliveryStore(queue);
+            Delivery oldest = delivery("sub", "success", "delivered");
+            store.record(oldest);
+            for (int i = 0; i < 205; i++) {
+                store.record(delivery("sub", "success", "delivered"));
+            }
+            assertEquals(200, store.listFor("sub", null, null, 500, 0).size());
+            assertTrue(store.get("sub", oldest.id()).isEmpty()); // evicted by the FIFO cap
+        }
+    }
+
+    @Test
+    void deleteForClearsTheLog(@TempDir Path dir) throws Exception {
+        try (Taskito queue =
+                Taskito.builder().sqlite(dir.resolve("t.db").toString()).open()) {
+            DeliveryStore store = new DeliveryStore(queue);
+            store.record(delivery("sub", "success", "delivered"));
+            store.deleteFor("sub");
+            assertTrue(store.listFor("sub", null, null, 50, 0).isEmpty());
+        }
+    }
+}

--- a/sdks/java/src/test/java/org/byteveda/taskito/webhooks/WebhookUrlValidatorTest.java
+++ b/sdks/java/src/test/java/org/byteveda/taskito/webhooks/WebhookUrlValidatorTest.java
@@ -1,0 +1,71 @@
+package org.byteveda.taskito.webhooks;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.byteveda.taskito.errors.WebhookException;
+import org.junit.jupiter.api.Test;
+
+/** SSRF guard: private/loopback/link-local/CGNAT/ULA/IPv4-mapped targets are refused. */
+class WebhookUrlValidatorTest {
+
+    // Loopback, RFC1918, link-local (incl. cloud metadata 169.254.169.254), IPv6
+    // loopback, IPv6 ULA, IPv4-mapped-IPv6 loopback, CGNAT, and blocked names.
+    private static final List<String> BLOCKED = List.of(
+            "http://127.0.0.1/x",
+            "http://10.0.0.1/x",
+            "http://172.16.0.1/x",
+            "http://192.168.1.1/x",
+            "http://169.254.169.254/x",
+            "http://[::1]/x",
+            "http://[fc00::1]/x",
+            "http://[::ffff:127.0.0.1]/x",
+            "http://100.64.0.1/x",
+            "http://localhost/x",
+            "http://foo.local/x");
+
+    @Test
+    void rejectsPrivateAndLoopbackTargets() {
+        for (String url : BLOCKED) {
+            assertThrows(WebhookException.class, () -> WebhookUrlValidator.validate(url, false), url);
+        }
+    }
+
+    @Test
+    void allowsPublicTarget() {
+        assertDoesNotThrow(() -> WebhookUrlValidator.validate("https://example.com/hook", false));
+    }
+
+    @Test
+    void allowPrivateBypassSkipsAddressChecks() {
+        for (String url : BLOCKED) {
+            assertDoesNotThrow(() -> WebhookUrlValidator.validate(url, true), url);
+        }
+    }
+
+    @Test
+    void rejectsNonHttpSchemeEvenWhenBypassed() {
+        assertThrows(WebhookException.class, () -> WebhookUrlValidator.validate("ftp://example.com/x", true));
+    }
+
+    @Test
+    void rejectsMissingHostEvenWhenBypassed() {
+        assertThrows(WebhookException.class, () -> WebhookUrlValidator.validate("http:///x", true));
+    }
+
+    @Test
+    void truthyEnvParsing() {
+        assertTrue(WebhookUrlValidator.isTruthy("1"));
+        assertTrue(WebhookUrlValidator.isTruthy("true"));
+        assertTrue(WebhookUrlValidator.isTruthy("yes"));
+        assertFalse(WebhookUrlValidator.isTruthy(null));
+        assertFalse(WebhookUrlValidator.isTruthy(""));
+        assertFalse(WebhookUrlValidator.isTruthy("0"));
+        assertFalse(WebhookUrlValidator.isTruthy("false"));
+        assertFalse(WebhookUrlValidator.isTruthy("off"));
+        assertFalse(WebhookUrlValidator.isTruthy("no"));
+    }
+}


### PR DESCRIPTION
Rounds out the dashboard's extensibility surface: manage webhook subscriptions and inspect their delivery history from the UI.

### Subscriptions (CRUD)

`WebhookManager` gains list/get/update/delete over the settings KV; `WebhookUpdate` is the partial-patch model (URL, events, secret, enabled, headers), merge-on-write. Programmatic `create()`/`update()` stay trusted (no SSRF check — they're called from app code); only untrusted **dashboard** input is validated.

### Deliveries

`DeliveryStore` persists each attempt (status enum, response code, timestamps, error) and pages them; `Deliverer` records into it and surfaces retry/last-status. Signature stays `X-Taskito-Signature: sha256=<hex>` over the raw body.

### SSRF guard

`WebhookUrlValidator` rejects non-HTTP(S) schemes, credentials-in-URL, and hosts resolving to private / loopback / link-local / unique-local ranges — applied at the **dashboard** boundary and again **at delivery time** (guarding against DNS-rebind between save and send).

### Dashboard routes

`/api/webhooks` (list/create), `/api/webhooks/<id>` (get/update/delete), `/api/webhooks/<id>/deliveries` (paged). `Contract` maps both to the SPA's snake_case shape.

### Tests

`DashboardWebhookTest` (CRUD + deliveries round-trip), `DeliveryStoreTest`, `WebhookUrlValidatorTest` (SSRF ranges). Full Java suite + checkstyle + Spotless clean.
