### PR TITLE
docs(java): dashboard, auth, OAuth/SSO, Spring, webhooks

### DIFF
--- a/docs/content/docs/java/guides/extensibility/webhooks.mdx
+++ b/docs/content/docs/java/guides/extensibility/webhooks.mdx
@@ -61,13 +61,75 @@ async `POST` with a JSON body in snake_case:
 A send error or a `5xx` response is retried with exponential backoff (500 ms
 base, doubling, capped at 30 s) up to `maxRetries`; `4xx` responses are not
 retried. Verify the signature on your endpoint by HMAC-SHA256-ing the raw body
-with the shared secret and comparing against the `X-Taskito-Signature` header
-in constant time.
+with the shared secret's raw UTF-8 bytes and comparing against the
+`X-Taskito-Signature` header in constant time.
 
 <Callout type="info">
-  Delivery is fire-and-forget: there is no persisted per-delivery log to query
-  — final failures are logged (with the URL's path redacted). Subscriptions
-  themselves are persisted in the queue's settings store, so every process
-  sharing the backend sees the same hooks; changes propagate to running
-  workers within 30 seconds.
+  Every attempt — successful or not — is recorded in a persistent,
+  per-subscription delivery log (see [Dashboard
+  management](#dashboard-management) below); final failures are also logged
+  server-side (with the URL's path redacted). Subscriptions themselves are
+  persisted in the queue's settings store, so every process sharing the
+  backend sees the same hooks; changes propagate to running workers within 30
+  seconds.
 </Callout>
+
+## SSRF guard
+
+Webhook URLs are vetted by `WebhookUrlValidator` before dashboard-submitted
+subscriptions are stored, and **every delivery re-validates the URL right
+before sending** — regardless of how the subscription was created — so a
+hostname that starts safe and is later rebound to an internal address (DNS
+rebinding) is still refused. Blocked by default:
+
+- Non-`http`/`https` schemes
+- `localhost` and `*.localhost` / `*.local` / `*.internal` / `*.intranet` /
+  `*.lan` / `*.private`
+- Any address that resolves to loopback, link-local, RFC1918 (site-local),
+  multicast, carrier-grade NAT (`100.64.0.0/10`), or IPv6 unique-local
+  (`fc00::/7`) — including cloud metadata endpoints like `169.254.169.254`
+  (link-local)
+
+Set `TASKITO_WEBHOOKS_ALLOW_PRIVATE` (`1`/`true`/`yes`/`on`) to lift the guard
+for local development against `http://localhost`. Keep it unset in
+production.
+
+<Callout type="warning">
+  `WebhookManager.create(...)` called directly from your own code is trusted
+  developer input and is <b>not</b> pre-validated at creation time — only
+  dashboard-submitted URLs are checked at creation. Every delivery, from
+  either surface, is always re-validated regardless.
+</Callout>
+
+## Dashboard management
+
+The same subscriptions this page describes are also manageable from the
+dashboard's Webhooks page, or directly over its REST API — full CRUD,
+delivery history, secret rotation, and a synchronous test-ping. It's the same
+`WebhookManager` under the hood (`WebhookManager.forQueue`, backed by the
+queue's settings store), so changes from either surface are immediately
+visible to every process sharing the backend.
+
+| Method · Path | Effect |
+|---|---|
+| `GET /api/webhooks` · `/{id}` | List / fetch subscriptions. Header values and the secret are masked — only a `has_secret` flag is returned. |
+| `POST /api/webhooks` | Create. Same fields as the builder, plus `generate_secret: true` to mint one server-side. |
+| `PUT /api/webhooks/{id}` | Partial update — only included fields change. |
+| `DELETE /api/webhooks/{id}` | Delete the subscription and its delivery log. |
+| `POST /api/webhooks/{id}/test` | Synchronously deliver a synthetic `test` event (single attempt, no retry) and record the outcome. |
+| `POST /api/webhooks/{id}/rotate-secret` | Mint a fresh secret and persist it. |
+| `GET /api/webhooks/{id}/deliveries` | Paged delivery log — `?status=&event=&limit=&offset=` (max 200). |
+| `GET /api/webhooks/{id}/deliveries/{deliveryId}` | A single delivery. |
+| `POST /api/webhooks/{id}/deliveries/{deliveryId}/replay` | Re-fire a stored payload as a fresh delivery (single attempt); the original record is kept. |
+
+The raw secret is returned exactly once — on `create` (when set or
+generated) and on `rotate-secret` — never on `list`/`get`.
+
+### Delivery history
+
+Each subscription keeps its most recent 200 deliveries in a FIFO log
+(`webhooks:deliveries:<subscriptionId>` in the settings store), newest-first
+when paged. Each record carries the event type, `status`
+(`delivered`/`failed`), attempt count, response code, a response body
+truncated to 2 KiB, latency, and any transport error — enough to debug a
+failing endpoint without leaving the dashboard.

--- a/docs/content/docs/java/guides/integrations/spring.mdx
+++ b/docs/content/docs/java/guides/integrations/spring.mdx
@@ -68,3 +68,35 @@ Taskito taskito(TaskitoProperties properties) {
   example in an `ApplicationRunner` or a `SmartLifecycle` bean) and register
   your handlers on it.
 </Callout>
+
+## Dashboard auto-configuration
+
+Set `taskito.dashboard.enabled=true` to auto-start a
+[`DashboardServer`](/java/guides/operations/dashboard) bean over the
+`Taskito` bean. It's stopped with the application context
+(`destroyMethod = "close"`) and backs off (`@ConditionalOnMissingBean`) if you
+define your own `DashboardServer` bean.
+
+```yaml
+taskito:
+  url: postgres://localhost/taskito
+  dashboard:
+    enabled: true
+    port: 8080
+    # token: ${DASH_TOKEN:}       # omit for session auth (default); set to use legacy shared-token mode
+    # static-dir: /opt/taskito/dashboard-static
+    # secure-cookies: true       # false drops the Secure cookie attribute for local HTTP
+```
+
+| Property | Type | Default | Description |
+|---|---|---|---|
+| `taskito.dashboard.enabled` | `boolean` | `false` | Auto-start the dashboard server |
+| `taskito.dashboard.port` | `int` | `8080` | Bind port (`0` for ephemeral) |
+| `taskito.dashboard.token` | `String` | none | Legacy shared token gating `/api/*`; unset enables [session auth](/java/guides/operations/dashboard#session-auth-default) |
+| `taskito.dashboard.static-dir` | `String` | auto-discovered | Directory of a prebuilt SPA, overriding the jar's extracted copy |
+| `taskito.dashboard.secure-cookies` | `boolean` | `true` | Drop the `Secure` cookie attribute for local HTTP development |
+
+OAuth/OIDC env vars (`TASKITO_DASHBOARD_OAUTH_*`, see
+[SSO](/java/guides/operations/sso)) and the admin bootstrap
+(`TASKITO_DASHBOARD_ADMIN_USER`/`_PASSWORD`) are read the same way regardless
+of Spring — they aren't Spring properties.

--- a/docs/content/docs/java/guides/operations/dashboard.mdx
+++ b/docs/content/docs/java/guides/operations/dashboard.mdx
@@ -178,7 +178,7 @@ the same contract the bundled SPA consumes. All paths below are relative to
 
 | Group | Routes |
 |---|---|
-| Auth | `auth/status`, `/setup`, `/login`, `/logout`, `/whoami`, `/change-password`, `/providers`, `/oauth/start/{slot}`, `/oauth/callback/{slot}` — see [SSO](/java/guides/operations/sso) |
+| Auth | `auth/status`, `auth/setup`, `auth/login`, `auth/logout`, `auth/whoami`, `auth/change-password`, `auth/providers`, `auth/oauth/start/{slot}`, `auth/oauth/callback/{slot}` — see [SSO](/java/guides/operations/sso) |
 | Stats & jobs | `stats`, `stats/queues`, `queues/paused`, `jobs` (+ `/{id}`, `/{id}/logs`, `/{id}/replay-history`, `/{id}/dag`, `/{id}/cancel`, `/{id}/replay`) |
 | Dead letters | `dead-letters` (+ `/{id}/retry`) |
 | Metrics & logs | `metrics`, `metrics/timeseries`, `logs` |

--- a/docs/content/docs/java/guides/operations/dashboard.mdx
+++ b/docs/content/docs/java/guides/operations/dashboard.mdx
@@ -1,10 +1,15 @@
 ---
 title: Dashboard
-description: "Serve the bundled web dashboard and its REST API from a Java process."
+description: "Serve the bundled web dashboard and its REST API — session auth, OAuth/SSO, and legacy token mode."
 ---
 
 The jar bundles the web dashboard SPA; `DashboardServer` serves it plus a JSON
 REST API over the queue — no separate service, no asset build step.
+
+## Starting the dashboard
+
+<Tabs items={["Programmatic", "Taskito.dashboard()", "CLI"]}>
+  <Tab value="Programmatic">
 
 ```java
 try (Taskito taskito = Taskito.builder().sqlite("taskito.db").open();
@@ -14,41 +19,126 @@ try (Taskito taskito = Taskito.builder().sqlite("taskito.db").open();
 }
 ```
 
-Or from the [CLI](/java/guides/operations/cli):
+`DashboardServer.start(queue, port)` opens in [session-auth
+mode](#session-auth-default). `start(queue, port, token)` switches to
+[legacy shared-token mode](#legacy-shared-token-mode); four- and five-argument
+overloads add an unpacked SPA directory and a `secureCookies` flag.
+
+  </Tab>
+  <Tab value="Taskito.dashboard()">
+
+```java
+try (Taskito taskito = Taskito.builder().sqlite("taskito.db").open();
+        DashboardServer server = taskito.dashboard(8080)) {
+    // ...
+}
+
+// Legacy shared-token mode, gating /api/* as a fixed admin identity:
+taskito.dashboard(8080, System.getenv("DASH_TOKEN"));
+```
+
+`Taskito.dashboard(port)` / `dashboard(port, token)` are convenience defaults
+over `DashboardServer.start(...)` for the common case — one fewer import.
+
+  </Tab>
+  <Tab value="CLI">
 
 ```bash
 taskito --url taskito.db dashboard --port 8080
 ```
 
+| Flag | Default | Description |
+|---|---|---|
+| `--port` | `8080` | Bind port (`0` for ephemeral) |
+| `--token` | none | Legacy shared token gating `/api/*` — disables session auth and OAuth |
+| `--static` | bundled SPA | Directory of a prebuilt SPA, overriding the jar's extracted copy |
+| `--insecure-cookies` | off | Drop the `Secure` cookie attribute — for local HTTP development |
+
+  </Tab>
+</Tabs>
+
 Pass `0` as the port for an ephemeral one (`server.port()` reports what was
 bound). The SPA is extracted from the jar to a per-user, content-addressed
 directory on first use; `-Dtaskito.dashboard.dir=/path` (or the `staticDir`
-argument) overrides it with an unpacked build. Without bundled assets only
-`/api/*` responds.
+argument / `--static`) overrides it with an unpacked build. Without bundled
+assets only `/api/*` responds.
 
-## REST API
-
-Everything is JSON, fields in snake_case, timestamps in Unix milliseconds.
-
-| Method · Path | Effect |
-|---|---|
-| `GET /api/stats` | Counts by status across all queues. |
-| `GET /api/stats/queues` | Counts per queue. |
-| `GET /api/queues/paused` | Names of paused queues. |
-| `GET /api/jobs` | Job list — `?status=&queue=&task=&limit=&offset=`. |
-| `GET /api/jobs/{id}` | A single job. |
-| `GET /api/dead-letters` | Dead-letter entries — `?limit=&offset=`. |
-| `GET /api/metrics` | Per-execution metrics — `?task=&since=` (ms window). |
-| `GET /api/workers` | Registered workers + heartbeats. |
-| `GET /api/auth/status` | `{ "auth_required": true\|false }` — never needs a token. |
-| `POST /api/jobs/{id}/cancel` | Cancel a job. |
-| `POST /api/dead-letters/{id}/retry` | Re-enqueue a dead-letter entry. |
-| `POST /api/queues/{name}/pause` · `/resume` | Pause / resume a queue. |
+<Callout type="info">
+  Running Spring Boot? `taskito-spring` can auto-start a `DashboardServer` bean
+  from `taskito.dashboard.*` properties — see
+  [Spring Boot: Dashboard auto-configuration](/java/guides/integrations/spring#dashboard-auto-configuration).
+</Callout>
 
 ## Auth
 
-Auth runs **open** by default. Pass a token to require it on every `/api/*`
-request (except `/api/auth/status`):
+Two modes, chosen by whether a `token` is passed to `start(...)` /
+`dashboard(...)`.
+
+### Session auth (default)
+
+With no token, the dashboard runs password sign-in (and optionally
+[OAuth/OIDC](/java/guides/operations/sso)) with server-side sessions. Users
+and sessions live in the queue's settings key/value store — no dedicated
+tables — so the model is identical across SQLite, PostgreSQL, and Redis.
+
+- **First-run setup.** On a fresh database every route except the public set
+  (`/api/auth/status`, `/api/auth/login`, `/api/auth/setup`,
+  `/api/auth/providers`, `/health`, `/readiness`, `/metrics`) returns
+  `503 setup_required` until an admin exists. `POST /api/auth/setup` creates
+  it (and signs it in); the route locks itself after the first user.
+- **Env-admin bootstrap.** Set both `TASKITO_DASHBOARD_ADMIN_USER` and
+  `TASKITO_DASHBOARD_ADMIN_PASSWORD` before starting the process to seed the
+  first admin without visiting a browser — useful for containers. It's
+  idempotent: once a user with that name exists, later restarts skip
+  creation.
+
+  ```bash
+  export TASKITO_DASHBOARD_ADMIN_USER=admin
+  export TASKITO_DASHBOARD_ADMIN_PASSWORD='change-me-on-first-login'
+  taskito --url taskito.db dashboard --port 8080
+  ```
+
+  <Callout type="warning">
+    Unlike a scripting-language runtime, the JVM cannot scrub a variable out
+    of its own process environment once it has been read — the password
+    stays visible to anything that can inspect the process (`/proc`, a
+    debugger, a core dump) for the process's lifetime. Prefer first-run setup
+    through the SPA where that matters; treat the env var as a one-time
+    recovery path and rotate the password after logging in.
+  </Callout>
+
+- **Passwords** are hashed with PBKDF2-HMAC-SHA256 — 600,000 iterations, a
+  16-byte random salt — no third-party crypto dependency.
+- **Sessions** are opaque tokens with a 24-hour TTL, carried in an `HttpOnly`,
+  `SameSite=Strict` `taskito_session` cookie (plus `Secure` unless disabled —
+  see below).
+- **CSRF** uses the double-submit pattern: a non-HttpOnly `taskito_csrf`
+  cookie must match both the token bound to the session and the
+  `X-CSRF-Token` header on every state-changing request
+  (`POST`/`PUT`/`DELETE`/`PATCH`). `/api/auth/login` and `/api/auth/setup` are
+  exempt — there is no session yet to bind to.
+- **`--insecure-cookies`** (or `secureCookies=false` on `DashboardServer.start`,
+  or `taskito.dashboard.secure-cookies=false` in Spring) drops the `Secure`
+  cookie attribute for local HTTP development. Keep it on — the default — for
+  anything served over HTTPS.
+
+### Roles
+
+RBAC is enforced server-side and is deliberately simple: every state-changing
+route is admin-only except two self-service routes; all reads are open to any
+authenticated user.
+
+| Role | Access |
+|---|---|
+| `admin` | Full access — cancel/replay jobs, purge dead letters, pause/resume queues, manage webhooks, edit settings, edit task/queue overrides. |
+| `viewer` | Read-only, plus their own `POST /api/auth/logout` and `POST /api/auth/change-password`. Any other mutating route returns `403 forbidden`. |
+
+The first user — created via setup or env bootstrap — is always `admin`.
+
+### Legacy shared-token mode
+
+Pass a `token` to gate `/api/*` behind a single fixed credential — no users,
+no sessions, no RBAC. Kept for back-compat with the pre-auth dashboard.
 
 ```java
 DashboardServer.start(taskito, 8080, System.getenv("DASH_TOKEN"));
@@ -56,18 +146,51 @@ DashboardServer.start(taskito, 8080, System.getenv("DASH_TOKEN"));
 
 Requests authenticate with `?token=<token>`; opening `/?token=<token>` once
 sets an httpOnly `taskito_token` cookie so the SPA works for the rest of the
-session. This is a single shared token — no per-user login, RBAC, or SSO. For
-those, put the server behind a reverse proxy that handles auth.
+session. OAuth has no login UI in this mode, so it's disabled automatically —
+`start(queue, port, token, ...)` never builds an OAuth flow when `token` is
+non-null.
 
 <Callout type="warning">
   `?token=` puts the secret in the URL, where it can leak via browser history,
   `Referer` headers, and proxy or access logs. Use it only over HTTPS, redact
-  query strings from logs, and rely on the cookie afterwards — once the first
-  request sets it, the token never needs to appear in a URL again.
+  query strings from logs, and rely on the cookie afterwards.
 </Callout>
 
+## Metrics and health probes
+
+Three routes sit outside `/api/*` and outside the session/token auth gate:
+
+| Route | Access | What it does |
+|---|---|---|
+| `GET /health` | Always public | Liveness — always `{"status": "ok"}` |
+| `GET /readiness` | Public unless `TASKITO_DASHBOARD_METRICS_TOKEN` is set | Storage/worker/resource readiness |
+| `GET /metrics` | Public unless `TASKITO_DASHBOARD_METRICS_TOKEN` is set | Prometheus text exposition |
+
+Set `TASKITO_DASHBOARD_METRICS_TOKEN` to require an
+`Authorization: Bearer <token>` header (checked in constant time) on
+`/readiness` and `/metrics`. `/health` always stays open for liveness probes.
+
+## REST API
+
+Everything is JSON, fields in snake_case, timestamps in Unix milliseconds —
+the same contract the bundled SPA consumes. All paths below are relative to
+`/api/`.
+
+| Group | Routes |
+|---|---|
+| Auth | `auth/status`, `/setup`, `/login`, `/logout`, `/whoami`, `/change-password`, `/providers`, `/oauth/start/{slot}`, `/oauth/callback/{slot}` — see [SSO](/java/guides/operations/sso) |
+| Stats & jobs | `stats`, `stats/queues`, `queues/paused`, `jobs` (+ `/{id}`, `/{id}/logs`, `/{id}/replay-history`, `/{id}/dag`, `/{id}/cancel`, `/{id}/replay`) |
+| Dead letters | `dead-letters` (+ `/{id}/retry`) |
+| Metrics & logs | `metrics`, `metrics/timeseries`, `logs` |
+| Infrastructure | `workers`, `circuit-breakers`, `resources`, `scaler`, `event-types` |
+| Queue control | `queues/{name}/pause`, `queues/{name}/resume` |
+| Task/queue overrides | `tasks`, `tasks/{name}/override`, `queues`, `queues/{name}/override` — runtime rate limit, concurrency, retries, timeout, priority, and pause, without redeploying |
+| Webhooks | `webhooks` (+ `/{id}`, `/{id}/test`, `/{id}/rotate-secret`, `/{id}/deliveries`, `/{id}/deliveries/{deliveryId}`, `/{id}/deliveries/{deliveryId}/replay`) — see [Webhooks: Dashboard management](/java/guides/extensibility/webhooks#dashboard-management) |
+| Workflows | `workflows/runs` (+ `/{id}`, `/{id}/dag`, `/{id}/children`) |
+| Settings | `settings`, `settings/{key}` |
+
 <Callout type="warning">
-  Open mode means anyone who can reach the port has full control. Bind it to
-  localhost, front it with your own auth, or at minimum set a token — see
-  [Security](/java/guides/operations/security).
+  Every route above is auth-gated: session mode requires a valid session (plus
+  CSRF on writes) except the public auth routes; legacy mode requires the
+  matching token. See [Auth](#auth).
 </Callout>

--- a/docs/content/docs/java/guides/operations/meta.json
+++ b/docs/content/docs/java/guides/operations/meta.json
@@ -1,1 +1,1 @@
-{ "title": "Operations", "pages": ["backends", "inspection", "dashboard", "mesh", "autoscaling", "cli", "testing", "security", "troubleshooting", "deployment", "graalvm"] }
+{ "title": "Operations", "pages": ["backends", "inspection", "dashboard", "sso", "mesh", "autoscaling", "cli", "testing", "security", "troubleshooting", "deployment", "graalvm"] }

--- a/docs/content/docs/java/guides/operations/security.mdx
+++ b/docs/content/docs/java/guides/operations/security.mdx
@@ -36,9 +36,14 @@ secret; the signature rides in `X-Taskito-Signature: sha256=<hex>`. Verify it
 on the receiver — HMAC the raw body with the shared secret and compare in
 constant time — before trusting the body.
 
-The deliverer POSTs the configured URL directly — there is **no SSRF
-allowlist.** Only register webhook URLs you control, and validate them before
-storing if they come from users.
+Dashboard-submitted webhook URLs are checked by an SSRF guard (loopback,
+link-local, RFC1918, multicast, CGNAT, and IPv6 unique-local addresses are
+rejected by default), and every delivery re-validates the URL again right
+before sending, closing the DNS-rebinding gap. `WebhookManager.create(...)`
+called directly from your own code is trusted input and isn't pre-validated
+at creation — only at delivery time. Set `TASKITO_WEBHOOKS_ALLOW_PRIVATE` to
+disable the guard for local development. See
+[Webhooks: SSRF guard](/java/guides/extensibility/webhooks#ssrf-guard).
 
 ## Proxies
 
@@ -50,10 +55,15 @@ permits any path**, so always set roots in production.
 
 ## Dashboard
 
-The [dashboard](/java/guides/operations/dashboard) runs in **open mode** by
-default — anyone who reaches the port has full control. Start it with a token
-to gate `/api/*`, bind it to localhost, or front it with a reverse proxy that
-enforces your own auth (login / RBAC / SSO).
+The [dashboard](/java/guides/operations/dashboard) requires sign-in by
+default: on a fresh database every route except a small public set returns
+`503 setup_required` until an admin exists, and every route after that needs
+a valid session (admin/viewer RBAC, CSRF on writes) or, if configured,
+[OAuth/OIDC](/java/guides/operations/sso). Passing a `token` instead switches
+to legacy shared-token mode — no users, no sessions, no RBAC — kept for
+back-compat; anyone with the token has full control. Either way, bind the
+port to a trusted network or front it with a reverse proxy for
+defense in depth.
 
 ## Mesh gossip
 
@@ -77,6 +87,7 @@ hosts with a `noexec` `/tmp`.
 - [ ] Payloads signed or encrypted where the storage host isn't fully trusted.
 - [ ] Webhook receivers verify the HMAC signature; webhook URLs are trusted.
 - [ ] `FileProxyHandler` configured with allowlisted roots.
-- [ ] Dashboard bound to localhost, or token-gated behind your own auth.
+- [ ] Dashboard admin account created (or env-bootstrapped) on first deploy;
+      bound to a trusted network regardless of auth mode.
 - [ ] Logs don't echo sensitive payloads (redact in `onEnqueue`
       [middleware](/java/guides/extensibility/middleware)).

--- a/docs/content/docs/java/guides/operations/sso.mdx
+++ b/docs/content/docs/java/guides/operations/sso.mdx
@@ -1,0 +1,279 @@
+---
+title: SSO (OAuth & OIDC)
+description: "Sign in to the dashboard with Google, GitHub, or any OIDC provider. Domain/org allowlists, OAuth-only mode."
+---
+
+The dashboard's [session auth](/java/guides/operations/dashboard#session-auth-default)
+supports native sign-in for **Google**, **GitHub**, and any
+**OIDC-compliant** provider (Okta, Auth0, Keycloak, Microsoft Entra, Dex, …).
+Multiple OIDC providers can run side by side, each its own button on the
+login screen. OAuth is off by default — setting any provider's env vars turns
+it on, alongside password login unless you opt out.
+
+<Callout title="Optional dependency for Google and OIDC">
+  ID-token validation for Google and generic OIDC needs
+  [`com.nimbusds:nimbus-jose-jwt`](https://connect2id.com/products/nimbus-jose-jwt)
+  on the classpath (see the coordinate below). If it's absent, the dashboard
+  logs a warning and degrades to password-only auth instead of failing to
+  start. **GitHub login needs no extra dependency** — GitHub is plain OAuth2
+  (no id-token to verify), so it works with only the main artifact.
+</Callout>
+
+<Tabs items={["Gradle", "Maven"]}>
+  <Tab value="Gradle">
+
+```kotlin
+implementation("com.nimbusds:nimbus-jose-jwt:10.9.1")
+```
+
+  </Tab>
+  <Tab value="Maven">
+
+```xml
+<dependency>
+  <groupId>com.nimbusds</groupId>
+  <artifactId>nimbus-jose-jwt</artifactId>
+  <version>10.9.1</version>
+</dependency>
+```
+
+  </Tab>
+</Tabs>
+
+## How it works
+
+<Mermaid
+  chart={`sequenceDiagram
+    autonumber
+    participant B as Browser
+    participant D as Dashboard
+    participant P as Provider
+
+    B->>D: GET /api/auth/providers
+    D-->>B: { password_enabled, providers: [...] }
+
+    Note over B: user clicks "Continue with Google"
+    B->>D: GET /api/auth/oauth/start/google?next=/jobs
+    Note over D: mint state + nonce + PKCE verifier<br/>persist state row (5-min TTL, single-use)
+    D-->>B: 302 to provider authorize URL
+
+    B->>P: GET /authorize?...
+    Note over P: user consents
+    P-->>B: 302 to /api/auth/oauth/callback/google?code=...&state=...
+
+    B->>D: GET /api/auth/oauth/callback/google
+    Note over D: consume state (deleted before parsing)<br/>exchange code for tokens
+    D->>P: POST token endpoint (code + code_verifier)
+    P-->>D: { id_token, access_token }
+    Note over D: verify JWKS signature / iss / aud / exp / nonce<br/>enforce allowlist<br/>get-or-create user, create session
+    D-->>B: 302 to next<br/>Set-Cookie: taskito_session, taskito_csrf`}
+/>
+
+State is single-use — `OAuthStateStore.consume` deletes the row before
+parsing it, so a replayed callback finds nothing — and time-bounded (5-minute
+TTL). PKCE with `S256`, the OIDC nonce, and the ID-token signature (against
+the provider's JWKS) are all enforced server-side.
+
+## Quick start: Google login
+
+1. **Create an OAuth client** in the
+   [Google Cloud Console → APIs & Services → Credentials](https://console.cloud.google.com/apis/credentials)
+   (type *Web application*) and register the callback URL:
+
+   ```
+   https://taskito.your-company.com/api/auth/oauth/callback/google
+   ```
+
+   For local development, `http://localhost:8080/api/auth/oauth/callback/google`
+   works without HTTPS.
+
+2. **Set env vars** before starting the dashboard:
+
+   ```bash
+   export TASKITO_DASHBOARD_OAUTH_REDIRECT_BASE_URL=https://taskito.your-company.com
+   export TASKITO_DASHBOARD_OAUTH_GOOGLE_CLIENT_ID=...apps.googleusercontent.com
+   export TASKITO_DASHBOARD_OAUTH_GOOGLE_CLIENT_SECRET=...
+   # Restrict logins to your Google Workspace domain:
+   export TASKITO_DASHBOARD_OAUTH_GOOGLE_ALLOWED_DOMAINS=your-company.com
+   ```
+
+3. **Start the dashboard.** The login screen now shows a "Continue with
+   Google" button above the password form.
+
+## GitHub login
+
+GitHub has no OIDC id-token, so identity comes from `GET /user` and
+`GET /user/emails`; org membership is verified via
+`GET /orgs/{org}/members/{login}`.
+
+1. Create a [GitHub OAuth App](https://github.com/settings/developers). Set
+   the *Authorization callback URL* to
+   `https://taskito.your-company.com/api/auth/oauth/callback/github`.
+
+2. Env vars:
+
+   ```bash
+   export TASKITO_DASHBOARD_OAUTH_GITHUB_CLIENT_ID=Iv1.xxxxx
+   export TASKITO_DASHBOARD_OAUTH_GITHUB_CLIENT_SECRET=...
+   # Restrict logins to members of these GitHub orgs:
+   export TASKITO_DASHBOARD_OAUTH_GITHUB_ALLOWED_ORGS=your-org,partner-org
+   ```
+
+When `_ALLOWED_ORGS` is set, the requested scope automatically grows to
+include `read:org` so the membership check returns reliable results for
+private orgs.
+
+<Callout type="warning" title="Verified primary email only">
+  A GitHub account with no `primary && verified` email (from
+  `GET /user/emails`) always lands in the `viewer` role, even if listed in
+  `TASKITO_DASHBOARD_OAUTH_ADMIN_EMAILS` — an unverified email can't be
+  trusted to grant admin.
+</Callout>
+
+## Generic OIDC (Okta, Auth0, Keycloak, Microsoft, …)
+
+Generic OIDC providers are **named slots** — each gets its own callback URL,
+its own namespaced users, and its own button on the login screen.
+
+```bash
+export TASKITO_DASHBOARD_OAUTH_REDIRECT_BASE_URL=https://taskito.your-company.com
+
+# List the slots first.
+export TASKITO_DASHBOARD_OAUTH_OIDC_PROVIDERS=okta,microsoft
+
+# Then per-slot config (slot name uppercased; '-' becomes '_').
+export TASKITO_DASHBOARD_OAUTH_OIDC_OKTA_CLIENT_ID=...
+export TASKITO_DASHBOARD_OAUTH_OIDC_OKTA_CLIENT_SECRET=...
+export TASKITO_DASHBOARD_OAUTH_OIDC_OKTA_DISCOVERY_URL=https://acme.okta.com/.well-known/openid-configuration
+export TASKITO_DASHBOARD_OAUTH_OIDC_OKTA_LABEL="Acme SSO"
+export TASKITO_DASHBOARD_OAUTH_OIDC_OKTA_ALLOWED_DOMAINS=your-company.com
+
+export TASKITO_DASHBOARD_OAUTH_OIDC_MICROSOFT_CLIENT_ID=...
+export TASKITO_DASHBOARD_OAUTH_OIDC_MICROSOFT_CLIENT_SECRET=...
+export TASKITO_DASHBOARD_OAUTH_OIDC_MICROSOFT_DISCOVERY_URL=https://login.microsoftonline.com/<tenant>/v2.0/.well-known/openid-configuration
+export TASKITO_DASHBOARD_OAUTH_OIDC_MICROSOFT_LABEL="Microsoft 365"
+```
+
+The callback URL for each slot is
+`{REDIRECT_BASE_URL}/api/auth/oauth/callback/{slot}` — register that exact
+URL with the identity provider.
+
+Slot names must match `^[a-z][a-z0-9_-]{0,31}$` and can't collide with
+`google` / `github` (the built-ins). A user signing in through an OIDC slot is
+namespaced as `{slot}:{subject}`, so two providers issuing overlapping
+subject values never collide.
+
+## Role assignment for OAuth users
+
+The first time someone signs in via any provider, the dashboard decides their
+role with this precedence:
+
+1. **`TASKITO_DASHBOARD_OAUTH_ADMIN_EMAILS` match** — case-insensitive match
+   against a verified email → `admin`.
+2. **Empty user table** — if no users exist yet (password or OAuth), the
+   first OAuth user with a verified email becomes `admin`.
+3. **Everyone else** → `viewer`.
+
+```bash
+export TASKITO_DASHBOARD_OAUTH_ADMIN_EMAILS=alice@your-company.com,bob@your-company.com
+```
+
+A user's role is **not** re-evaluated on later logins — change it from the
+dashboard once created. Their email and display name refresh from each
+login's claims.
+
+## OAuth-only mode
+
+Disable password login entirely:
+
+```bash
+export TASKITO_DASHBOARD_PASSWORD_AUTH_ENABLED=false
+```
+
+Startup refuses this combination if no provider ends up configured — you'd
+have no way to log in — and falls back to password-only rather than locking
+you out. The login page hides the username/password form and renders only
+provider buttons when password auth is off and at least one provider is
+configured.
+
+## Security model
+
+| Control | Implementation |
+|---|---|
+| **PKCE** | `S256` challenge derived from a 32-byte random verifier (RFC 7636). |
+| **State** | 32-byte URL-safe random, stored server-side under `auth:oauth_state:<state>` with a 5-minute TTL. Deleted on first read — a replayed callback always fails. |
+| **Nonce** | 16-byte random, sent in the OIDC authorize request, checked against the ID-token's `nonce` claim. |
+| **ID-token signature** | Verified against the provider's JWKS, algorithm pinned to `RS256`/`ES256` — an `alg:none` or HMAC token has no matching key and is rejected. |
+| **iss / aud / exp** | All checked; 60-second clock-skew tolerance on `exp`; a multi-audience token must additionally carry `azp == client_id`. |
+| **Open redirect** | The `next` query param must be a bare rooted path (`UrlSafety.isSafeRedirect`) — no scheme, no host, no `//` or `/\` prefix. Falls back to `/`. |
+| **HTTPS required** | The redirect base URL must be `https://` unless the host is `localhost` / `127.0.0.1` / `::1`. A misconfiguration is rejected at config-parse time. |
+| **Provider tokens** | Never persisted — only the verified identity produces a Taskito session. |
+| **Cross-provider identity** | A given `(slot, subject)` always maps to one user; the same email at two different providers creates two distinct users. |
+
+## API surface
+
+| Method | Path | What it does |
+|---|---|---|
+| `GET` | `/api/auth/providers` | Public. `{password_enabled, providers: [{slot, label, type}]}` for the login UI. |
+| `GET` | `/api/auth/oauth/start/{slot}` | Public. Mints state, 302s to the provider's authorize URL. Accepts `?next=/path` (validated). |
+| `GET` | `/api/auth/oauth/callback/{slot}` | Public. Validates state, exchanges the code, enforces the allowlist, creates/refreshes the user, sets cookies, 302s to `next`. |
+
+The callback sets the same `taskito_session` + `taskito_csrf` cookies as
+password login — every other dashboard route works identically once you're
+signed in.
+
+## Troubleshooting
+
+Callback failures redirect to `/login?error=<code>` rather than rendering
+JSON:
+
+- **`oauth_state_invalid`** — the state row expired (5-minute window) or was
+  already consumed. Usually the user pressed back/refresh after the provider
+  redirected; have them restart the flow.
+- **`oauth_denied`** — the identity was fetched successfully but rejected by
+  an allowlist (`ALLOWED_DOMAINS` / `ALLOWED_ORGS`). Widen the allowlist or
+  remove it.
+- **`oauth_failed`** — token exchange, signature verification, or a claim
+  check failed. Check server logs for the underlying message (issuer
+  mismatch, expired token, missing claim, provider error).
+- **`oauth_not_configured`** (404, on `start`/`callback`) — the slot isn't
+  registered. Either the env vars weren't set, or config parsing failed at
+  startup (check for a startup warning) and OAuth degraded to disabled.
+
+**Provider button missing** — `GET /api/auth/providers` returns the list the
+login screen renders. If a provider you configured isn't there, check the
+server log at startup: a partial or invalid config (for example a Google
+client id with no matching secret) throws at parse time, which
+`DashboardServer` catches and logs as a warning, disabling OAuth entirely
+rather than failing to start.
+
+## Env var reference
+
+```bash
+# Required when any provider is configured.
+TASKITO_DASHBOARD_OAUTH_REDIRECT_BASE_URL=https://taskito.company.com
+
+# Google.
+TASKITO_DASHBOARD_OAUTH_GOOGLE_CLIENT_ID=...
+TASKITO_DASHBOARD_OAUTH_GOOGLE_CLIENT_SECRET=...
+TASKITO_DASHBOARD_OAUTH_GOOGLE_ALLOWED_DOMAINS=company.com,partner.com   # optional
+
+# GitHub.
+TASKITO_DASHBOARD_OAUTH_GITHUB_CLIENT_ID=Iv1.xxxxx
+TASKITO_DASHBOARD_OAUTH_GITHUB_CLIENT_SECRET=...
+TASKITO_DASHBOARD_OAUTH_GITHUB_ALLOWED_ORGS=org1,org2                     # optional
+
+# Generic OIDC — list slots, then configure each one.
+TASKITO_DASHBOARD_OAUTH_OIDC_PROVIDERS=okta,microsoft
+TASKITO_DASHBOARD_OAUTH_OIDC_OKTA_CLIENT_ID=...
+TASKITO_DASHBOARD_OAUTH_OIDC_OKTA_CLIENT_SECRET=...
+TASKITO_DASHBOARD_OAUTH_OIDC_OKTA_DISCOVERY_URL=https://acme.okta.com/.well-known/openid-configuration
+TASKITO_DASHBOARD_OAUTH_OIDC_OKTA_LABEL=Acme SSO                          # optional
+TASKITO_DASHBOARD_OAUTH_OIDC_OKTA_ALLOWED_DOMAINS=company.com             # optional
+
+# Role bootstrap.
+TASKITO_DASHBOARD_OAUTH_ADMIN_EMAILS=alice@company.com,bob@company.com    # optional
+
+# Disable password login (OAuth-only mode). Defaults to true.
+TASKITO_DASHBOARD_PASSWORD_AUTH_ENABLED=false                             # optional
+```

--- a/docs/content/docs/java/guides/operations/sso.mdx
+++ b/docs/content/docs/java/guides/operations/sso.mdx
@@ -190,11 +190,10 @@ Disable password login entirely:
 export TASKITO_DASHBOARD_PASSWORD_AUTH_ENABLED=false
 ```
 
-Startup refuses this combination if no provider ends up configured — you'd
-have no way to log in — and falls back to password-only rather than locking
-you out. The login page hides the username/password form and renders only
-provider buttons when password auth is off and at least one provider is
-configured.
+Startup **fails** if you disable password auth without configuring at least
+one provider — that would leave no way to log in. With password auth off and
+at least one provider configured, the login page hides the username/password
+form and renders only the provider buttons.
 
 ## Security model
 


### PR DESCRIPTION
## Docs — Java dashboard, auth, OAuth/SSO, Spring, webhooks (PR 8, final)

Documents the Java dashboard parity work shipped across #387–#397.

- **`operations/dashboard.mdx`** — session auth, first-run setup, RBAC, CSRF, legacy token mode, settings/overrides, metrics, probes, and the REST surface.
- **`operations/sso.mdx`** (new) — OAuth/OIDC setup for Google, GitHub, and generic OIDC providers; PKCE, id-token validation, allowlists, `next` handling; added to the operations nav.
- **`integrations/spring.mdx`** — `TaskitoDashboardAutoConfiguration` + `taskito.dashboard.*` properties and `Taskito.dashboard()`.
- **`extensibility/webhooks.mdx`** — subscription CRUD, delivery history, signature, and the SSRF guard.
- **`operations/security.mdx`** — webhook signing + SSRF notes.

### Verification

`biome check` + `typecheck` clean; full docs build succeeds (the new SSO page prerenders). No sibling-SDK names in the Java docs (cross-SDK independence).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new SSO operations guide covering OAuth2/OIDC setup, security model, and login flow behavior.
  * Expanded dashboard documentation with Spring Boot auto-configuration and detailed startup/auth mode descriptions (session auth vs legacy shared-token).
  * Updated the operations guide index to include the new SSO page.

* **Documentation**
  * Clarified webhook delivery logging (persistent per-subscription history), replay/secret rotation behavior, and SSRF safeguards with URL re-validation at delivery time.
  * Rewrote dashboard security and API/probe access rules, including `setup_required` gating, RBAC/CSRF requirements, and metrics token checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->