### PR TITLE
docs: unify guide subsection overviews on card grids

### DIFF
--- a/docs/content/docs/java/guides/core/index.mdx
+++ b/docs/content/docs/java/guides/core/index.mdx
@@ -5,15 +5,55 @@ description: "The building blocks of every Java taskito application."
 
 The building blocks of every taskito application.
 
-| Guide | Description |
-|---|---|
-| [Tasks](/java/guides/core/tasks) | Describe tasks with `Task.of()`, configure retries, timeouts, and options |
-| [Queues & Priority](/java/guides/core/queues) | Named queues, priority levels, and routing |
-| [Workers](/java/guides/core/workers) | Start workers, control concurrency, graceful shutdown |
-| [Execution Models](/java/guides/core/execution-model) | How tasks move from enqueue to completion |
-| [Enqueue options](/java/guides/core/enqueue-options) | Per-job delay, priority, uniqueness, and metadata |
-| [Batching](/java/guides/core/batching) | Producer-side `Batcher`/`enqueueMany` and worker-side `batchSize` |
-| [Predicates](/java/guides/core/predicates) | Gate an enqueue on a runtime condition |
-| [Scheduling](/java/guides/core/scheduling) | Periodic tasks with cron expressions |
-| [Cancellation](/java/guides/core/cancellation) | Cancel queued and in-flight jobs |
-| [Streaming partial results](/java/guides/core/streaming) | Emit progress from a running task |
+<Cards>
+  <Card
+    title="Tasks"
+    href="/java/guides/core/tasks"
+    description="Describe tasks with Task.of(), configure retries, timeouts, and options"
+  />
+  <Card
+    title="Queues & Priority"
+    href="/java/guides/core/queues"
+    description="Named queues, priority levels, and routing"
+  />
+  <Card
+    title="Workers"
+    href="/java/guides/core/workers"
+    description="Start workers, control concurrency, graceful shutdown"
+  />
+  <Card
+    title="Execution Models"
+    href="/java/guides/core/execution-model"
+    description="How tasks move from enqueue to completion"
+  />
+  <Card
+    title="Enqueue options"
+    href="/java/guides/core/enqueue-options"
+    description="Per-job delay, priority, uniqueness, and metadata"
+  />
+  <Card
+    title="Batching"
+    href="/java/guides/core/batching"
+    description="Producer-side Batcher/enqueueMany and worker-side batchSize"
+  />
+  <Card
+    title="Predicates"
+    href="/java/guides/core/predicates"
+    description="Gate an enqueue on a runtime condition"
+  />
+  <Card
+    title="Scheduling"
+    href="/java/guides/core/scheduling"
+    description="Periodic tasks with cron expressions"
+  />
+  <Card
+    title="Cancellation"
+    href="/java/guides/core/cancellation"
+    description="Cancel queued and in-flight jobs"
+  />
+  <Card
+    title="Streaming partial results"
+    href="/java/guides/core/streaming"
+    description="Emit progress from a running task"
+  />
+</Cards>

--- a/docs/content/docs/java/guides/extensibility/index.mdx
+++ b/docs/content/docs/java/guides/extensibility/index.mdx
@@ -5,9 +5,25 @@ description: "Extend the Java SDK at every stage of the task lifecycle."
 
 Extend taskito with custom behavior at every stage of the task lifecycle.
 
-| Guide | Description |
-|---|---|
-| [Events](/java/guides/extensibility/events) | Subscribe to job outcome events on the worker |
-| [Middleware](/java/guides/extensibility/middleware) | Wrap task execution with before/after/error and outcome hooks |
-| [Webhooks](/java/guides/extensibility/webhooks) | Push signed notifications to external services |
-| [Pluggable Serializers](/java/guides/extensibility/serializers) | Custom payload serialization — MessagePack, codecs, encryption |
+<Cards>
+  <Card
+    title="Events"
+    href="/java/guides/extensibility/events"
+    description="Subscribe to job outcome events on the worker"
+  />
+  <Card
+    title="Middleware"
+    href="/java/guides/extensibility/middleware"
+    description="Wrap task execution with before/after/error and outcome hooks"
+  />
+  <Card
+    title="Webhooks"
+    href="/java/guides/extensibility/webhooks"
+    description="Push signed notifications to external services"
+  />
+  <Card
+    title="Pluggable Serializers"
+    href="/java/guides/extensibility/serializers"
+    description="Custom payload serialization — MessagePack, codecs, encryption"
+  />
+</Cards>

--- a/docs/content/docs/java/guides/integrations/index.mdx
+++ b/docs/content/docs/java/guides/integrations/index.mdx
@@ -25,9 +25,25 @@ implementation("io.sentry:sentry:7.14.0")                     // contrib.SentryM
 
 ## Framework
 
-- [Spring Boot](/java/guides/integrations/spring) — auto-configured `Taskito` bean from `taskito.*` properties.
+<Cards>
+  <Card
+    title="Spring Boot"
+    href="/java/guides/integrations/spring"
+    description="auto-configured Taskito bean from taskito.* properties."
+  />
+</Cards>
 
 ## Observability
 
-- [Micrometer](/java/guides/integrations/micrometer) — one `Observation` per execution: a timer plus a trace span.
-- [Sentry](/java/guides/integrations/sentry) — capture handler exceptions and dead-letters.
+<Cards>
+  <Card
+    title="Micrometer"
+    href="/java/guides/integrations/micrometer"
+    description="one Observation per execution: a timer plus a trace span."
+  />
+  <Card
+    title="Sentry"
+    href="/java/guides/integrations/sentry"
+    description="capture handler exceptions and dead-letters."
+  />
+</Cards>

--- a/docs/content/docs/java/guides/observability/index.mdx
+++ b/docs/content/docs/java/guides/observability/index.mdx
@@ -7,10 +7,18 @@ See what the queue is doing — counts, per-execution metrics, live workers,
 per-job logs — and emit structured logs, all from the `Taskito` handle with no
 extra service.
 
-| Page | What it covers |
-|---|---|
-| [Monitoring](/java/guides/observability/monitoring) | Stats, per-execution metrics, worker heartbeats, Micrometer/Sentry pointers |
-| [Logging](/java/guides/observability/logging) | The built-in leveled logger and per-job task logs — levels, pluggable sink |
+<Cards>
+  <Card
+    title="Monitoring"
+    href="/java/guides/observability/monitoring"
+    description="Stats, per-execution metrics, worker heartbeats, Micrometer/Sentry pointers"
+  />
+  <Card
+    title="Logging"
+    href="/java/guides/observability/logging"
+    description="The built-in leveled logger and per-job task logs — levels, pluggable sink"
+  />
+</Cards>
 
 <Callout type="info">
   Lifecycle [events](/java/guides/extensibility/events) and

--- a/docs/content/docs/java/guides/operations/index.mdx
+++ b/docs/content/docs/java/guides/operations/index.mdx
@@ -5,17 +5,65 @@ description: "Run the Java SDK reliably in production — deployment, scaling, i
 
 Run taskito reliably in production.
 
-| Guide | Description |
-|---|---|
-| [Backends](/java/guides/operations/backends) | SQLite, Postgres, and Redis — setup and trade-offs |
-| [Job Management](/java/guides/operations/inspection) | Inspect, cancel, replay, and clean up jobs |
-| [Dashboard](/java/guides/operations/dashboard) | Serve the bundled web dashboard and its REST API |
-| [SSO (OAuth & OIDC)](/java/guides/operations/sso) | Google, GitHub, and OIDC sign-in for the dashboard |
-| [Mesh Scheduling](/java/guides/operations/mesh) | Decentralized work-stealing across worker nodes |
-| [Autoscaling](/java/guides/operations/autoscaling) | In-process thread autoscaling and the KEDA scaler endpoint |
-| [CLI](/java/guides/operations/cli) | Operate the queue from the terminal |
-| [Testing](/java/guides/operations/testing) | The in-memory backend and integration patterns |
-| [Security](/java/guides/operations/security) | Signing, encryption, and dashboard auth |
-| [Troubleshooting](/java/guides/operations/troubleshooting) | Diagnose stuck jobs and worker issues |
-| [Deployment](/java/guides/operations/deployment) | Process model, packaging, and graceful shutdown |
-| [GraalVM Native Image](/java/guides/operations/graalvm) | Compile applications to a native binary |
+<Cards>
+  <Card
+    title="Backends"
+    href="/java/guides/operations/backends"
+    description="SQLite, Postgres, and Redis — setup and trade-offs"
+  />
+  <Card
+    title="Job Management"
+    href="/java/guides/operations/inspection"
+    description="Inspect, cancel, replay, and clean up jobs"
+  />
+  <Card
+    title="Dashboard"
+    href="/java/guides/operations/dashboard"
+    description="Serve the bundled web dashboard and its REST API"
+  />
+  <Card
+    title="SSO (OAuth & OIDC)"
+    href="/java/guides/operations/sso"
+    description="Google, GitHub, and OIDC sign-in for the dashboard"
+  />
+  <Card
+    title="Mesh Scheduling"
+    href="/java/guides/operations/mesh"
+    description="Decentralized work-stealing across worker nodes"
+  />
+  <Card
+    title="Autoscaling"
+    href="/java/guides/operations/autoscaling"
+    description="In-process thread autoscaling and the KEDA scaler endpoint"
+  />
+  <Card
+    title="CLI"
+    href="/java/guides/operations/cli"
+    description="Operate the queue from the terminal"
+  />
+  <Card
+    title="Testing"
+    href="/java/guides/operations/testing"
+    description="The in-memory backend and integration patterns"
+  />
+  <Card
+    title="Security"
+    href="/java/guides/operations/security"
+    description="Signing, encryption, and dashboard auth"
+  />
+  <Card
+    title="Troubleshooting"
+    href="/java/guides/operations/troubleshooting"
+    description="Diagnose stuck jobs and worker issues"
+  />
+  <Card
+    title="Deployment"
+    href="/java/guides/operations/deployment"
+    description="Process model, packaging, and graceful shutdown"
+  />
+  <Card
+    title="GraalVM Native Image"
+    href="/java/guides/operations/graalvm"
+    description="Compile applications to a native binary"
+  />
+</Cards>

--- a/docs/content/docs/java/guides/reliability/index.mdx
+++ b/docs/content/docs/java/guides/reliability/index.mdx
@@ -5,14 +5,50 @@ description: "Harden your Java task queue for production workloads."
 
 Harden your task queue for production workloads.
 
-| Guide | Description |
-|---|---|
-| [Error Handling](/java/guides/reliability/error-handling) | Task failure lifecycle, error inspection, the exception hierarchy |
-| [Delivery Guarantees](/java/guides/reliability/guarantees) | At-least-once delivery and exactly-once patterns |
-| [Retries](/java/guides/reliability/retries) | Automatic retries with exponential backoff |
-| [Timeouts](/java/guides/reliability/timeouts) | Bound task runtime per execution attempt |
-| [Idempotency](/java/guides/reliability/idempotency) | Deduplicate enqueues with unique keys |
-| [Rate Limiting](/java/guides/reliability/rate-limiting) | Throttle and defer enqueues with gates |
-| [Concurrency](/java/guides/reliability/concurrency) | Size and autoscale the worker's handler pool |
-| [Dead-letter queue](/java/guides/reliability/dead-letter) | Capture and replay exhausted jobs |
-| [Distributed Locking](/java/guides/reliability/locks) | Mutual exclusion across workers with database-backed locks |
+<Cards>
+  <Card
+    title="Error Handling"
+    href="/java/guides/reliability/error-handling"
+    description="Task failure lifecycle, error inspection, the exception hierarchy"
+  />
+  <Card
+    title="Delivery Guarantees"
+    href="/java/guides/reliability/guarantees"
+    description="At-least-once delivery and exactly-once patterns"
+  />
+  <Card
+    title="Retries"
+    href="/java/guides/reliability/retries"
+    description="Automatic retries with exponential backoff"
+  />
+  <Card
+    title="Timeouts"
+    href="/java/guides/reliability/timeouts"
+    description="Bound task runtime per execution attempt"
+  />
+  <Card
+    title="Idempotency"
+    href="/java/guides/reliability/idempotency"
+    description="Deduplicate enqueues with unique keys"
+  />
+  <Card
+    title="Rate Limiting"
+    href="/java/guides/reliability/rate-limiting"
+    description="Throttle and defer enqueues with gates"
+  />
+  <Card
+    title="Concurrency"
+    href="/java/guides/reliability/concurrency"
+    description="Size and autoscale the worker's handler pool"
+  />
+  <Card
+    title="Dead-letter queue"
+    href="/java/guides/reliability/dead-letter"
+    description="Capture and replay exhausted jobs"
+  />
+  <Card
+    title="Distributed Locking"
+    href="/java/guides/reliability/locks"
+    description="Mutual exclusion across workers with database-backed locks"
+  />
+</Cards>

--- a/docs/content/docs/java/guides/resources/index.mdx
+++ b/docs/content/docs/java/guides/resources/index.mdx
@@ -22,14 +22,38 @@ try (Taskito queue = Taskito.builder().sqlite("tasks.db").open()) {
 }
 ```
 
-| Page | What it covers |
-|---|---|
-| [Dependency injection](/java/guides/resources/dependency-injection) | `Taskito.resource()`, the five scopes, `Resources.use`, annotation-driven injection, teardown, metrics |
-| [Configuration](/java/guides/resources/configuration) | The `resource()` overloads, choosing a scope, teardown, and `PoolConfig` tuning |
-| [Enqueue interception](/java/guides/resources/interception) | `Interceptor` strategies and the `onEnqueue` hook — validate, rewrite, redirect, and reject jobs before serialization |
-| [Resource proxies](/java/guides/resources/proxies) | Signed `ProxyRef`s for non-serializable values — HMAC signing, TTL, purpose binding, sessions |
-| [Observability](/java/guides/resources/observability) | Reading `resourceMetrics()` — created/disposed/active counters |
-| [Testing](/java/guides/resources/testing) | Registering stub resources with `InMemoryTaskito` |
+<Cards>
+  <Card
+    title="Dependency injection"
+    href="/java/guides/resources/dependency-injection"
+    description="Taskito.resource(), the five scopes, Resources.use, annotation-driven injection, teardown, metrics"
+  />
+  <Card
+    title="Configuration"
+    href="/java/guides/resources/configuration"
+    description="The resource() overloads, choosing a scope, teardown, and PoolConfig tuning"
+  />
+  <Card
+    title="Enqueue interception"
+    href="/java/guides/resources/interception"
+    description="Interceptor strategies and the onEnqueue hook — validate, rewrite, redirect, and reject jobs before serialization"
+  />
+  <Card
+    title="Resource proxies"
+    href="/java/guides/resources/proxies"
+    description="Signed ProxyRefs for non-serializable values — HMAC signing, TTL, purpose binding, sessions"
+  />
+  <Card
+    title="Observability"
+    href="/java/guides/resources/observability"
+    description="Reading resourceMetrics() — created/disposed/active counters"
+  />
+  <Card
+    title="Testing"
+    href="/java/guides/resources/testing"
+    description="Registering stub resources with InMemoryTaskito"
+  />
+</Cards>
 
 ## The five scopes
 

--- a/docs/content/docs/node/guides/core/index.mdx
+++ b/docs/content/docs/node/guides/core/index.mdx
@@ -5,14 +5,50 @@ description: "The building blocks of every Node.js taskito application."
 
 The building blocks of every taskito application.
 
-| Guide | Description |
-|---|---|
-| [Tasks](/node/guides/core/tasks) | Register tasks with `queue.task()`, configure retries, timeouts, and options |
-| [Queues & Priority](/node/guides/core/queues) | Named queues, priority levels, and routing |
-| [Workers](/node/guides/core/workers) | Start workers, control concurrency, graceful shutdown |
-| [Execution Models](/node/guides/core/execution-model) | How tasks move from enqueue to completion |
-| [Enqueue options](/node/guides/core/enqueue-options) | Per-job delay, priority, uniqueness, and metadata |
-| [Predicates](/node/guides/core/predicates) | Gate an enqueue on a runtime condition |
-| [Scheduling](/node/guides/core/scheduling) | Periodic tasks with cron expressions |
-| [Cancellation](/node/guides/core/cancellation) | Cancel queued and in-flight jobs |
-| [Streaming partial results](/node/guides/core/streaming) | Emit progress from a running task |
+<Cards>
+  <Card
+    title="Tasks"
+    href="/node/guides/core/tasks"
+    description="Register tasks with queue.task(), configure retries, timeouts, and options"
+  />
+  <Card
+    title="Queues & Priority"
+    href="/node/guides/core/queues"
+    description="Named queues, priority levels, and routing"
+  />
+  <Card
+    title="Workers"
+    href="/node/guides/core/workers"
+    description="Start workers, control concurrency, graceful shutdown"
+  />
+  <Card
+    title="Execution Models"
+    href="/node/guides/core/execution-model"
+    description="How tasks move from enqueue to completion"
+  />
+  <Card
+    title="Enqueue options"
+    href="/node/guides/core/enqueue-options"
+    description="Per-job delay, priority, uniqueness, and metadata"
+  />
+  <Card
+    title="Predicates"
+    href="/node/guides/core/predicates"
+    description="Gate an enqueue on a runtime condition"
+  />
+  <Card
+    title="Scheduling"
+    href="/node/guides/core/scheduling"
+    description="Periodic tasks with cron expressions"
+  />
+  <Card
+    title="Cancellation"
+    href="/node/guides/core/cancellation"
+    description="Cancel queued and in-flight jobs"
+  />
+  <Card
+    title="Streaming partial results"
+    href="/node/guides/core/streaming"
+    description="Emit progress from a running task"
+  />
+</Cards>

--- a/docs/content/docs/node/guides/extensibility/index.mdx
+++ b/docs/content/docs/node/guides/extensibility/index.mdx
@@ -5,9 +5,25 @@ description: "Extend the Node.js SDK at every stage of the task lifecycle."
 
 Extend taskito with custom behavior at every stage of the task lifecycle.
 
-| Guide | Description |
-|---|---|
-| [Events](/node/guides/extensibility/events) | Subscribe to queue and worker lifecycle events |
-| [Per-Task Middleware](/node/guides/extensibility/middleware) | Wrap task execution with before/after/error hooks |
-| [Webhooks](/node/guides/extensibility/webhooks) | Push signed notifications to external services |
-| [Pluggable Serializers](/node/guides/extensibility/serializers) | Custom payload serialization — msgpack, encryption |
+<Cards>
+  <Card
+    title="Events"
+    href="/node/guides/extensibility/events"
+    description="Subscribe to queue and worker lifecycle events"
+  />
+  <Card
+    title="Per-Task Middleware"
+    href="/node/guides/extensibility/middleware"
+    description="Wrap task execution with before/after/error hooks"
+  />
+  <Card
+    title="Webhooks"
+    href="/node/guides/extensibility/webhooks"
+    description="Push signed notifications to external services"
+  />
+  <Card
+    title="Pluggable Serializers"
+    href="/node/guides/extensibility/serializers"
+    description="Custom payload serialization — msgpack, encryption"
+  />
+</Cards>

--- a/docs/content/docs/node/guides/integrations/index.mdx
+++ b/docs/content/docs/node/guides/integrations/index.mdx
@@ -25,12 +25,40 @@ pnpm add @nestjs/common reflect-metadata  # taskito/contrib/nest
 
 ## Observability
 
-- [OpenTelemetry](/node/guides/integrations/otel) — one span per execution attempt.
-- [Prometheus](/node/guides/integrations/prometheus) — execution metrics + polled depth gauges.
-- [Sentry](/node/guides/integrations/sentry) — capture the original exception on dead-letter.
+<Cards>
+  <Card
+    title="OpenTelemetry"
+    href="/node/guides/integrations/otel"
+    description="one span per execution attempt."
+  />
+  <Card
+    title="Prometheus"
+    href="/node/guides/integrations/prometheus"
+    description="execution metrics + polled depth gauges."
+  />
+  <Card
+    title="Sentry"
+    href="/node/guides/integrations/sentry"
+    description="capture the original exception on dead-letter."
+  />
+</Cards>
 
 ## Web frameworks
 
-- [Express](/node/guides/integrations/express) — REST router + dashboard mount.
-- [Fastify](/node/guides/integrations/fastify) — REST + dashboard plugins.
-- [NestJS](/node/guides/integrations/nest) — injectable `TaskitoService`.
+<Cards>
+  <Card
+    title="Express"
+    href="/node/guides/integrations/express"
+    description="REST router + dashboard mount."
+  />
+  <Card
+    title="Fastify"
+    href="/node/guides/integrations/fastify"
+    description="REST + dashboard plugins."
+  />
+  <Card
+    title="NestJS"
+    href="/node/guides/integrations/nest"
+    description="injectable TaskitoService."
+  />
+</Cards>

--- a/docs/content/docs/node/guides/observability/index.mdx
+++ b/docs/content/docs/node/guides/observability/index.mdx
@@ -7,10 +7,18 @@ See what the queue is doing — counts, per-task latency, job progress, live
 workers — and emit structured logs, all from the `Queue` handle with no extra
 service.
 
-| Page | What it covers |
-|---|---|
-| [Monitoring](/node/guides/observability/monitoring) | Stats, per-task metrics, progress, worker heartbeats, Prometheus/OTel/Sentry pointers |
-| [Logging](/node/guides/observability/logging) | The built-in leveled logger — levels, namespaces, pluggable sink |
+<Cards>
+  <Card
+    title="Monitoring"
+    href="/node/guides/observability/monitoring"
+    description="Stats, per-task metrics, progress, worker heartbeats, Prometheus/OTel/Sentry pointers"
+  />
+  <Card
+    title="Logging"
+    href="/node/guides/observability/logging"
+    description="The built-in leveled logger — levels, namespaces, pluggable sink"
+  />
+</Cards>
 
 <Callout type="info">
   Lifecycle [events](/node/guides/extensibility/events) and

--- a/docs/content/docs/node/guides/operations/index.mdx
+++ b/docs/content/docs/node/guides/operations/index.mdx
@@ -5,17 +5,65 @@ description: "Run the Node.js SDK reliably in production — deployment, scaling
 
 Run taskito reliably in production.
 
-| Guide | Description |
-|---|---|
-| [Backends](/node/guides/operations/backends) | SQLite, Postgres, and Redis — setup and trade-offs |
-| [Job Management](/node/guides/operations/inspection) | Inspect, cancel, replay, and clean up jobs |
-| [Dashboard](/node/guides/operations/dashboard) | Serve the web dashboard from a Node worker |
-| [Dashboard REST API](/node/guides/operations/dashboard-api) | The JSON API behind the dashboard |
-| [Mesh Scheduling](/node/guides/operations/mesh) | Decentralized work-stealing across worker nodes |
-| [KEDA Autoscaling](/node/guides/operations/keda) | Kubernetes event-driven autoscaling from queue depth |
-| [CLI](/node/guides/operations/cli) | Manage queues and workers from the command line |
-| [Testing](/node/guides/operations/testing) | Test mode, fixtures, and mocking |
-| [Security](/node/guides/operations/security) | Signing, encryption, and dashboard auth |
-| [Troubleshooting](/node/guides/operations/troubleshooting) | Diagnose stuck jobs and worker issues |
-| [Deployment](/node/guides/operations/deployment) | Docker, process managers, and production checklists |
-| [Migrating from BullMQ](/node/guides/operations/migration) | Side-by-side comparison and migration guide |
+<Cards>
+  <Card
+    title="Backends"
+    href="/node/guides/operations/backends"
+    description="SQLite, Postgres, and Redis — setup and trade-offs"
+  />
+  <Card
+    title="Job Management"
+    href="/node/guides/operations/inspection"
+    description="Inspect, cancel, replay, and clean up jobs"
+  />
+  <Card
+    title="Dashboard"
+    href="/node/guides/operations/dashboard"
+    description="Serve the web dashboard from a Node worker"
+  />
+  <Card
+    title="Dashboard REST API"
+    href="/node/guides/operations/dashboard-api"
+    description="The JSON API behind the dashboard"
+  />
+  <Card
+    title="Mesh Scheduling"
+    href="/node/guides/operations/mesh"
+    description="Decentralized work-stealing across worker nodes"
+  />
+  <Card
+    title="KEDA Autoscaling"
+    href="/node/guides/operations/keda"
+    description="Kubernetes event-driven autoscaling from queue depth"
+  />
+  <Card
+    title="CLI"
+    href="/node/guides/operations/cli"
+    description="Manage queues and workers from the command line"
+  />
+  <Card
+    title="Testing"
+    href="/node/guides/operations/testing"
+    description="Test mode, fixtures, and mocking"
+  />
+  <Card
+    title="Security"
+    href="/node/guides/operations/security"
+    description="Signing, encryption, and dashboard auth"
+  />
+  <Card
+    title="Troubleshooting"
+    href="/node/guides/operations/troubleshooting"
+    description="Diagnose stuck jobs and worker issues"
+  />
+  <Card
+    title="Deployment"
+    href="/node/guides/operations/deployment"
+    description="Docker, process managers, and production checklists"
+  />
+  <Card
+    title="Migrating from BullMQ"
+    href="/node/guides/operations/migration"
+    description="Side-by-side comparison and migration guide"
+  />
+</Cards>

--- a/docs/content/docs/node/guides/reliability/index.mdx
+++ b/docs/content/docs/node/guides/reliability/index.mdx
@@ -5,15 +5,55 @@ description: "Harden your Node.js task queue for production workloads."
 
 Harden your task queue for production workloads.
 
-| Guide | Description |
-|---|---|
-| [Error Handling](/node/guides/reliability/error-handling) | Task failure lifecycle, error inspection, debugging patterns |
-| [Delivery Guarantees](/node/guides/reliability/guarantees) | At-least-once delivery and exactly-once patterns |
-| [Retries](/node/guides/reliability/retries) | Automatic retries with exponential backoff |
-| [Timeouts](/node/guides/reliability/timeouts) | Bound task runtime and reclaim stalled jobs |
-| [Idempotency](/node/guides/reliability/idempotency) | Deduplicate enqueues with unique keys |
-| [Rate Limiting](/node/guides/reliability/rate-limiting) | Throttle task execution with token-bucket limits |
-| [Concurrency](/node/guides/reliability/concurrency) | Cap how many jobs of a task run at once |
-| [Circuit Breakers](/node/guides/reliability/circuit-breakers) | Protect downstream services from cascading failures |
-| [Dead-letter queue](/node/guides/reliability/dead-letter) | Capture and replay exhausted jobs |
-| [Distributed Locking](/node/guides/reliability/locks) | Mutual exclusion across workers with database-backed locks |
+<Cards>
+  <Card
+    title="Error Handling"
+    href="/node/guides/reliability/error-handling"
+    description="Task failure lifecycle, error inspection, debugging patterns"
+  />
+  <Card
+    title="Delivery Guarantees"
+    href="/node/guides/reliability/guarantees"
+    description="At-least-once delivery and exactly-once patterns"
+  />
+  <Card
+    title="Retries"
+    href="/node/guides/reliability/retries"
+    description="Automatic retries with exponential backoff"
+  />
+  <Card
+    title="Timeouts"
+    href="/node/guides/reliability/timeouts"
+    description="Bound task runtime and reclaim stalled jobs"
+  />
+  <Card
+    title="Idempotency"
+    href="/node/guides/reliability/idempotency"
+    description="Deduplicate enqueues with unique keys"
+  />
+  <Card
+    title="Rate Limiting"
+    href="/node/guides/reliability/rate-limiting"
+    description="Throttle task execution with token-bucket limits"
+  />
+  <Card
+    title="Concurrency"
+    href="/node/guides/reliability/concurrency"
+    description="Cap how many jobs of a task run at once"
+  />
+  <Card
+    title="Circuit Breakers"
+    href="/node/guides/reliability/circuit-breakers"
+    description="Protect downstream services from cascading failures"
+  />
+  <Card
+    title="Dead-letter queue"
+    href="/node/guides/reliability/dead-letter"
+    description="Capture and replay exhausted jobs"
+  />
+  <Card
+    title="Distributed Locking"
+    href="/node/guides/reliability/locks"
+    description="Mutual exclusion across workers with database-backed locks"
+  />
+</Cards>

--- a/docs/content/docs/node/guides/resources/index.mdx
+++ b/docs/content/docs/node/guides/resources/index.mdx
@@ -21,10 +21,18 @@ queue.task("sync", async (id: string) => {
 });
 ```
 
-| Page | What it covers |
-|---|---|
-| [Dependency injection](/node/guides/resources/dependency-injection) | `queue.resource()`, worker/task/pooled scopes, `useResource`, declarative `inject`, teardown |
-| [Enqueue interception](/node/guides/resources/interception) | The `onEnqueue` hook — validate, redact, and rewrite jobs before serialization |
+<Cards>
+  <Card
+    title="Dependency injection"
+    href="/node/guides/resources/dependency-injection"
+    description="queue.resource(), worker/task/pooled scopes, useResource, declarative inject, teardown"
+  />
+  <Card
+    title="Enqueue interception"
+    href="/node/guides/resources/interception"
+    description="The onEnqueue hook — validate, redact, and rewrite jobs before serialization"
+  />
+</Cards>
 
 <Callout type="info">
   Coming from Python? Node's resource system is intentionally lighter — no

--- a/docs/content/docs/node/guides/workflows/index.mdx
+++ b/docs/content/docs/node/guides/workflows/index.mdx
@@ -3,9 +3,6 @@ title: Workflows
 description: "Orchestrate multi-step DAGs in Node.js with the Taskito workflow builder."
 ---
 
-import { Cards, Card } from "fumadocs-ui/components/card";
-import { Callout } from "fumadocs-ui/components/callout";
-
 Orchestrate multi-step DAGs (directed acyclic graphs — steps with dependencies
 and no cycles) where each step is a registered task and `after` declares its
 dependencies. The Rust core schedules steps in topological order; a worker

--- a/docs/content/docs/python/guides/advanced-execution/index.mdx
+++ b/docs/content/docs/python/guides/advanced-execution/index.mdx
@@ -5,11 +5,35 @@ description: "Patterns for scaling and optimizing task execution."
 
 Patterns for scaling and optimizing task execution.
 
-| Guide | Description |
-|---|---|
-| [Prefork Pool](/python/guides/advanced-execution/prefork) | Process-based isolation for CPU-bound or memory-leaking tasks |
-| [Native Async Tasks](/python/guides/advanced-execution/async-tasks) | `async def` tasks with native event loop integration |
-| [Result Streaming](/python/guides/advanced-execution/streaming) | Stream partial results and progress updates in real time |
-| [Dependencies](/python/guides/advanced-execution/dependencies) | DAG-based job dependencies — run tasks in order |
-| [Batch Enqueue](/python/guides/advanced-execution/batch-enqueue) | Enqueue many jobs efficiently with `task.map()` and `enqueue_many()` |
-| [Unique Tasks](/python/guides/advanced-execution/unique-tasks) | Deduplicate active jobs with unique keys |
+<Cards>
+  <Card
+    title="Prefork Pool"
+    href="/python/guides/advanced-execution/prefork"
+    description="Process-based isolation for CPU-bound or memory-leaking tasks"
+  />
+  <Card
+    title="Native Async Tasks"
+    href="/python/guides/advanced-execution/async-tasks"
+    description="async def tasks with native event loop integration"
+  />
+  <Card
+    title="Result Streaming"
+    href="/python/guides/advanced-execution/streaming"
+    description="Stream partial results and progress updates in real time"
+  />
+  <Card
+    title="Dependencies"
+    href="/python/guides/advanced-execution/dependencies"
+    description="DAG-based job dependencies — run tasks in order"
+  />
+  <Card
+    title="Batch Enqueue"
+    href="/python/guides/advanced-execution/batch-enqueue"
+    description="Enqueue many jobs efficiently with task.map() and enqueue_many()"
+  />
+  <Card
+    title="Unique Tasks"
+    href="/python/guides/advanced-execution/unique-tasks"
+    description="Deduplicate active jobs with unique keys"
+  />
+</Cards>

--- a/docs/content/docs/python/guides/core/index.mdx
+++ b/docs/content/docs/python/guides/core/index.mdx
@@ -5,13 +5,45 @@ description: "The building blocks of every taskito application."
 
 The building blocks of every taskito application.
 
-| Guide | Description |
-|---|---|
-| [Tasks](/python/guides/core/tasks) | Define tasks with `@queue.task()`, configure retries, timeouts, and options |
-| [Workers](/python/guides/core/workers) | Start workers, control concurrency, graceful shutdown |
-| [Execution Models](/python/guides/core/execution-model) | How tasks move from enqueue to completion |
-| [Queues & Priority](/python/guides/core/queues) | Named queues, priority levels, and routing |
-| [Scheduling](/python/guides/core/scheduling) | Periodic tasks with cron expressions |
-| [Predicates](/python/guides/core/predicates) | Gate execution with a serializable predicate DSL — time windows, feature flags |
-| [Task Batching](/python/guides/core/batching) | Collect many small calls into a single job |
-| [Workflows](/python/guides/core/workflows) | Chains, groups, and chords for multi-step pipelines |
+<Cards>
+  <Card
+    title="Tasks"
+    href="/python/guides/core/tasks"
+    description="Define tasks with @queue.task(), configure retries, timeouts, and options"
+  />
+  <Card
+    title="Workers"
+    href="/python/guides/core/workers"
+    description="Start workers, control concurrency, graceful shutdown"
+  />
+  <Card
+    title="Execution Models"
+    href="/python/guides/core/execution-model"
+    description="How tasks move from enqueue to completion"
+  />
+  <Card
+    title="Queues & Priority"
+    href="/python/guides/core/queues"
+    description="Named queues, priority levels, and routing"
+  />
+  <Card
+    title="Scheduling"
+    href="/python/guides/core/scheduling"
+    description="Periodic tasks with cron expressions"
+  />
+  <Card
+    title="Predicates"
+    href="/python/guides/core/predicates"
+    description="Gate execution with a serializable predicate DSL — time windows, feature flags"
+  />
+  <Card
+    title="Task Batching"
+    href="/python/guides/core/batching"
+    description="Collect many small calls into a single job"
+  />
+  <Card
+    title="Workflows"
+    href="/python/guides/core/workflows"
+    description="Chains, groups, and chords for multi-step pipelines"
+  />
+</Cards>

--- a/docs/content/docs/python/guides/dashboard/index.mdx
+++ b/docs/content/docs/python/guides/dashboard/index.mdx
@@ -3,9 +3,6 @@ title: Overview
 description: "Zero-dependency built-in web UI for browsing jobs, configuring webhooks, tuning per-task runtime limits, and managing the queue."
 ---
 
-import { Callout } from "fumadocs-ui/components/callout";
-import { Tab, Tabs } from "fumadocs-ui/components/tabs";
-
 taskito ships with a built-in web dashboard for monitoring jobs, inspecting
 dead letters (the DLQ — a holding area for jobs that exhausted their retries), configuring webhooks, tuning per-task runtime limits, and
 managing your task queue in real time. The dashboard is a single-page
@@ -16,6 +13,31 @@ dependencies required**.
 > separate monitoring service to install or run.
 
 ![Overview page with stats cards, throughput chart, and recent activity](/screenshots/dashboard/overview.png)
+
+## In this section
+
+<Cards>
+  <Card
+    title="Authentication"
+    href="/python/guides/dashboard/authentication"
+    description="Session-based login, CSRF, env-var bootstrap, and the setup-required flow."
+  />
+  <Card
+    title="SSO (OAuth & OIDC)"
+    href="/python/guides/dashboard/sso"
+    description="Sign in with Google, GitHub, or any OIDC provider — per-domain and per-org allowlists, OAuth-only mode."
+  />
+  <Card
+    title="Task & Queue Overrides"
+    href="/python/guides/dashboard/task-overrides"
+    description="Tune retry policy, concurrency, rate limits, and middleware per task — without redeploying."
+  />
+  <Card
+    title="REST API"
+    href="/python/guides/dashboard/rest-api"
+    description="JSON endpoints for stats, jobs, dead letters, metrics, logs, infrastructure, webhooks, and runtime overrides."
+  />
+</Cards>
 
 ## Launching the dashboard
 

--- a/docs/content/docs/python/guides/extensibility/index.mdx
+++ b/docs/content/docs/python/guides/extensibility/index.mdx
@@ -5,8 +5,20 @@ description: "Extend taskito at every stage of the task lifecycle."
 
 Extend taskito with custom behavior at every stage of the task lifecycle.
 
-| Guide | Description |
-|---|---|
-| [Middleware](/python/guides/extensibility/middleware) | Hook into task execution with `before`, `after`, `on_retry`, and more |
-| [Serializers](/python/guides/extensibility/serializers) | Custom payload serialization — msgpack, orjson, encryption |
-| [Events & Webhooks](/python/guides/extensibility/events-webhooks) | React to queue events and push notifications to external services |
+<Cards>
+  <Card
+    title="Middleware"
+    href="/python/guides/extensibility/middleware"
+    description="Hook into task execution with before, after, on_retry, and more"
+  />
+  <Card
+    title="Serializers"
+    href="/python/guides/extensibility/serializers"
+    description="Custom payload serialization — msgpack, orjson, encryption"
+  />
+  <Card
+    title="Events & Webhooks"
+    href="/python/guides/extensibility/events-webhooks"
+    description="React to queue events and push notifications to external services"
+  />
+</Cards>

--- a/docs/content/docs/python/guides/index.mdx
+++ b/docs/content/docs/python/guides/index.mdx
@@ -14,6 +14,7 @@ import {
   Workflow,
   Plug,
   Puzzle,
+  LayoutDashboard,
 } from "lucide-react";
 
 Pick the topic you're working through. Each guide is self-contained, with code
@@ -51,6 +52,12 @@ overview of everything taskito does, see
     title="Observability"
     href="/python/guides/observability"
     description="Metrics, logs, dashboard, OpenTelemetry, Sentry, Prometheus."
+  />
+  <Card
+    icon={<LayoutDashboard />}
+    title="Dashboard"
+    href="/python/guides/dashboard"
+    description="Built-in web UI — browse jobs, configure webhooks, tune per-task limits, manage the queue."
   />
   <Card
     icon={<Layers />}

--- a/docs/content/docs/python/guides/integrations/index.mdx
+++ b/docs/content/docs/python/guides/integrations/index.mdx
@@ -30,15 +30,43 @@ tools. Install only what you need.
 
 ## Framework integrations
 
-- **[Flask](/python/guides/integrations/flask)** — full Flask extension with app config, factory pattern, and CLI commands
-- **[FastAPI](/python/guides/integrations/fastapi)** — pre-built `APIRouter` with job status, SSE progress, and DLQ management
-- **[Django](/python/guides/integrations/django)** — admin views for browsing jobs, dead letters, and queue stats
+<Cards>
+  <Card
+    title="Flask"
+    href="/python/guides/integrations/flask"
+    description="Full Flask extension with app config, factory pattern, and CLI commands"
+  />
+  <Card
+    title="FastAPI"
+    href="/python/guides/integrations/fastapi"
+    description="Pre-built APIRouter with job status, SSE progress, and DLQ management"
+  />
+  <Card
+    title="Django"
+    href="/python/guides/integrations/django"
+    description="Admin views for browsing jobs, dead letters, and queue stats"
+  />
+</Cards>
 
 ## Observability integrations
 
-- **[OpenTelemetry](/python/guides/integrations/otel)** — distributed tracing with per-task spans
-- **[Prometheus](/python/guides/integrations/prometheus)** — counters, histograms, and gauges for task execution
-- **[Sentry](/python/guides/integrations/sentry)** — automatic error capture with task context
+<Cards>
+  <Card
+    title="OpenTelemetry"
+    href="/python/guides/integrations/otel"
+    description="Distributed tracing with per-task spans"
+  />
+  <Card
+    title="Prometheus"
+    href="/python/guides/integrations/prometheus"
+    description="Counters, histograms, and gauges for task execution"
+  />
+  <Card
+    title="Sentry"
+    href="/python/guides/integrations/sentry"
+    description="Automatic error capture with task context"
+  />
+</Cards>
 
 ## Combining integrations
 

--- a/docs/content/docs/python/guides/observability/index.mdx
+++ b/docs/content/docs/python/guides/observability/index.mdx
@@ -5,11 +5,23 @@ description: "Monitor, log, and inspect your task queue in real time."
 
 Monitor, log, and inspect your task queue in real time.
 
-| Guide | Description |
-|---|---|
-| [Monitoring & Hooks](/python/guides/observability/monitoring) | Queue stats, progress tracking, worker heartbeat, and alerting hooks |
-| [Structured Logging](/python/guides/observability/logging) | Per-task structured logs with automatic context |
-| [Structured Notes](/python/guides/observability/notes) | Operator-visible metadata attached to individual jobs |
+<Cards>
+  <Card
+    title="Monitoring & Hooks"
+    href="/python/guides/observability/monitoring"
+    description="Queue stats, progress tracking, worker heartbeat, and alerting hooks"
+  />
+  <Card
+    title="Structured Logging"
+    href="/python/guides/observability/logging"
+    description="Per-task structured logs with automatic context"
+  />
+  <Card
+    title="Structured Notes"
+    href="/python/guides/observability/notes"
+    description="Operator-visible metadata attached to individual jobs"
+  />
+</Cards>
 
 For the built-in web UI, see the [Dashboard](/python/guides/dashboard) section —
 it covers the browser app, password and SSO login, runtime task/queue

--- a/docs/content/docs/python/guides/operations/index.mdx
+++ b/docs/content/docs/python/guides/operations/index.mdx
@@ -6,16 +6,60 @@ description: "Run taskito reliably in production — testing, deployment, scalin
 Run taskito reliably in production — with no Redis or RabbitMQ broker to operate,
 just an embedded SQLite file or a Postgres instance.
 
-| Guide | Description |
-|---|---|
-| [Testing](/python/guides/operations/testing) | Test mode, fixtures, mocking resources, and workflow testing |
-| [Job Management](/python/guides/operations/job-management) | Cancel, pause, archive, revoke, replay, and clean up jobs |
-| [Troubleshooting](/python/guides/operations/troubleshooting) | Diagnose stuck jobs, lock contention, and worker issues |
-| [Security](/python/guides/operations/security) | Serializer signing/encryption, dashboard auth, and SSRF guards |
-| [Deployment](/python/guides/operations/deployment) | systemd, Docker, WAL mode, Postgres, and production checklists |
-| [Mesh Scheduling](/python/guides/operations/mesh) | Decentralized multi-worker work-stealing overlay |
-| [Bare-Metal Autoscaler](/python/guides/operations/autoscaler) | Automatically scale worker processes without Kubernetes |
-| [KEDA Autoscaling](/python/guides/operations/keda) | Kubernetes event-driven autoscaling for workers |
-| [Postgres Backend](/python/guides/operations/postgres) | Set up and run taskito with PostgreSQL |
-| [Migrating from Celery](/python/guides/operations/migration) | Side-by-side comparison and step-by-step migration guide |
-| [Upgrading to 0.15](/python/guides/operations/upgrading-0.15) | Breaking changes and migration steps for the 0.15 release |
+<Cards>
+  <Card
+    title="Testing"
+    href="/python/guides/operations/testing"
+    description="Test mode, fixtures, mocking resources, and workflow testing"
+  />
+  <Card
+    title="Job Management"
+    href="/python/guides/operations/job-management"
+    description="Cancel, pause, archive, revoke, replay, and clean up jobs"
+  />
+  <Card
+    title="Troubleshooting"
+    href="/python/guides/operations/troubleshooting"
+    description="Diagnose stuck jobs, lock contention, and worker issues"
+  />
+  <Card
+    title="Security"
+    href="/python/guides/operations/security"
+    description="Serializer signing/encryption, dashboard auth, and SSRF guards"
+  />
+  <Card
+    title="Deployment"
+    href="/python/guides/operations/deployment"
+    description="systemd, Docker, WAL mode, Postgres, and production checklists"
+  />
+  <Card
+    title="Mesh Scheduling"
+    href="/python/guides/operations/mesh"
+    description="Decentralized multi-worker work-stealing overlay"
+  />
+  <Card
+    title="Bare-Metal Autoscaler"
+    href="/python/guides/operations/autoscaler"
+    description="Automatically scale worker processes without Kubernetes"
+  />
+  <Card
+    title="KEDA Autoscaling"
+    href="/python/guides/operations/keda"
+    description="Kubernetes event-driven autoscaling for workers"
+  />
+  <Card
+    title="Postgres Backend"
+    href="/python/guides/operations/postgres"
+    description="Set up and run taskito with PostgreSQL"
+  />
+  <Card
+    title="Migrating from Celery"
+    href="/python/guides/operations/migration"
+    description="Side-by-side comparison and step-by-step migration guide"
+  />
+  <Card
+    title="Upgrading to 0.15"
+    href="/python/guides/operations/upgrading-0.15"
+    description="Breaking changes and migration steps for the 0.15 release"
+  />
+</Cards>

--- a/docs/content/docs/python/guides/reliability/index.mdx
+++ b/docs/content/docs/python/guides/reliability/index.mdx
@@ -5,12 +5,40 @@ description: "Harden your task queue for production workloads."
 
 Harden your task queue for production workloads.
 
-| Guide | Description |
-|---|---|
-| [Retries & Dead Letters](/python/guides/reliability/retries) | Automatic retries with exponential backoff, dead letter queue |
-| [Error Handling](/python/guides/reliability/error-handling) | Task failure lifecycle, error inspection, debugging patterns |
-| [Delivery Guarantees](/python/guides/reliability/guarantees) | At-least-once delivery, idempotency, and exactly-once patterns |
-| [Idempotency](/python/guides/reliability/idempotency) | Auto-derived dedup keys — identical enqueues coalesce to one execution |
-| [Rate Limiting](/python/guides/reliability/rate-limiting) | Throttle task execution with token bucket rate limits |
-| [Circuit Breakers](/python/guides/reliability/circuit-breakers) | Protect downstream services from cascading failures |
-| [Distributed Locking](/python/guides/reliability/locking) | Mutual exclusion across workers with database-backed locks |
+<Cards>
+  <Card
+    title="Retries & Dead Letters"
+    href="/python/guides/reliability/retries"
+    description="Automatic retries with exponential backoff, dead letter queue"
+  />
+  <Card
+    title="Error Handling"
+    href="/python/guides/reliability/error-handling"
+    description="Task failure lifecycle, error inspection, debugging patterns"
+  />
+  <Card
+    title="Delivery Guarantees"
+    href="/python/guides/reliability/guarantees"
+    description="At-least-once delivery, idempotency, and exactly-once patterns"
+  />
+  <Card
+    title="Idempotency"
+    href="/python/guides/reliability/idempotency"
+    description="Auto-derived dedup keys — identical enqueues coalesce to one execution"
+  />
+  <Card
+    title="Rate Limiting"
+    href="/python/guides/reliability/rate-limiting"
+    description="Throttle task execution with token bucket rate limits"
+  />
+  <Card
+    title="Circuit Breakers"
+    href="/python/guides/reliability/circuit-breakers"
+    description="Protect downstream services from cascading failures"
+  />
+  <Card
+    title="Distributed Locking"
+    href="/python/guides/reliability/locking"
+    description="Mutual exclusion across workers with database-backed locks"
+  />
+</Cards>

--- a/docs/content/docs/python/guides/resources/index.mdx
+++ b/docs/content/docs/python/guides/resources/index.mdx
@@ -101,11 +101,35 @@ taskito worker --app myapp.tasks:queue
 
 ## Section overview
 
-| Page | What it covers |
-|---|---|
-| [Argument Interception](/python/guides/resources/interception) | Modes, strategies, custom types, `analyze()`, metrics |
-| [Dependency Injection](/python/guides/resources/dependency-injection) | `worker_resource()`, scopes, dependencies, teardown, health checks |
-| [Resource Proxies](/python/guides/resources/proxies) | Built-in handlers, HMAC signing, security, `NoProxy`, cloud handlers |
-| [Configuration](/python/guides/resources/configuration) | TOML config, pool tuning, frozen and reloadable resources, hot reload |
-| [Testing](/python/guides/resources/testing) | `test_mode(resources=)`, `MockResource`, pytest fixtures |
-| [Observability](/python/guides/resources/observability) | Prometheus metrics, dashboard endpoints, CLI commands |
+<Cards>
+  <Card
+    title="Argument Interception"
+    href="/python/guides/resources/interception"
+    description="Modes, strategies, custom types, analyze(), metrics"
+  />
+  <Card
+    title="Dependency Injection"
+    href="/python/guides/resources/dependency-injection"
+    description="worker_resource(), scopes, dependencies, teardown, health checks"
+  />
+  <Card
+    title="Resource Proxies"
+    href="/python/guides/resources/proxies"
+    description="Built-in handlers, HMAC signing, security, NoProxy, cloud handlers"
+  />
+  <Card
+    title="Configuration"
+    href="/python/guides/resources/configuration"
+    description="TOML config, pool tuning, frozen and reloadable resources, hot reload"
+  />
+  <Card
+    title="Testing"
+    href="/python/guides/resources/testing"
+    description="test_mode(resources=), MockResource, pytest fixtures"
+  />
+  <Card
+    title="Observability"
+    href="/python/guides/resources/observability"
+    description="Prometheus metrics, dashboard endpoints, CLI commands"
+  />
+</Cards>

--- a/docs/content/docs/python/guides/workflows/index.mdx
+++ b/docs/content/docs/python/guides/workflows/index.mdx
@@ -64,13 +64,45 @@ in `wf.step(...)`. To pass a value between steps, use fan-out / fan-in or read
 
 ## Section overview
 
-| Page | What it covers |
-|---|---|
-| [Building Workflows](/python/guides/workflows/building) | `Workflow.step()`, decorator pattern, step configuration, DAG structure |
-| [Fan-Out & Fan-In](/python/guides/workflows/fan-out) | Splitting results into parallel jobs, collecting with aggregation |
-| [Conditions & Error Handling](/python/guides/workflows/conditions) | `on_success`, `on_failure`, `always`, callable conditions, `on_failure` modes |
-| [Approval Gates](/python/guides/workflows/gates) | Human-in-the-loop pause/resume, timeout, approve/reject API |
-| [Sub-Workflows & Scheduling](/python/guides/workflows/composition) | Nesting workflows, cron-scheduled runs |
-| [Incremental Runs](/python/guides/workflows/caching) | Result hashing, `CACHE_HIT`, dirty-set propagation, TTL |
-| [Analysis & Visualization](/python/guides/workflows/analysis) | Critical path, bottleneck analysis, Mermaid/DOT rendering |
-| [Canvas Primitives](/python/guides/workflows/canvas) | Chain, group, chord — simple composition without DAGs |
+<Cards>
+  <Card
+    title="Building Workflows"
+    href="/python/guides/workflows/building"
+    description="Workflow.step(), decorator pattern, step configuration, DAG structure"
+  />
+  <Card
+    title="Fan-Out & Fan-In"
+    href="/python/guides/workflows/fan-out"
+    description="Splitting results into parallel jobs, collecting with aggregation"
+  />
+  <Card
+    title="Conditions & Error Handling"
+    href="/python/guides/workflows/conditions"
+    description="on_success, on_failure, always, callable conditions, on_failure modes"
+  />
+  <Card
+    title="Approval Gates"
+    href="/python/guides/workflows/gates"
+    description="Human-in-the-loop pause/resume, timeout, approve/reject API"
+  />
+  <Card
+    title="Sub-Workflows & Scheduling"
+    href="/python/guides/workflows/composition"
+    description="Nesting workflows, cron-scheduled runs"
+  />
+  <Card
+    title="Incremental Runs"
+    href="/python/guides/workflows/caching"
+    description="Result hashing, CACHE_HIT, dirty-set propagation, TTL"
+  />
+  <Card
+    title="Analysis & Visualization"
+    href="/python/guides/workflows/analysis"
+    description="Critical path, bottleneck analysis, Mermaid/DOT rendering"
+  />
+  <Card
+    title="Canvas Primitives"
+    href="/python/guides/workflows/canvas"
+    description="Chain, group, chord — simple composition without DAGs"
+  />
+</Cards>


### PR DESCRIPTION
Every `/{sdk}/guides/{section}` overview page now uses the same Card-grid format.

## Before

Subsection index pages were a mix: most were Markdown tables (`| Guide | Description |`), the two `workflows` indexes used Card grids, and the `integrations` indexes were grouped bullet lists. The top-level Python guides overview was also missing a card for its **Dashboard** subsection.

## After

- Converted all ~24 subsection index pages (core, reliability, operations, workflows, resources, observability, extensibility, integrations, advanced-execution) across Python / Node / Java to `<Cards>` grids — one `<Card>` per child page with a one-line gloss, order preserved.
- `integrations` pages keep their `## Observability` / `## Web frameworks` groupings, each with its own grid.
- Added the missing **Dashboard** card to the Python guides overview, and an "In this section" grid to the Python dashboard index (surfaces the previously-unlinked SSO page).
- Dropped redundant `fumadocs-ui` Card/Callout imports — those components are globally registered.

## Verification

- `pnpm build` — all pages compile and prerender; spot-checked rendered HTML (e.g. `/python/guides/core` = 8 cards, `/node/guides/integrations` keeps both group headings).
- `pnpm run typecheck` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Java, Node.js, and Python guide landing pages with card-based navigation for improved browsing.
  * Preserved existing guide links and descriptions across core, extensibility, integrations, observability, operations, reliability, resources, workflows, and advanced execution sections.
  * Added a Dashboard entry to the Python guides overview.
  * Added Dashboard subsection links for Authentication, SSO, task and queue overrides, and the REST API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->