### PR TITLE
fix: harden dashboard frontend and add security headers

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -5,14 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="color-scheme" content="light dark" />
     <title>Taskito</title>
-    <script>
-      (() => {
-        const stored = localStorage.getItem("taskito.theme");
-        const preferred =
-          stored ?? (window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
-        document.documentElement.classList.toggle("dark", preferred === "dark");
-      })();
-    </script>
+    <!-- External (not inline) so servers can ship `script-src 'self'` CSP. -->
+    <script src="/theme-init.js"></script>
   </head>
   <body>
     <div id="app"></div>

--- a/dashboard/public/theme-init.js
+++ b/dashboard/public/theme-init.js
@@ -1,0 +1,9 @@
+// Pre-hydration theme bootstrap. Lives in its own file (not inline in
+// index.html) so the servers can ship a CSP with `script-src 'self'` —
+// an inline script would need a hash that drifts with every edit.
+(() => {
+  const stored = localStorage.getItem("taskito.theme");
+  const preferred =
+    stored ?? (window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
+  document.documentElement.classList.toggle("dark", preferred === "dark");
+})();

--- a/dashboard/src/components/layout/backend-offline.tsx
+++ b/dashboard/src/components/layout/backend-offline.tsx
@@ -96,7 +96,7 @@ export function BackendOffline({ error }: { error: Error }) {
           <a
             href="https://docs.byteveda.org/taskito/guide/observability/dashboard"
             target="_blank"
-            rel="noreferrer"
+            rel="noreferrer noopener"
             className="inline-flex items-center gap-1.5 text-sm text-[var(--fg-muted)] hover:text-[var(--fg)]"
           >
             Docs <ExternalLink className="size-3.5" aria-hidden />

--- a/dashboard/src/features/auth/components/login-form.tsx
+++ b/dashboard/src/features/auth/components/login-form.tsx
@@ -15,10 +15,20 @@ const ERROR_MESSAGES: Record<string, string> = {
   oauth_denied: "Access denied. Your account is not in the allowed list.",
 };
 
+/**
+ * Post-login redirects must stay on this origin: only root-relative paths
+ * (``/...`` but not protocol-relative ``//...``) are honoured, mirroring the
+ * server-side ``next`` validation on the OAuth callback.
+ */
+function safeNextPath(next: unknown): string | undefined {
+  if (typeof next !== "string") return undefined;
+  return next.startsWith("/") && !next.startsWith("//") ? next : undefined;
+}
+
 export function LoginForm() {
   const navigate = useNavigate();
   const search = useSearch({ strict: false }) as { next?: string; error?: string } | undefined;
-  const nextPath = typeof search?.next === "string" ? search.next : undefined;
+  const nextPath = safeNextPath(search?.next);
   const oauthError =
     typeof search?.error === "string" ? (ERROR_MESSAGES[search.error] ?? search.error) : null;
 

--- a/dashboard/src/features/auth/components/login-form.tsx
+++ b/dashboard/src/features/auth/components/login-form.tsx
@@ -22,7 +22,9 @@ const ERROR_MESSAGES: Record<string, string> = {
  */
 function safeNextPath(next: unknown): string | undefined {
   if (typeof next !== "string") return undefined;
-  return next.startsWith("/") && !next.startsWith("//") ? next : undefined;
+  // Backslashes are rejected too: WHATWG URL parsing normalizes "\" to "/"
+  // for http(s), so "/\evil.com" would escape the origin.
+  return next.startsWith("/") && !next.startsWith("//") && !next.includes("\\") ? next : undefined;
 }
 
 export function LoginForm() {

--- a/dashboard/src/features/settings/derived.test.ts
+++ b/dashboard/src/features/settings/derived.test.ts
@@ -12,6 +12,11 @@ describe("isSafeLinkUrl", () => {
     expect(isSafeLinkUrl("//evil.com")).toBe(false);
   });
 
+  it("rejects backslashes in paths (URL parsing folds them to slashes)", () => {
+    expect(isSafeLinkUrl("/\\evil.com")).toBe(false);
+    expect(isSafeLinkUrl("/jobs\\..\\x")).toBe(false);
+  });
+
   it("rejects javascript:, data:, and other schemes", () => {
     expect(isSafeLinkUrl("javascript:alert(document.cookie)")).toBe(false);
     expect(isSafeLinkUrl("data:text/html,<script>alert(1)</script>")).toBe(false);

--- a/dashboard/src/features/settings/derived.test.ts
+++ b/dashboard/src/features/settings/derived.test.ts
@@ -1,5 +1,35 @@
 import { describe, expect, it } from "vitest";
-import { applyJobContext, parseExternalLinks } from "./derived";
+import { applyJobContext, isSafeLinkUrl, parseExternalLinks } from "./derived";
+
+describe("isSafeLinkUrl", () => {
+  it("allows http and https URLs", () => {
+    expect(isSafeLinkUrl("https://grafana.example.com/d/abc")).toBe(true);
+    expect(isSafeLinkUrl("http://localhost:3000")).toBe(true);
+  });
+
+  it("allows same-origin paths but not protocol-relative URLs", () => {
+    expect(isSafeLinkUrl("/jobs")).toBe(true);
+    expect(isSafeLinkUrl("//evil.com")).toBe(false);
+  });
+
+  it("rejects javascript:, data:, and other schemes", () => {
+    expect(isSafeLinkUrl("javascript:alert(document.cookie)")).toBe(false);
+    expect(isSafeLinkUrl("data:text/html,<script>alert(1)</script>")).toBe(false);
+    expect(isSafeLinkUrl("vbscript:x")).toBe(false);
+    expect(isSafeLinkUrl("file:///etc/passwd")).toBe(false);
+  });
+
+  it("rejects relative fragments and garbage", () => {
+    expect(isSafeLinkUrl("jobs")).toBe(false);
+    expect(isSafeLinkUrl("")).toBe(false);
+    expect(isSafeLinkUrl("   ")).toBe(false);
+  });
+
+  it("tolerates surrounding whitespace", () => {
+    expect(isSafeLinkUrl("  https://example.com  ")).toBe(true);
+    expect(isSafeLinkUrl("  javascript:alert(1)  ")).toBe(false);
+  });
+});
 
 describe("parseExternalLinks", () => {
   it("returns [] for undefined or empty input", () => {
@@ -44,6 +74,16 @@ describe("parseExternalLinks", () => {
   it("strips extra fields, keeping only label and url", () => {
     const raw = JSON.stringify([{ label: "Docs", url: "/d", danger: "<script>" }]);
     expect(parseExternalLinks(raw)).toEqual([{ label: "Docs", url: "/d" }]);
+  });
+
+  it("drops entries whose URL scheme is unsafe", () => {
+    const raw = JSON.stringify([
+      { label: "Docs", url: "https://docs.example.com" },
+      { label: "Evil", url: "javascript:alert(1)" },
+      { label: "Data", url: "data:text/html,x" },
+      { label: "Proto-relative", url: "//evil.com" },
+    ]);
+    expect(parseExternalLinks(raw)).toEqual([{ label: "Docs", url: "https://docs.example.com" }]);
   });
 });
 

--- a/dashboard/src/features/settings/derived.ts
+++ b/dashboard/src/features/settings/derived.ts
@@ -12,7 +12,11 @@ import { type ExternalLink, type IntegrationUrls, SETTING_KEYS } from "./types";
  */
 export function isSafeLinkUrl(value: string): boolean {
   const trimmed = value.trim();
-  if (trimmed.startsWith("/")) return !trimmed.startsWith("//");
+  if (trimmed.startsWith("/")) {
+    // Reject protocol-relative (//host) and backslashes: WHATWG URL parsing
+    // normalizes "\" to "/" for http(s), so "/\evil.com" escapes the origin.
+    return !trimmed.startsWith("//") && !trimmed.includes("\\");
+  }
   try {
     const protocol = new URL(trimmed).protocol;
     return protocol === "http:" || protocol === "https:";

--- a/dashboard/src/features/settings/derived.ts
+++ b/dashboard/src/features/settings/derived.ts
@@ -4,9 +4,27 @@ import { useSettings } from "./hooks";
 import { type ExternalLink, type IntegrationUrls, SETTING_KEYS } from "./types";
 
 /**
+ * Whether a configured URL may safely become an ``href``. Allows http(s)
+ * and same-origin paths only — a stored ``javascript:``/``data:`` URI would
+ * execute in the dashboard origin when clicked, so scheme filtering here is
+ * the security control (the ``type="url"`` inputs are UX only and settings
+ * can be written directly through the API).
+ */
+export function isSafeLinkUrl(value: string): boolean {
+  const trimmed = value.trim();
+  if (trimmed.startsWith("/")) return !trimmed.startsWith("//");
+  try {
+    const protocol = new URL(trimmed).protocol;
+    return protocol === "http:" || protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Parse the JSON-encoded ``external_links`` setting into a typed list,
  * tolerating malformed values (returns ``[]``) so a bad write never
- * breaks the page.
+ * breaks the page. Entries with unsafe URL schemes are dropped.
  */
 export function parseExternalLinks(raw: string | undefined): ExternalLink[] {
   if (!raw) return [];
@@ -19,7 +37,8 @@ export function parseExternalLinks(raw: string | undefined): ExternalLink[] {
           typeof item === "object" &&
           item !== null &&
           typeof (item as ExternalLink).label === "string" &&
-          typeof (item as ExternalLink).url === "string",
+          typeof (item as ExternalLink).url === "string" &&
+          isSafeLinkUrl((item as ExternalLink).url),
       )
       .map((item) => ({ label: item.label, url: item.url }));
   } catch {
@@ -33,13 +52,17 @@ export function useExternalLinks(): ExternalLink[] {
   return parseExternalLinks(data?.[SETTING_KEYS.externalLinks]);
 }
 
-/** Configured integration URLs, with empty/whitespace values normalized. */
+/** Configured integration URLs — normalized and dropped unless scheme-safe. */
 export function useIntegrations(): IntegrationUrls {
   const { data } = useSettings();
+  const sanitize = (raw: string | undefined): string => {
+    const value = raw?.trim() ?? "";
+    return value && isSafeLinkUrl(value) ? value : "";
+  };
   return {
-    grafana: data?.[SETTING_KEYS.integrationGrafana]?.trim() ?? "",
-    sentry: data?.[SETTING_KEYS.integrationSentry]?.trim() ?? "",
-    otel: data?.[SETTING_KEYS.integrationOtel]?.trim() ?? "",
+    grafana: sanitize(data?.[SETTING_KEYS.integrationGrafana]),
+    sentry: sanitize(data?.[SETTING_KEYS.integrationSentry]),
+    otel: sanitize(data?.[SETTING_KEYS.integrationOtel]),
   };
 }
 

--- a/dashboard/src/features/webhooks/api.ts
+++ b/dashboard/src/features/webhooks/api.ts
@@ -19,19 +19,19 @@ export function createWebhook(input: CreateWebhookInput): Promise<Webhook> {
 }
 
 export function updateWebhook(id: string, input: UpdateWebhookInput): Promise<Webhook> {
-  return api.put<Webhook>(`/api/webhooks/${id}`, input);
+  return api.put<Webhook>(`/api/webhooks/${encodeURIComponent(id)}`, input);
 }
 
 export function deleteWebhook(id: string): Promise<{ deleted: true }> {
-  return api.delete<{ deleted: true }>(`/api/webhooks/${id}`);
+  return api.delete<{ deleted: true }>(`/api/webhooks/${encodeURIComponent(id)}`);
 }
 
 export function rotateWebhookSecret(id: string): Promise<RotateSecretResult> {
-  return api.post<RotateSecretResult>(`/api/webhooks/${id}/rotate-secret`);
+  return api.post<RotateSecretResult>(`/api/webhooks/${encodeURIComponent(id)}/rotate-secret`);
 }
 
 export function testWebhook(id: string): Promise<TestWebhookResult> {
-  return api.post<TestWebhookResult>(`/api/webhooks/${id}/test`);
+  return api.post<TestWebhookResult>(`/api/webhooks/${encodeURIComponent(id)}/test`);
 }
 
 export function listEventTypes(signal?: AbortSignal): Promise<string[]> {
@@ -42,14 +42,17 @@ export function listDeliveries(
   subscriptionId: string,
   options: { status?: DeliveryStatus; limit?: number; offset?: number; signal?: AbortSignal } = {},
 ): Promise<DeliveryListPage> {
-  return api.get<DeliveryListPage>(`/api/webhooks/${subscriptionId}/deliveries`, {
-    signal: options.signal,
-    params: {
-      status: options.status,
-      limit: options.limit,
-      offset: options.offset,
+  return api.get<DeliveryListPage>(
+    `/api/webhooks/${encodeURIComponent(subscriptionId)}/deliveries`,
+    {
+      signal: options.signal,
+      params: {
+        status: options.status,
+        limit: options.limit,
+        offset: options.offset,
+      },
     },
-  });
+  );
 }
 
 export function replayDelivery(
@@ -57,6 +60,6 @@ export function replayDelivery(
   deliveryId: string,
 ): Promise<ReplayDeliveryResult> {
   return api.post<ReplayDeliveryResult>(
-    `/api/webhooks/${subscriptionId}/deliveries/${deliveryId}/replay`,
+    `/api/webhooks/${encodeURIComponent(subscriptionId)}/deliveries/${encodeURIComponent(deliveryId)}/replay`,
   );
 }

--- a/docs/content/docs/java/guides/operations/dashboard.mdx
+++ b/docs/content/docs/java/guides/operations/dashboard.mdx
@@ -193,6 +193,11 @@ that mode's own credential (a valid session, or the shared token) or a
 point scrapers at the bearer token. In open mode they stay public unless that
 env token is set. `/health` always stays open for liveness probes.
 
+Every response — JSON, SPA assets, and probes alike — carries defense-in-depth
+headers: a `Content-Security-Policy` locked to the dashboard's own origin,
+`X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, and
+`Referrer-Policy: same-origin`.
+
 ## REST API
 
 Everything is JSON, fields in snake_case, timestamps in Unix milliseconds —

--- a/docs/content/docs/node/guides/operations/security.mdx
+++ b/docs/content/docs/node/guides/operations/security.mdx
@@ -60,6 +60,11 @@ way, bind it to localhost or a private network, or mount it behind your own
 auth via the [Express](/node/guides/integrations/express#dashboard) /
 [Fastify](/node/guides/integrations/fastify) helpers.
 
+Every dashboard response carries defense-in-depth headers: a
+`Content-Security-Policy` locked to the dashboard's own origin,
+`X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY` (the dashboard
+can't be framed), and `Referrer-Policy: same-origin`.
+
 ## Hardening checklist
 
 - [ ] Storage reachable only from trusted services, on a private network.

--- a/docs/content/docs/python/guides/operations/security.mdx
+++ b/docs/content/docs/python/guides/operations/security.mdx
@@ -100,6 +100,12 @@ once at least one user exists; until then every API route returns
   is always open for liveness probes.
 - **Settings.** The settings API never exposes or accepts keys under the
   internal `auth:` namespace (password hashes, sessions, CSRF secret).
+- **Security headers.** Every dashboard response carries a
+  `Content-Security-Policy` locked to the dashboard's own origin,
+  `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, and
+  `Referrer-Policy: same-origin`. Configured external links and integration
+  URLs are also scheme-filtered client-side — only `http(s)` and same-origin
+  paths ever become clickable.
 
 <Callout type="warn" title="Contrib routers are not auth-gated by default">
   The FastAPI/Flask routers in `taskito.contrib` expose job-control endpoints

--- a/sdks/java/src/main/java/org/byteveda/taskito/dashboard/DashboardServer.java
+++ b/sdks/java/src/main/java/org/byteveda/taskito/dashboard/DashboardServer.java
@@ -63,6 +63,24 @@ public final class DashboardServer implements AutoCloseable {
     private static final TaskitoLogger LOG = TaskitoLogger.create("dashboard");
     private static final String METRICS_TOKEN_ENV = "TASKITO_DASHBOARD_METRICS_TOKEN";
 
+    /**
+     * Defense-in-depth headers on every response. The CSP assumes a fully
+     * self-contained SPA bundle (no inline scripts — the theme bootstrap ships
+     * as /theme-init.js); inline style attributes need 'unsafe-inline' in
+     * style-src.
+     */
+    private static final String[][] SECURITY_HEADERS = {
+        {
+            "Content-Security-Policy",
+            "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; "
+                    + "img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; "
+                    + "base-uri 'self'; form-action 'self'; object-src 'none'"
+        },
+        {"X-Content-Type-Options", "nosniff"},
+        {"X-Frame-Options", "DENY"},
+        {"Referrer-Policy", "same-origin"},
+    };
+
     private final HttpServer server;
     private final Taskito queue;
     private final Path staticDir;
@@ -214,6 +232,11 @@ public final class DashboardServer implements AutoCloseable {
 
     private void dispatch(HttpExchange exchange) throws IOException {
         try {
+            // Single choke point: every response — JSON, assets, probes,
+            // redirects — carries the security headers.
+            for (String[] header : SECURITY_HEADERS) {
+                exchange.getResponseHeaders().set(header[0], header[1]);
+            }
             String path = exchange.getRequestURI().getPath();
             if (path.equals("/health")) {
                 Http.respondJson(exchange, 200, Map.of("status", "ok"));

--- a/sdks/java/src/test/java/org/byteveda/taskito/dashboard/DashboardTest.java
+++ b/sdks/java/src/test/java/org/byteveda/taskito/dashboard/DashboardTest.java
@@ -94,6 +94,37 @@ class DashboardTest {
 
     @Test
     @Timeout(30)
+    void setsSecurityHeadersOnEveryResponse(@TempDir Path dir) throws Exception {
+        try (Taskito queue = Taskito.builder()
+                .backend("sqlite")
+                .url(dir.resolve("t.db").toString())
+                .open()) {
+            try (DashboardServer server = DashboardServer.start(queue, 0)) {
+                for (String path : new String[] {"/health", "/api/stats"}) {
+                    HttpResponse<String> res = get(server.port(), path);
+                    assertEquals(
+                            "nosniff",
+                            res.headers().firstValue("X-Content-Type-Options").orElse(""),
+                            path);
+                    assertEquals(
+                            "DENY", res.headers().firstValue("X-Frame-Options").orElse(""), path);
+                    assertEquals(
+                            "same-origin",
+                            res.headers().firstValue("Referrer-Policy").orElse(""),
+                            path);
+                    assertTrue(
+                            res.headers()
+                                    .firstValue("Content-Security-Policy")
+                                    .orElse("")
+                                    .contains("default-src 'self'"),
+                            path);
+                }
+            }
+        }
+    }
+
+    @Test
+    @Timeout(30)
     void enforcesToken(@TempDir Path dir) throws Exception {
         try (Taskito queue = Taskito.builder()
                 .backend("sqlite")

--- a/sdks/node/src/dashboard/server.ts
+++ b/sdks/node/src/dashboard/server.ts
@@ -41,6 +41,23 @@ const log = createLogger("dashboard");
 /** Max request body size (1 MiB) — reject larger payloads to bound memory. */
 const MAX_BODY_BYTES = 1024 * 1024;
 
+/**
+ * Defense-in-depth headers on every response. The CSP assumes a fully
+ * self-contained SPA bundle (no inline scripts — the theme bootstrap ships as
+ * /theme-init.js); inline style attributes need 'unsafe-inline' in style-src.
+ */
+const SECURITY_HEADERS: ReadonlyArray<readonly [string, string]> = [
+  [
+    "content-security-policy",
+    "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; " +
+      "img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; " +
+      "base-uri 'self'; form-action 'self'; object-src 'none'",
+  ],
+  ["x-content-type-options", "nosniff"],
+  ["x-frame-options", "DENY"],
+  ["referrer-policy", "same-origin"],
+];
+
 /** Options accepted by {@link createDashboardHandler} / {@link createDashboardServer}. */
 export interface DashboardHandlerOptions {
   /** Legacy shared-token gate. When set, the session-auth flow is disabled. */
@@ -76,6 +93,11 @@ export function createDashboardHandler(
   const assets = new StaticAssets(staticDir);
   const resolved = normalizeOptions(options);
   return (req, res) => {
+    // Single choke point: every response — JSON, assets, probes, redirects —
+    // carries the security headers.
+    for (const [name, value] of SECURITY_HEADERS) {
+      res.setHeader(name, value);
+    }
     void dispatch(queue, assets, req, res, resolved).catch((error) => {
       log.error(() => "dashboard dispatch failed", error);
       if (!res.headersSent) {

--- a/sdks/node/test/dashboard/auth.test.ts
+++ b/sdks/node/test/dashboard/auth.test.ts
@@ -85,3 +85,13 @@ it("gates probes behind the legacy token; /health stays public", async () => {
   const ok = await fetch(`${base}/readiness`, { headers: { "x-taskito-token": TOKEN } });
   expect(ok.status).not.toBe(401);
 });
+
+it("sets security headers on every response", async () => {
+  for (const path of ["/health", "/api/auth/status", "/"]) {
+    const res = await fetch(`${base}${path}`);
+    expect(res.headers.get("x-content-type-options"), path).toBe("nosniff");
+    expect(res.headers.get("x-frame-options"), path).toBe("DENY");
+    expect(res.headers.get("referrer-policy"), path).toBe("same-origin");
+    expect(res.headers.get("content-security-policy"), path).toContain("default-src 'self'");
+  }
+});

--- a/sdks/python/taskito/dashboard/server.py
+++ b/sdks/python/taskito/dashboard/server.py
@@ -91,6 +91,21 @@ _LOG_PATH_MAX = 256
 # Hard cap on the request body we'll parse for PUT/POST requests.
 _MAX_BODY_BYTES = 1 * 1024 * 1024  # 1 MiB
 
+# Defense-in-depth headers on every response. The CSP assumes a fully
+# self-contained SPA bundle (no inline scripts — the theme bootstrap ships as
+# /theme-init.js); inline style attributes need 'unsafe-inline' in style-src.
+_SECURITY_HEADERS: tuple[tuple[str, str], ...] = (
+    (
+        "Content-Security-Policy",
+        "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; "
+        "img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; "
+        "base-uri 'self'; form-action 'self'; object-src 'none'",
+    ),
+    ("X-Content-Type-Options", "nosniff"),
+    ("X-Frame-Options", "DENY"),
+    ("Referrer-Policy", "same-origin"),
+)
+
 
 def _safe_path(path: str) -> str:
     """Return ``path`` with control characters stripped and length capped."""
@@ -194,6 +209,13 @@ def _make_handler(
 
     class DashboardHandler(BaseHTTPRequestHandler):
         # ── Entry points ────────────────────────────────────────────
+
+        def end_headers(self) -> None:
+            # Single choke point: every response — JSON, assets, probes,
+            # redirects — carries the security headers.
+            for name, value in _SECURITY_HEADERS:
+                self.send_header(name, value)
+            super().end_headers()
 
         def do_GET(self) -> None:
             try:

--- a/sdks/python/tests/dashboard/test_auth.py
+++ b/sdks/python/tests/dashboard/test_auth.py
@@ -708,6 +708,22 @@ def test_probe_accepts_metrics_bearer_when_auth_enabled(
     assert status == 200
 
 
+# ── Security headers ───────────────────────────────────────────────────
+
+
+def test_security_headers_on_every_response(open_dashboard_server: tuple[str, Queue]) -> None:
+    base, _ = open_dashboard_server
+    # "/" is skipped: SPA assets may be absent in CI, and the headers are
+    # emitted from end_headers() so they apply to every response uniformly.
+    for path in ("/health", "/api/stats"):
+        resp = urllib.request.urlopen(f"{base}{path}")
+        headers = resp.headers
+        assert headers["X-Content-Type-Options"] == "nosniff", path
+        assert headers["X-Frame-Options"] == "DENY", path
+        assert headers["Referrer-Policy"] == "same-origin", path
+        assert "default-src 'self'" in (headers["Content-Security-Policy"] or ""), path
+
+
 # ── Auth disabled (the default) ────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Frontend security audit of the dashboard SPA found the classic surfaces already clean — no raw-HTML sinks, CSRF attached centrally, HttpOnly session never touched by JS, no secrets in storage or the bundle. This PR closes the gaps the audit did find.

### Safe URL schemes for configured links
Operator-configured URLs (sidebar external links, Grafana/Sentry/OTel deep-links) previously flowed into `href` with only a `type="url"` input hint, so a value written directly through the settings API could plant a clickable `javascript:`/`data:` URI. `isSafeLinkUrl` now filters at the parse layer — only `http(s)` and same-origin paths ever render as links.

### Security headers on every dashboard response
All three SDK servers now emit a `Content-Security-Policy` locked to the dashboard's own origin plus `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, and `Referrer-Policy: same-origin`, each from a single choke point in the dispatch path. The SPA's inline theme bootstrap moved to `/theme-init.js` so the CSP can ship `script-src 'self'` without hash maintenance.

### Smaller fixes
- Post-login `next` redirect only honours root-relative paths (`/...`, not `//...`), mirroring the server-side OAuth `next` validation.
- Webhook API calls now `encodeURIComponent` their path params, matching every other feature client.
- The backend-offline docs link gained `noopener`.

## Tests

- New unit coverage for `isSafeLinkUrl` and scheme filtering in `parseExternalLinks`; security-header assertions in each SDK's dashboard suite.
- Dashboard SPA: 112 tests, biome, tsc green. Python: 285 dashboard tests, ruff, mypy green. Node: 97 dashboard tests, tsc green. Java: dashboard suites green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added consistent security headers to all dashboard responses.
  * Restricted configurable links and integration URLs to safe HTTP(S) or same-origin paths.
  * Secured redirect handling and webhook requests involving identifiers.
  * Improved protection for external documentation links.

* **Bug Fixes**
  * Preserved the selected light or dark theme during dashboard startup, including CSP-compatible loading.

* **Documentation**
  * Documented dashboard security headers and URL safety behavior across supported SDK guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->