### PR TITLE
fix: docs topbar and inline code overflow on phones

### DIFF
--- a/docs/app/components/ui/site-nav.tsx
+++ b/docs/app/components/ui/site-nav.tsx
@@ -123,7 +123,7 @@ function SdkSelect() {
         onClick={() => setOpen((o) => !o)}
       >
         <span className="sdk-dd-icon">{SDK_ICONS[active.id]}</span>
-        <span>{active.label}</span>
+        <span className="sdk-dd-name">{active.label}</span>
         <ChevronDown className="sdk-caret" size={13} aria-hidden="true" />
       </button>
       {open ? (

--- a/docs/app/styles/atoms.css
+++ b/docs/app/styles/atoms.css
@@ -351,6 +351,16 @@
   .kbar {
     display: none;
   }
+  /* Tighten the bar so its min-content width fits small phones (375px) —
+     otherwise the whole page gains a horizontal scroll and the right-side
+     icons land off-screen. */
+  .nav {
+    gap: 12px;
+    padding: 14px 16px;
+  }
+  .navright {
+    gap: 8px;
+  }
   .foot-grid {
     grid-template-columns: 1fr 1fr;
   }

--- a/docs/app/styles/changelog.css
+++ b/docs/app/styles/changelog.css
@@ -134,6 +134,9 @@
   padding: 1px 5px;
   border-radius: 5px;
   color: var(--txt);
+  /* Long identifiers (env vars, dotted paths) must break rather than widen
+     the page into a horizontal scroll on phones. */
+  overflow-wrap: anywhere;
 }
 .rel-earlier {
   margin-top: 6px;

--- a/docs/app/styles/docs.css
+++ b/docs/app/styles/docs.css
@@ -52,6 +52,20 @@ body {
   .side-search {
     display: flex;
   }
+  /* The dropdown button already names the SDK; the label is dead weight at
+     phone widths where the topbar is fighting for room. */
+  .sdk-dd-label {
+    display: none;
+  }
+}
+@media (max-width: 480px) {
+  /* Collapse the SDK picker to its language icon + caret so the topbar's
+     min-content width fits small phones (down to 320px) without pushing the
+     theme/GitHub buttons off-screen. The icon still identifies the SDK and
+     the accessible name is unchanged. */
+  .sdk-dd-name {
+    display: none;
+  }
 }
 .side-search:hover {
   border-color: var(--line3);

--- a/docs/app/styles/docs.css
+++ b/docs/app/styles/docs.css
@@ -398,6 +398,9 @@ body {
   padding: 1.5px 6px;
   border-radius: 5px;
   color: var(--txt);
+  /* Long identifiers (env vars, dotted paths) must break rather than widen
+     the page into a horizontal scroll on phones. */
+  overflow-wrap: anywhere;
 }
 .article a {
   color: var(--indigo-br);


### PR DESCRIPTION
## Summary

On phone viewports the docs pages gained a horizontal scroll, pushing the theme and GitHub buttons in the topbar off-screen (reported on iPhone SE, 375px).

Two causes, measured with headless Chrome at 375/360/320px:

- **Topbar min-content width (412px)** exceeded the viewport: desktop gap/padding plus the full SDK picker never shrank. The existing mobile breakpoint now tightens nav spacing, and below 480px the SDK picker collapses to its language icon + caret (accessible name unchanged; the brand wordmark stays).
- **Long inline code tokens** (env vars, dotted paths) could not break, widening the page — worst on the changelog (568px wide at 375). Inline code in articles and release notes now uses `overflow-wrap: anywhere`.

## Verification

Headless-Chrome sweep of landing, quickstart (both SDK trees), architecture, and changelog at 375/360/320px: `document.scrollWidth === clientWidth` on every page (was 412 and 568 before). Screenshot check at 375px confirms all topbar controls visible with no horizontal scroll. `biome check` and `typecheck` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved mobile navigation spacing on small screens.
  * Simplified the SDK picker display on very small phones.
  * Added wrapping for long code identifiers to prevent horizontal scrolling in documentation and changelogs.
  * Refined SDK dropdown label styling without changing its behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->