### PR TITLE
fix: stop docs table-cell code breaking mid-token

### DIFF
--- a/docs/app/styles/docs.css
+++ b/docs/app/styles/docs.css
@@ -847,6 +847,14 @@ body {
 .md-table tr td:first-child {
   white-space: nowrap;
 }
+/* Inline code in cells (types like `str | None`, defaults, identifiers) must
+   stay on one line: the article-wide `overflow-wrap: anywhere` otherwise breaks
+   them character-by-character when a column is squeezed by a long description.
+   Genuinely wide tokens overflow into the wrapper's horizontal scroll instead. */
+.md-table td code {
+  white-space: nowrap;
+  overflow-wrap: normal;
+}
 .md-table a {
   color: var(--indigo-br);
   border-bottom: 1px solid var(--indigo-line);


### PR DESCRIPTION
## Problem
In parameter tables, a narrow Type column (squeezed by a long Description) rendered inline code like `str | None` broken character-by-character — e.g. `st` / `r |` / `Non` / `e` stacked vertically.

## Cause
The article-wide `overflow-wrap: anywhere` rule (added for long identifiers on phones) applies to inline code inside table cells too, so a squeezed column breaks short type tokens at every character.

## Fix
Scope table-cell inline code to `white-space: nowrap; overflow-wrap: normal`, so types/defaults/identifiers stay on one line. Genuinely wide tokens fall back to the table wrapper's existing `overflow-x: auto` horizontal scroll instead of mangling.

## Verification
Headless render of the affected table, 760px container: the Type cell height drops from 52px (3 wrapped lines) to 16px (one line). Docs typecheck + lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved inline code formatting in documentation tables.
  * Long code identifiers now remain on a single line without breaking unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->