### PR TITLE
fix(docs): wrap first-column params to avoid table h-scroll

### DIFF
--- a/docs/app/styles/docs.css
+++ b/docs/app/styles/docs.css
@@ -844,8 +844,13 @@ body {
   color: var(--txt2);
   vertical-align: top;
 }
+/* First column wraps at token boundaries so a cell listing several parameters
+   (`a` / `b` / `c` …) folds onto multiple lines instead of widening the table
+   into a horizontal scroll. Each identifier stays whole via the `td code` rule
+   below; only the ` / ` separators are break points. */
 .md-table tr td:first-child {
-  white-space: nowrap;
+  white-space: normal;
+  overflow-wrap: normal;
 }
 /* Inline code in cells (types like `str | None`, defaults, identifiers) must
    stay on one line: the article-wide `overflow-wrap: anywhere` otherwise breaks


### PR DESCRIPTION
## Problem

The `queue.publish()` parameter table on the Pub/Sub API reference page (and any table whose first column lists several parameters, e.g. `priority` / `max_retries` / `timeout` / `expires` / `result_ttl`) forced a horizontal scrollbar. The first column was `white-space: nowrap`, so a multi-token cell stayed on one line and widened the whole table past the content area, squeezing the description column off-screen.

## Fix

Relax the first column to `white-space: normal; overflow-wrap: normal`. Individual identifiers still stay whole — the existing `.md-table td code { white-space: nowrap }` rule keeps each code token unbroken — so the cell now folds at the ` / ` separators instead of overflowing. Single-token first cells (`idempotency_key`, `notes`, …) are unaffected.

Result: the content wraps and the table fits its container. No horizontal scroll.

## Verification

- `pnpm --dir docs lint` — pass
- `pnpm --dir docs types:check` — pass (pre-commit)
- `pnpm --dir docs build` — static export succeeds; compiled bundle carries the new rule

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated documentation table styling so content in the first column wraps onto multiple lines instead of being forced to remain on one line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->