### PR TITLE
fix(docs): stop decimal markers overlapping flowsteps badges

### DIFF
--- a/docs/app/styles/docs.css
+++ b/docs/app/styles/docs.css
@@ -449,19 +449,19 @@ body {
 /* Ordered lists: Tailwind Preflight resets `ol` to `list-style: none`, so the
    numbers disappear. Restore decimal markers + the indent they need, and tint
    them. (Kept off `display: flex`, which would drop the ::marker.) */
-.article ol {
+.article ol:not(.flowsteps) {
   margin: 14px 0;
   padding-left: 26px;
   list-style: decimal;
 }
-.article ol li {
+.article ol:not(.flowsteps) li {
   font-size: 15px;
   line-height: 1.6;
   color: var(--txt2);
   padding-left: 6px;
   margin: 9px 0;
 }
-.article ol li::marker {
+.article ol:not(.flowsteps) li::marker {
   color: var(--indigo);
   font-weight: 600;
 }


### PR DESCRIPTION
The `.flowsteps` numbered lists (Architecture → Mesh: "Protocol period", the mesh-bridge steps) rendered the browser's decimal `::marker` **and** the custom step badge on top of each other, hiding the first letter of every item ("Picks" → "Ficks").

Cause: `.article ol` (specificity 0,1,1) set `list-style: decimal` and its own padding, out-specifying `.flowsteps` (0,1,0) / `.flowsteps li` — so both the decimal marker and the badge showed and the 44px badge indent was lost.

Fix: scope the decimal-list rules to `.article ol:not(.flowsteps)` so `.flowsteps` keeps its badge styling and drops the overlapping marker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated documentation list styling so flow-step lists retain their intended appearance without standard decimal markers or tinting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->