### PR TITLE
docs: fix SDK root 404, breadcrumb link, callout icons

### DIFF
--- a/docs/app/lib/redirects.ts
+++ b/docs/app/lib/redirects.ts
@@ -17,15 +17,19 @@ const ARCH_PAGES = [
   "serialization",
 ];
 
+const SDKS = ["node", "python", "java"];
+
 // Sections that have child pages but no landing/index page. A bare hit on the
 // section URL (e.g. from a breadcrumb crumb or an external link) would otherwise
-// 404, so send it to the section's first page.
-const SECTION_LANDINGS = ["node", "python", "java"].map(
-  (sdk): [string, string] => [
-    `/${sdk}/getting-started`,
-    `/${sdk}/getting-started/installation`,
-  ],
-);
+// 404, so send it to the section's first page. This covers both the bare SDK
+// root (`/python`) and its getting-started section (`/python/getting-started`).
+const SECTION_LANDINGS = SDKS.flatMap((sdk): [string, string][] => {
+  const first = `/${sdk}/getting-started/installation`;
+  return [
+    [`/${sdk}`, first],
+    [`/${sdk}/getting-started`, first],
+  ];
+});
 
 export const REDIRECTS: Record<string, string> = {
   ...Object.fromEntries(

--- a/docs/app/routes/docs.$.tsx
+++ b/docs/app/routes/docs.$.tsx
@@ -6,6 +6,7 @@ import { mdxComponents } from "@/components/mdx";
 import { getDocLoader } from "@/lib/content";
 import { docMeta } from "@/lib/manifest";
 import { redirectFor } from "@/lib/redirects";
+import { isSdk } from "@/lib/sdk-registry";
 import type { Route } from "./+types/docs.$";
 
 function pathOf(params: { "*"?: string }): string {
@@ -23,13 +24,19 @@ function Breadcrumb({ path }: { path: string }) {
     const label =
       docMeta(href)?.title ??
       seg.replace(/-/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
-    return { href, label };
+    // The SDK root (e.g. `/python`) has no page of its own — it only redirects
+    // to the first doc — so render it as a plain label, not a link.
+    return { href, label, linked: !(i === 0 && isSdk(seg)) };
   });
   return (
     <div className="crumb">
       {crumbs.map((c) => (
         <Fragment key={c.href}>
-          <Link to={c.href}>{c.label}</Link>
+          {c.linked ? (
+            <Link to={c.href}>{c.label}</Link>
+          ) : (
+            <span className="crumb-root">{c.label}</span>
+          )}
           <span className="sep">/</span>
         </Fragment>
       ))}

--- a/docs/app/styles/docs.css
+++ b/docs/app/styles/docs.css
@@ -295,6 +295,9 @@ body {
 .crumb a:hover {
   color: var(--mut);
 }
+.crumb-root {
+  cursor: default;
+}
 .crumb .sep {
   opacity: 0.5;
 }

--- a/docs/content/docs/architecture/storage.mdx
+++ b/docs/content/docs/architecture/storage.mdx
@@ -19,7 +19,7 @@ queue, rate limits, periodic tasks, and worker heartbeats.
 
 <SchemaGrid />
 
-<Callout>
+<Callout type="info">
   **Relationships:** `jobs` → `job_errors` (1 ─ \*, error history) and `jobs` →
   `dead_letter` (1 ─ 0..1, DLQ on retry exhaustion).
 </Callout>

--- a/docs/content/docs/java/guides/operations/sso.mdx
+++ b/docs/content/docs/java/guides/operations/sso.mdx
@@ -10,7 +10,7 @@ Multiple OIDC providers can run side by side, each its own button on the
 login screen. OAuth is off by default — setting any provider's env vars turns
 it on, alongside password login unless you opt out.
 
-<Callout title="Optional dependency for Google and OIDC">
+<Callout title="Optional dependency for Google and OIDC" type="info">
   ID-token validation for Google and generic OIDC needs
   [`com.nimbusds:nimbus-jose-jwt`](https://connect2id.com/products/nimbus-jose-jwt)
   on the classpath (see the coordinate below). If it's absent, the dashboard

--- a/docs/content/docs/python/getting-started/installation.mdx
+++ b/docs/content/docs/python/getting-started/installation.mdx
@@ -5,7 +5,7 @@ description: "Install taskito and prepare your environment."
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-<Callout title="New to taskito?">
+<Callout title="New to taskito?" type="info">
   See [**Capabilities at a glance**](/python/getting-started/capabilities) for everything taskito does —
   workflows, retries, the dashboard, prefork pools — each with a link to its guide.
 </Callout>

--- a/docs/content/docs/python/guides/dashboard/sso.mdx
+++ b/docs/content/docs/python/guides/dashboard/sso.mdx
@@ -23,7 +23,7 @@ Quick glossary for the acronyms used on this page:
 - **nonce** — a one-time value that ties a login response to your request
 - **aud** / **iss** — the audience and issuer claims in the ID token
 
-<Callout title="Optional dependency">
+<Callout title="Optional dependency" type="info">
   OAuth requires the `authlib` extra:
 
   ```bash


### PR DESCRIPTION
Three docs-site fixes reported after #400.

## Bare SDK root 404'd

Visiting \`/python\` (and \`/node\`, \`/java\`) hit **Page not found** — the SDK root has no page of its own, and only the \`/{sdk}/getting-started\` section landing was in the redirect map. Added the bare SDK root to the same landing map, so it redirects to \`getting-started/installation\`. Verified in the prerendered stub (\`build/client/python/index.html\` meta-refreshes to the installation page).

## SDK breadcrumb was a dead link

The leading breadcrumb crumb (e.g. **Python**) linked to that same redirect-only SDK root. It now renders as a plain label — the rest of the trail stays clickable.

## Inconsistent callout icons

Four callouts omitted \`type=\`, so they fell back to the neutral default variant and their icon/border differed from every other info callout (191 use \`type="info"\`). Set \`type="info"\` on all four (`installation`, two `sso` pages, `architecture/storage`).

## Verification

- \`pnpm run typecheck\` and \`biome check\` clean
- \`pnpm build\` — prerender emits the \`/python\`, \`/node\`, \`/java\` redirect stubs; breadcrumb renders \`<span class="crumb-root">Python</span>\` (non-link)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added redirects from SDK root pages to their installation guides.
  - Improved SDK breadcrumbs by displaying the root SDK name as non-clickable text.

- **Documentation**
  - Updated several guidance callouts to use consistent informational styling.
  - Clarified installation, storage schema, and SSO documentation presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->