### PR TITLE
docs: add shared guide content

### DIFF
--- a/docs/app/styles/docs.css
+++ b/docs/app/styles/docs.css
@@ -449,19 +449,19 @@ body {
 /* Ordered lists: Tailwind Preflight resets `ol` to `list-style: none`, so the
    numbers disappear. Restore decimal markers + the indent they need, and tint
    them. (Kept off `display: flex`, which would drop the ::marker.) */
-.article ol {
+.article ol:not(.flowsteps) {
   margin: 14px 0;
   padding-left: 26px;
   list-style: decimal;
 }
-.article ol li {
+.article ol:not(.flowsteps) li {
   font-size: 15px;
   line-height: 1.6;
   color: var(--txt2);
   padding-left: 6px;
   margin: 9px 0;
 }
-.article ol li::marker {
+.article ol:not(.flowsteps) li::marker {
   color: var(--indigo);
   font-weight: 600;
 }

--- a/docs/content/docs/shared/guides/core/predicates.mdx
+++ b/docs/content/docs/shared/guides/core/predicates.mdx
@@ -452,7 +452,9 @@ skipped for the current job — job dispatch is unaffected.
 <SdkOnly sdk="node">
 
 Gates run once, on the **producer** side, at enqueue time — there's
-no worker-dispatch phase.
+no worker-dispatch phase. Gates are in-process functions only: there's no
+serializable predicate DSL (no JSON/string form, no config-file or dashboard
+round-trip).
 
 </SdkOnly>
 
@@ -460,7 +462,8 @@ no worker-dispatch phase.
 
 Predicates and gates run once, synchronously, on the **producer**
 thread at enqueue time — there's no worker-dispatch phase. Keep them
-fast and side-effect-free.
+fast and side-effect-free. Gates are in-process lambdas — there's no
+serializable predicate DSL (no JSON or string form).
 
 </SdkOnly>
 
@@ -502,9 +505,9 @@ payloads that need skip/defer semantics.
 
 </SdkOnly>
 
-<SdkOnly sdk="python">
-
 ## Persistence & inspection
+
+<SdkOnly sdk="python">
 
 Every registered predicate is serialized once at decoration time. The
 JSON is reachable through:
@@ -533,7 +536,26 @@ restored = Predicate.from_dict(blob)
 # restored.evaluate(ctx) — re-evaluate against a context
 ```
 
+</SdkOnly>
+
+<SdkOnly sdk="node">
+
+Node has no predicate inspection API — gates are opaque closures held on the
+queue; there's no `listPredicates()` equivalent and the dashboard shows no
+"gated by" schema for Node.
+
+</SdkOnly>
+
+<SdkOnly sdk="java">
+
+Java exposes no predicate inspection API — registered gates are opaque and
+there is no `listPredicates()` equivalent.
+
+</SdkOnly>
+
 ## Metrics & events
+
+<SdkOnly sdk="python">
 
 ```python
 queue.predicate_stats()
@@ -562,7 +584,26 @@ for event in (
     queue.on_event(event, on_predicate_event)
 ```
 
+</SdkOnly>
+
+<SdkOnly sdk="node">
+
+Node emits no predicate metrics or events. The event bus covers job lifecycle
+only (`job.completed`, `job.retrying`, `job.dead`, `job.cancelled`) — there is
+no `predicateStats()` and no deferred/rejected event.
+
+</SdkOnly>
+
+<SdkOnly sdk="java">
+
+Java emits no predicate metrics or events — no `predicateStats()`, and the
+event enum carries no deferred/rejected predicate signals.
+
+</SdkOnly>
+
 ## Examples
+
+<SdkOnly sdk="python">
 
 ### Business-hours-only report with urgent override
 
@@ -634,6 +675,71 @@ queue.register_predicate("quota_available")(QuotaAvailable)
 
 @queue.task(predicate=QuotaAvailable(url="http://quota.internal"))
 async def index_document(tenant: str, doc_id: str): ...
+```
+
+</SdkOnly>
+
+<SdkOnly sdk="node">
+
+### Tenant allowlist (deny rejects the enqueue)
+
+```ts
+const allowed = new Set(["acme", "globex"]);
+
+queue.gate("reindexSearch", ({ args }) => allowed.has(args[0] as string));
+
+queue.enqueue("reindexSearch", ["acme"]); // ok
+queue.enqueue("reindexSearch", ["evilcorp"]); // throws PredicateRejectedError
+```
+
+### Business-hours + urgent override (booleans, no defer)
+
+```ts
+import { anyOf } from "@byteveda/taskito";
+
+const businessHours = () => {
+  const h = new Date().getHours();
+  return h >= 9 && h < 17;
+};
+const urgent = ({ args }: { args: readonly unknown[] }) => args[1] === true;
+
+queue.gate("sendDailyReport", anyOf(businessHours, urgent));
+
+queue.enqueue("sendDailyReport", ["alpha"]); // outside 09–17: throws (rejected, not deferred)
+queue.enqueue("sendDailyReport", ["alpha", true]); // urgent bypass: always enqueues
+```
+
+Unlike Python's `is_business_hours` (which *defers* to opening time), a Node
+gate that returns `false` **rejects** the enqueue — Node has no defer outcome.
+
+</SdkOnly>
+
+<SdkOnly sdk="java">
+
+### Business-hours + urgent override (recipe defers, urgent allows now)
+
+```java
+EnqueueGate hours = Recipes.businessHours(ZoneId.of("America/Los_Angeles"));
+
+taskito.gate("sendDailyReport", ctx ->
+    ((Report) ctx.payload()).urgent() ? EnqueueDecision.allow() : hours.decide(ctx));
+
+taskito.enqueue(sendReport, new Report("alpha", false)); // defers to next 09:00 PT
+taskito.enqueue(sendReport, new Report("alpha", true));  // runs now
+```
+
+### Tenant allowlist (skip vs reject, gate-aware `tryEnqueue`)
+
+```java
+Set<String> allowed = Set.of("acme", "globex");
+
+taskito.gate("reindexSearch", ctx ->
+    allowed.contains(((Reindex) ctx.payload()).tenant())
+        ? EnqueueDecision.allow()
+        : EnqueueDecision.reject("tenant not allowed"));
+
+Optional<String> id = taskito.tryEnqueue(reindex, new Reindex("acme")); // present
+taskito.enqueue(reindex, new Reindex("evilcorp"));   // throws PredicateRejectedException
 ```
 
 </SdkOnly>

--- a/docs/content/docs/shared/guides/core/queues.mdx
+++ b/docs/content/docs/shared/guides/core/queues.mdx
@@ -369,9 +369,9 @@ Map<String, QueueStats> all = taskito.statsAllQueues();
   </Tab>
 </CodeTabs>
 
-<SdkOnly sdk="python">
-
 ## Queue-level defaults
+
+<SdkOnly sdk="python">
 
 Configure defaults for every task at the `Queue` level; individual
 `@queue.task()` decorators override them:
@@ -383,6 +383,37 @@ queue = Queue(
     default_retry=3,       # default max retries
     default_timeout=300,   # default timeout in seconds
 )
+```
+
+</SdkOnly>
+
+<SdkOnly sdk="node">
+
+There's no queue-level defaults object. Retry and timeout defaults are set
+**per task** on `queue.task(...)` via `maxRetries` and `timeoutMs`; a per-call
+`enqueue()` override still wins. `priority` has no default — it's enqueue-only
+(see [Default priority](#default-priority) above). `configureQueue()` only sets
+a queue's `rateLimit` / `maxConcurrent`.
+
+```ts
+queue.task("resize", (id: string) => { /* ... */ }, {
+  maxRetries: 3, // default retry budget for this task
+  timeoutMs: 300_000, // default per-job timeout (ms)
+});
+```
+
+</SdkOnly>
+
+<SdkOnly sdk="java">
+
+Java has no queue-level defaults object — defaults live on the **task
+descriptor**, and a per-enqueue `EnqueueOptions` still overrides them:
+
+```java
+Task<ResizePayload> resize = Task.of("resize", ResizePayload.class)
+        .priority(0)                       // default priority
+        .maxRetries(3)                     // default retry budget
+        .timeout(Duration.ofSeconds(300)); // default per-job timeout
 ```
 
 </SdkOnly>

--- a/docs/content/docs/shared/guides/core/tasks.mdx
+++ b/docs/content/docs/shared/guides/core/tasks.mdx
@@ -17,24 +17,46 @@ from taskito import Queue
 
 queue = Queue(db_path="myapp.db")
 
-@queue.task()
-def process_data(data: dict) -> str:
-    # Your logic here
-    return "done"
+@queue.task(queue="emails", max_retries=5)
+def send_email(to: str, subject: str, body: str) -> str:
+    smtp.send(to, subject, body)
+    return "sent"
 ```
 
   </Tab>
   <Tab sdk="node">
 
 ```ts
-queue.task("add", (a: number, b: number) => a + b);
+import { Queue } from "@byteveda/taskito";
+
+const queue = new Queue({ dbPath: "myapp.db" });
+
+// The name is the contract; the handler runs on a worker and its return is the result.
+queue.task(
+  "sendEmail",
+  async (to: string, subject: string, body: string) => {
+    await smtp.send(to, subject, body);
+    return "sent";
+  },
+  { maxRetries: 5 }, // queue is chosen per-enqueue, not here
+);
 ```
 
   </Tab>
   <Tab sdk="java">
 
 ```java
-Task<EmailPayload> sendEmail = Task.of("send_email", EmailPayload.class);
+record EmailPayload(String to, String subject, String body) {}
+
+// Producer side: a typed descriptor (name + payload type + defaults).
+Task<EmailPayload> sendEmail = Task.of("send_email", EmailPayload.class)
+        .queue("emails")
+        .maxRetries(5);
+
+// Worker side: bind the logic separately as a TaskFunction.
+Worker worker = taskito.worker()
+        .handle(sendEmail, payload -> { smtp.send(payload); return "sent"; })
+        .start();
 ```
 
 For generic payloads that a `Class` token can't express, use a Jackson
@@ -497,9 +519,9 @@ the limit, or serialize the critical section with a
 
 </SdkOnly>
 
-<SdkOnly sdk="python">
-
 ## Per-task middleware
+
+<SdkOnly sdk="python">
 
 Apply middleware to a specific task only, in addition to queue-level
 middleware:
@@ -512,7 +534,27 @@ def important_task():
     ...
 ```
 
+</SdkOnly>
+
+<SdkOnly sdk="node">
+
+Node middleware is registered queue-wide with `queue.use(...)`; there's no
+per-task `middleware` option. Scope logic to a task inside the middleware via
+`ctx.taskName` in `before` / `after`, or toggle a global middleware per task
+from the dashboard (`queue.disableMiddlewareForTask(task, name)`).
+
+</SdkOnly>
+
+<SdkOnly sdk="java">
+
+Java `Middleware` is registered globally with `taskito.use(...)`; there's no
+per-task attachment. Branch inside the middleware on `ctx.taskName()`.
+
+</SdkOnly>
+
 ## Per-task serializer
+
+<SdkOnly sdk="python">
 
 Override the queue-level serializer for a specific task — the full
 round-trip: arguments are serialized with it at enqueue time and deserialized
@@ -532,7 +574,41 @@ Useful when a task needs a different format (e.g., human-readable JSON for
 audit tasks) or when the payload isn't picklable. See
 <SdkLink to="guides/extensibility/serializers">Serializers</SdkLink>.
 
+</SdkOnly>
+
+<SdkOnly sdk="node">
+
+The serializer is a queue-level choice (`new Queue({ serializer })`); it can't
+be swapped per task. For per-task payload handling, register named `codecs`
+(compression / encryption / signing) applied on top of the queue serializer:
+
+```ts
+const queue = new Queue({ dbPath: "myapp.db", codecs: { gzip: new GzipCodec() } });
+queue.task("audit_event", handleAudit, { codecs: ["gzip"] }); // transform, not a format swap
+```
+
+See <SdkLink to="guides/extensibility/serializers">Serializers</SdkLink>.
+
+</SdkOnly>
+
+<SdkOnly sdk="java">
+
+The serializer is a builder-level choice (`Taskito.builder().serializer(...)`);
+it can't be swapped per task. For per-task payload handling, use
+`Task.codecs(...)` — the same layered-transform model (compression / encryption
+/ signing) applied on top of the builder serializer:
+
+```java
+Task<AuditEvent> audit = Task.of("audit_event", AuditEvent.class).codecs("gzip");
+```
+
+See <SdkLink to="guides/extensibility/serializers">Serializers</SdkLink>.
+
+</SdkOnly>
+
 ## Job expiration
+
+<SdkOnly sdk="python">
 
 `expires` skips a job that wasn't started within the deadline. Set a default
 on the task, override it per call, or pass it only at enqueue time:
@@ -546,7 +622,29 @@ time_sensitive.delay()                      # uses the 300s default
 time_sensitive.apply_async(args=(), expires=60)  # tighter window for this call
 ```
 
+</SdkOnly>
+
+<SdkOnly sdk="node">
+
+The Node SDK has no job-expiration deadline. Job options are `delayMs`
+(earliest start) and `timeoutMs` (max run time), but a queued job is never
+discarded for sitting too long. Gate stale work inside the handler, or cancel
+it with `queue.cancelJob(id)`.
+
+</SdkOnly>
+
+<SdkOnly sdk="java">
+
+The Java SDK has no job-expiration deadline. `EnqueueOptions` offers `delay`
+(earliest start) and `timeout` (max run time), but a queued job is never
+discarded for sitting too long. Gate stale work inside the handler, or cancel
+it with `taskito.cancelJob(id)`.
+
+</SdkOnly>
+
 ## Task naming
+
+<SdkOnly sdk="python">
 
 By default, tasks are named using `module.qualname`:
 
@@ -563,6 +661,34 @@ Override with an explicit name:
 @queue.task(name="my-custom-name")
 def process():  # Named: my-custom-name
     ...
+```
+
+</SdkOnly>
+
+<SdkOnly sdk="node">
+
+Node task names are always explicit — the required first argument of
+`queue.task(name, handler)`. Unlike Python's `module.qualname` default, there is
+no auto-derived name (JS function names are unreliable after bundling).
+
+```ts
+queue.task("emails.send", (to: string, subject: string) => send(to, subject));
+queue.enqueue("emails.send", ["user@example.com", "Welcome"]);
+```
+
+</SdkOnly>
+
+<SdkOnly sdk="java">
+
+`Task.of(name, type)` takes an explicit name. With the `@TaskHandler`
+annotation, an empty `value()` defaults the task name to the method name:
+
+```java
+@TaskHandler("emails.send")   // explicit name
+String send(EmailPayload p) { ... }
+
+@TaskHandler                  // name defaults to the method name: "report"
+Report report(List<Metric> m) { ... }
 ```
 
 </SdkOnly>
@@ -647,15 +773,44 @@ String id = taskito.enqueue(sendEmail, payload, EnqueueOptions.builder()
   </Tab>
 </CodeTabs>
 
-<SdkOnly sdk="python">
-
 ### Direct call
+
+<SdkOnly sdk="python">
 
 Calling a task directly runs it synchronously, bypassing the queue —
 useful in tests:
 
 ```python
 result = send_email("user@example.com", "Hello", "World")  # Runs immediately
+```
+
+</SdkOnly>
+
+<SdkOnly sdk="node">
+
+`queue.task()` returns the queue, not a task object, so there's nothing to
+"call directly." Keep a reference to your handler function and invoke it
+directly in tests; only `enqueue()` routes through the queue.
+
+```ts
+const sendEmail = async (to: string, subject: string) => { /* ... */ return "sent"; };
+queue.task("sendEmail", sendEmail);
+
+const result = await sendEmail("user@example.com", "Hi"); // runs now, bypasses the queue
+```
+
+</SdkOnly>
+
+<SdkOnly sdk="java">
+
+A `Task<T>` carries no logic to call. Invoke the `TaskFunction` / handler
+method directly for a synchronous run; `taskito.enqueue(task, payload)` is the
+only path that goes through the queue.
+
+```java
+TaskFunction<EmailPayload, String> send = payload -> smtp.deliver(payload);
+
+String result = send.apply(payload); // runs now, bypasses the queue
 ```
 
 </SdkOnly>

--- a/docs/content/docs/shared/guides/core/workers.mdx
+++ b/docs/content/docs/shared/guides/core/workers.mdx
@@ -179,9 +179,9 @@ taskito.worker()
   </Tab>
 </CodeTabs>
 
-<SdkOnly sdk="python">
-
 ## Worker specialization
+
+<SdkOnly sdk="python">
 
 Advertise capability tags when starting a worker:
 
@@ -194,6 +194,30 @@ Tags are stored with the worker's registration and show up in
 have which capabilities at a glance. They're informational: the scheduler
 doesn't filter dispatch by tag, so route GPU-only or heavy-workload jobs to
 the right machines with [dedicated queues](#selecting-queues) instead.
+
+</SdkOnly>
+
+<SdkOnly sdk="node">
+
+Node workers can't advertise capability tags — `runWorker()` has no `tags`
+option. Route capability-specific work with [dedicated queues](#selecting-queues)
+instead: give GPU or heavy jobs their own queue and start a worker with
+`runWorker({ queues: ["gpu"] })`.
+
+`listWorkers()` rows include a `tags` field, but only SDKs that can set it
+populate it — it stays empty for Node-started workers.
+
+</SdkOnly>
+
+<SdkOnly sdk="java">
+
+`taskito.worker()` has no `tags(...)` builder method — Java workers can't
+advertise capability tags. Route capability-specific work with
+[dedicated queues](#selecting-queues) instead
+(`taskito.worker().queues("gpu").start()`).
+
+`WorkerInfo.tags` exists on `listWorkers()` rows, but only SDKs that support
+tag advertisement set it; it's null for Java-started workers.
 
 </SdkOnly>
 
@@ -348,12 +372,28 @@ The heartbeat fires every 5 seconds and carries the current resource-health
 snapshot, so <SdkLink to="guides/resources/dependency-injection">worker
 resources</SdkLink> going unhealthy shows up in `listWorkers()` too.
 
+### Lifecycle events
+
+Node has no worker-lifecycle events. `queue.on(event, handler)` fires only the
+four job-outcome events (`job.completed`, `job.retrying`, `job.dead`,
+`job.cancelled`) — there's no `WORKER_ONLINE` / `OFFLINE` / `UNHEALTHY`. Observe
+worker presence and health by polling `listWorkers()`, whose rows carry
+`status` and a per-resource `resourceHealth` snapshot from the last heartbeat.
+
 </SdkOnly>
 
 <SdkOnly sdk="java">
 
 Heartbeating is managed natively by the core — there's no user-facing
 interval to configure.
+
+### Lifecycle events
+
+Java has no worker-lifecycle events. `.on(EventName, ...)` fires only the four
+job-outcome events (`SUCCESS`, `RETRY`, `DEAD`, `CANCELLED`) — there's no
+`WORKER_ONLINE` / `OFFLINE` / `UNHEALTHY`. Observe worker presence and health by
+polling `taskito.listWorkers()`, whose `WorkerInfo` rows carry `status` and a
+`resourceHealth` snapshot from the last heartbeat.
 
 </SdkOnly>
 

--- a/docs/content/docs/shared/guides/extensibility/serializers.mdx
+++ b/docs/content/docs/shared/guides/extensibility/serializers.mdx
@@ -505,6 +505,44 @@ overview and what gets serialized where.
 
 </SdkOnly>
 
+<SdkOnly sdk="node">
+
+## Choosing a serializer
+
+| Serializer | When to use | Cross-SDK? |
+|---|---|---|
+| `JsonSerializer` | The default — human-readable, debuggable payloads for Node↔Node work. Leave it unless you have a reason to switch. | No — portable format, same-SDK payloads |
+| `MsgpackSerializer` | Node↔Node work where you want compact binary payloads instead of JSON text. | No — portable format, same-SDK payloads |
+| `CborSerializer` | A task is produced or consumed by another Taskito SDK. The only serializer whose wire format (the `0x02` envelope tag) is part of the cross-SDK contract; round-trips big integers as `BigInt`. | Yes — cross-SDK wire format |
+| `SignedSerializer(secret, inner?)` | Payloads must be tamper-evident but not hidden — prefixes an HMAC-SHA256 tag and rejects mismatches. Authentication, not encryption. | Same-SDK by default (wraps `JsonSerializer`) |
+| `EncryptedSerializer(secret, inner?)` | Tasks carry sensitive data that must not be readable in the database — AES-256-GCM confidentiality **and** integrity. | Same-SDK by default (wraps `JsonSerializer`) |
+
+**Rule of thumb**: keep the default `JsonSerializer` unless you have a specific
+reason to switch. Use `MsgpackSerializer` for more compact Node↔Node payloads,
+`CborSerializer` when a task crosses SDK boundaries, and `EncryptedSerializer`
+when payloads must not be readable in storage.
+
+</SdkOnly>
+
+<SdkOnly sdk="java">
+
+## Choosing a serializer
+
+| Serializer | When to use | Cross-SDK? |
+|---|---|---|
+| `JsonSerializer` | The default — JSON via Jackson, accepts a custom `ObjectMapper`. Human-readable and debuggable for Java↔Java work. | No — portable format, same-SDK payloads |
+| `MsgpackSerializer` | Java↔Java work where you want compact binary payloads. Its `jackson-dataformat-msgpack` dependency is `compileOnly` — add it to your build. | No — portable format, same-SDK payloads |
+| `CborSerializer` | A task is produced or consumed by another Taskito SDK. The only serializer whose wire format (the `0x02` envelope tag) is part of the cross-SDK contract. `jackson-dataformat-cbor` is `compileOnly`. | Yes — cross-SDK wire format |
+| `SignedSerializer(delegate, key)` | Payloads must be tamper-evident but not hidden — prefixes an HMAC-SHA256 tag with constant-time verification. Authentication, not encryption. | Same-SDK by default (depends on `delegate`) |
+| `EncryptedSerializer(delegate, key)` | Tasks carry sensitive data that must not be readable in the database — AES-GCM confidentiality **and** integrity. Key must be 16, 24, or 32 bytes. | Same-SDK by default (depends on `delegate`) |
+
+**Rule of thumb**: keep the default `JsonSerializer` unless you have a specific
+reason to switch. Use `MsgpackSerializer` for more compact Java↔Java payloads,
+`CborSerializer` when a task crosses SDK boundaries, and `EncryptedSerializer`
+when payloads must not be readable in storage.
+
+</SdkOnly>
+
 ## Payload codecs
 
 A `PayloadCodec` is a reversible byte-to-byte transform layered *around* a

--- a/docs/content/docs/shared/guides/integrations/prometheus.mdx
+++ b/docs/content/docs/shared/guides/integrations/prometheus.mdx
@@ -7,14 +7,58 @@ Taskito exports Prometheus metrics through two pieces — a middleware that
 records per-task execution counters and a duration histogram, and a stats
 collector that polls queue depth and dead-letter size onto gauges on an
 interval. Both write into the same
-<SdkSwap python={<code>prometheus-client</code>} node={<code>prom-client</code>} />
+<SdkSwap python={<code>prometheus-client</code>} node={<code>prom-client</code>} java={<code>Micrometer</code>} />
 registry, so one HTTP endpoint can serve everything.
 
 <SdkOnly sdk="java">
 
-Java has no Prometheus contrib — metrics come from
-[Micrometer](/java/guides/integrations/micrometer) instead, which yields a
-timer (and a trace span) from one instrumentation.
+Java has no Prometheus contrib. Metrics come from Micrometer: the
+`TaskitoObservation` middleware wraps each task execution in a Micrometer
+`Observation`, which a `PrometheusMeterRegistry` turns into a timer (and, if you
+add a tracing bridge, a span). See the dedicated
+[Micrometer guide](/java/guides/integrations/micrometer) for the full API.
+
+## Setup
+
+The SDK compiles against `io.micrometer:micrometer-observation` as `compileOnly`,
+so add it plus a Prometheus registry to your build:
+
+- `io.micrometer:micrometer-observation`
+- `io.micrometer:micrometer-registry-prometheus` (brings `micrometer-core`, which
+  provides `DefaultMeterObservationHandler` and `PrometheusMeterRegistry`)
+
+```java
+import io.micrometer.core.instrument.observation.DefaultMeterObservationHandler;
+import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.prometheusmetrics.PrometheusConfig;
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
+import org.byteveda.taskito.contrib.TaskitoObservation;
+
+PrometheusMeterRegistry prometheus = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+ObservationRegistry observations = ObservationRegistry.create();
+observations.observationConfig()
+        .observationHandler(new DefaultMeterObservationHandler(prometheus));
+
+taskito.use(new TaskitoObservation(observations));
+```
+
+## What's emitted
+
+Each execution attempt starts an observation named `taskito.task` (customizable
+via `new TaskitoObservation(registry, name, taskFilter)`) tagged with
+`taskito.task` = the task name. Micrometer's meter handler converts it into a
+timer on the Prometheus registry; the exposed series name and suffixes follow
+Micrometer's Prometheus naming convention (dots become underscores, a `_seconds`
+suffix is added), not a fixed `taskito_*` name from the contrib. Retries are
+separate attempts, each producing its own observation.
+
+## Exposing metrics
+
+Serve `prometheus.scrape()` from any HTTP endpoint, or use Spring Boot Actuator's
+`/actuator/prometheus`, which wires the registry for you. The `taskito_jobs_total`
+/ `taskito_dlq_size` names and the polled queue-depth gauges below are Python/Node
+only — build Java dashboards and alerts on the timer series your
+Micrometer→Prometheus registry emits.
 
 </SdkOnly>
 

--- a/docs/content/docs/shared/guides/reliability/guarantees.mdx
+++ b/docs/content/docs/shared/guides/reliability/guarantees.mdx
@@ -133,8 +133,14 @@ queue.task("charge", async (orderId: string) => {
   <Tab sdk="java">
 
 ```java
+// Java handlers receive only the payload, so idempotency comes from a
+// natural key in it — here order.id().
 Worker worker = queue.worker()
-        .handle(CHARGE, order -> payments.charge(order.total(), order.id()))
+        .handle(CHARGE, order -> {
+            if (charges.exists(order.id())) return;      // already processed on a prior attempt
+            payments.charge(order.total(), order.id());   // key also dedupes at the provider
+            charges.record(order.id(), order.total());
+        })
         .start();
 ```
 

--- a/docs/content/docs/shared/guides/reliability/retries.mdx
+++ b/docs/content/docs/shared/guides/reliability/retries.mdx
@@ -149,6 +149,20 @@ retries fire immediately (no exponential fallback).
 
 </SdkOnly>
 
+<SdkOnly sdk="node">
+
+Node has no per-attempt delay list — tune the exponential curve instead via
+`retryBackoff` (`baseMs` is `B`, `maxMs` is `M` in the backoff formula above):
+
+```ts
+queue.task("flakyApiCall", handleCall, {
+  maxRetries: 5,
+  retryBackoff: { baseMs: 2000, maxMs: 300_000 }, // 2s base, 5min cap
+});
+```
+
+</SdkOnly>
+
 ## Exception filtering
 
 <SdkOnly sdk="python">

--- a/docs/content/docs/shared/guides/workflows/canvas.mdx
+++ b/docs/content/docs/shared/guides/workflows/canvas.mdx
@@ -540,9 +540,9 @@ return a plain `Workflow`, and `Workflow.named(...).step(...)` exposes a
 
 </SdkOnly>
 
-<SdkOnly sdk="python">
-
 ## chunks / starmap
+
+<SdkOnly sdk="python">
 
 ```python
 from taskito import chunks, starmap
@@ -560,7 +560,57 @@ result = chord(
 results = starmap(add, [(1, 2), (3, 4), (5, 6)]).apply(queue)
 ```
 
+</SdkOnly>
+
+<SdkOnly sdk="node">
+
+Node has no `chunks` / `starmap` helper — both are just a `group` of pre-sized
+steps. Build the batches in JS and hand them to `.group()`:
+
+```ts
+// chunks: split items into batches of 100
+const size = 100;
+const batches = Array.from({ length: Math.ceil(items.length / size) }, (_, i) =>
+  items.slice(i * size, (i + 1) * size),
+);
+queue.workflows
+  .define("batch")
+  .group(batches.map((b, i) => ({ name: `chunk-${i}`, task: "processBatch", args: [b] })))
+  .submit();
+
+// starmap: one step per arg tuple
+queue.workflows
+  .define("pairs")
+  .group([[1, 2], [3, 4]].map(([a, b], i) => ({ name: `add-${i}`, task: "add", args: [a, b] })))
+  .submit();
+```
+
+For dynamic batching driven by an upstream result, use `fanOut` / `fanIn`.
+
+</SdkOnly>
+
+<SdkOnly sdk="java">
+
+Java has no `chunks` / `starmap` shortcut — they are a `group` of fixed steps.
+Slice in Java and pass the links to `Canvas.group`:
+
+```java
+List<Canvas.Link> links = new ArrayList<>();
+for (int i = 0; i < items.size(); i += 100) {
+    List<Item> batch = items.subList(i, Math.min(i + 100, items.size()));
+    links.add(Canvas.link("chunk-" + (i / 100), processBatch, batch));
+}
+Workflow wf = Canvas.group("batch", links.toArray(new Canvas.Link[0]));
+queue.submitWorkflow(wf);
+```
+
+For dynamic per-item fan-out, use `Step.Builder.fanOut(...)` / `.fanIn(...)`.
+
+</SdkOnly>
+
 ## Canvas vs DAG workflows
+
+<SdkOnly sdk="python">
 
 | Feature | Canvas | DAG Workflows |
 |---------|--------|---------------|
@@ -580,5 +630,22 @@ Use canvas for quick one-off pipelines. Use
 <SdkLink to="guides/workflows/building">DAG workflows</SdkLink> for
 production pipelines that need monitoring, conditions, or complex
 topologies.
+
+</SdkOnly>
+
+<SdkOnly sdk="node">
+
+Canvas is not a separate engine in Node — `chain` / `group` / `chord` are
+methods on `WorkflowBuilder` that produce an ordinary DAG workflow. Reach for
+conditions, gates, or sub-workflows on the same builder when you need them; see
+<SdkLink to="guides/workflows">Workflows</SdkLink>.
+
+</SdkOnly>
+
+<SdkOnly sdk="java">
+
+`Canvas.chain` / `group` / `chord` return a plain `Workflow` you can keep
+extending with the builder (conditions, gates, sub-workflows) — canvas and DAG
+are the same object. See <SdkLink to="guides/workflows">Workflows</SdkLink>.
 
 </SdkOnly>

--- a/docs/content/docs/shared/guides/workflows/gates.mdx
+++ b/docs/content/docs/shared/guides/workflows/gates.mdx
@@ -320,9 +320,9 @@ is cancelled if the gate is resolved manually first.
 
 </SdkOnly>
 
-<SdkOnly sdk="python">
-
 ## Gate conditions
+
+<SdkOnly sdk="python">
 
 Gates respect the same `condition` DSL as regular steps, evaluated against
 the gate's predecessors *before* it's entered:
@@ -336,10 +336,24 @@ wf.step("deploy", deploy_task, after="approve")
 If `test` fails, the gate is skipped (its condition isn't met) — and
 `deploy`, the gate's successor, is skipped too.
 
-<Callout type="info">
-  Node's `.gate()` step options and Java's `GateConfig`/`Workflow.gate()`
-  don't expose a condition on the gate node itself — only Python's
-  `Workflow.gate()` takes one directly.
+</SdkOnly>
+
+<SdkOnly sdk="node">
+
+<Callout type="info" title="Node: gate conditions are Python-only">
+  A Node gate node has no entry condition — `.gate()` options cover only the
+  predecessor(s), `timeoutMs`, `onTimeout`, and `message`. To make a gate
+  conditional, put the `condition` on the step(s) around it instead.
+</Callout>
+
+</SdkOnly>
+
+<SdkOnly sdk="java">
+
+<Callout type="info" title="Java: gate conditions are Python-only">
+  A Java gate node has no entry condition — `GateConfig` covers only `timeout`,
+  `onTimeout`, and `message`. To make a gate conditional, put the condition on
+  the step(s) around it instead.
 </Callout>
 
 </SdkOnly>
@@ -381,9 +395,9 @@ rejection branch.
 
 </SdkOnly>
 
-<SdkOnly sdk="python">
-
 ## Events
+
+<SdkOnly sdk="python">
 
 When a gate enters `WAITING_APPROVAL`, a `WORKFLOW_GATE_REACHED` event fires
 in the process that reached it — the same process whose tracker owns the run
@@ -402,6 +416,29 @@ queue.on_event(EventType.WORKFLOW_GATE_REACHED, notify_team)
 
 The payload carries `run_id`, `node_name`, and `message` (the gate's
 `message`, or `None` if it wasn't set).
+
+</SdkOnly>
+
+<SdkOnly sdk="node">
+
+<Callout type="info" title="Node: no gate events">
+  There is no gate/workflow event in Node — `queue.on(...)` delivers only
+  job-outcome events (`job.completed`, `job.retrying`, `job.dead`,
+  `job.cancelled`). To react to a gate being reached, notify from the resolver
+  side (the endpoint that calls `approveGate` / `rejectGate`), or poll node
+  status for `waiting_approval` (see "Resolving a gate").
+</Callout>
+
+</SdkOnly>
+
+<SdkOnly sdk="java">
+
+<Callout type="info" title="Java: no gate events">
+  There is no gate/workflow event in Java — the worker's event listeners
+  deliver only job outcomes (`SUCCESS`, `RETRY`, `DEAD`, `CANCELLED`). To react
+  to a gate being reached, notify from the resolver side, or poll node status
+  for `WAITING_APPROVAL` (see "Resolving a gate").
+</Callout>
 
 </SdkOnly>
 

--- a/docs/content/docs/shared/guides/workflows/saga.mdx
+++ b/docs/content/docs/shared/guides/workflows/saga.mdx
@@ -324,7 +324,11 @@ Workflow partial = Workflow.named("partial-saga")
   on a cancelled run) and `COMPLETED_WITH_FAILURES`, covered next.
 </Callout>
 
+</SdkOnly>
+
 ## Compensating on continue-mode workflows
+
+<SdkOnly sdk="python">
 
 By default, `on_failure="continue"` workflows never trigger compensation —
 they run every step regardless of individual failures and always reach
@@ -350,6 +354,29 @@ reverse-topological order, same as a `fail_fast` saga, and the run ends
 `Compensated` or `CompensationFailed`. Without it, a `continue`-mode run
 with failures just stays `COMPLETED_WITH_FAILURES` and no compensation
 runs.
+
+</SdkOnly>
+
+<SdkOnly sdk="node">
+
+<Callout type="info" title="Node: no continue-mode compensation">
+  The Node builder has no run-level failure policy, so there is no
+  `compensateOnContinue` equivalent. `on_failure` here is only a per-step
+  `condition` (`"on_success"` | `"on_failure"` | `"always"`), not a
+  continue-vs-abort mode for the whole run. Saga compensation is declared
+  per step with `compensate` and runs only when the run itself fails.
+</Callout>
+
+</SdkOnly>
+
+<SdkOnly sdk="java">
+
+<Callout type="info" title="Java: no continue-mode compensation">
+  The `Workflow` builder has no run-level failure policy and no
+  `compensateOnContinue`. `onFailure()` is only a per-step `condition`
+  shorthand. Compensation is declared per step with
+  `Step.Builder.compensate(...)` and rolls back only when the run fails.
+</Callout>
 
 </SdkOnly>
 
@@ -418,9 +445,9 @@ Workflow safeCheckout = Workflow.named("safe-checkout")
   </Tab>
 </CodeTabs>
 
-<SdkOnly sdk="python">
-
 ## Events
+
+<SdkOnly sdk="python">
 
 Saga lifecycle emits dedicated events on the queue's event bus, subscribed
 via `queue.on_event(event_type, callback)`:
@@ -434,6 +461,28 @@ via `queue.on_event(event_type, callback)`:
 | `NODE_COMPENSATING` | A step's compensator was enqueued |
 | `NODE_COMPENSATED` | A step's compensator finished successfully |
 | `NODE_COMPENSATION_FAILED` | A step's compensator failed after retries |
+
+</SdkOnly>
+
+<SdkOnly sdk="node">
+
+<Callout type="info" title="Node: no saga events">
+  The Node SDK emits only the four job-lifecycle events — `job.completed`,
+  `job.retrying`, `job.dead`, `job.cancelled` — via `queue.on(...)`. There
+  are no `WORKFLOW_COMPENSATING` / `NODE_COMPENSATED`-style saga events. Track
+  compensation progress by polling the run handle: `handle.status()` and
+  `handle.nodes()`.
+</Callout>
+
+</SdkOnly>
+
+<SdkOnly sdk="java">
+
+<Callout type="info" title="Java: no saga events">
+  Java's `EventName` enum has only the four job outcomes — `SUCCESS`, `RETRY`,
+  `DEAD`, `CANCELLED`. No workflow/saga transition events are emitted. Poll
+  `WorkflowRun` / `status.nodes` for compensation progress.
+</Callout>
 
 </SdkOnly>
 


### PR DESCRIPTION
Second slice of the docs SDK-parity work: fill the Python-only holes in the shared guide tree so Node and Java readers get the same content — real ported examples where the feature ships, honest callouts where it doesn't. Every ported API verified against SDK source. 12 commits.

## Core guides
- `tasks`: unified "Defining a task" example; ported task naming to Node/Java; callouts for `expires` / direct-call / per-task-middleware / per-task-serializer (all feature-absent in Node/Java).
- `queues`: queue-level defaults — Node callout (per-task only), Java per-task descriptor.
- `workers`: worker tags + lifecycle events — feature-absent in Node/Java, now honest callouts.
- `predicates`: Node + Java worked examples; DSL/persistence/metrics gap callouts.

## Workflow guides
- `canvas`: chunks/starmap → Node/Java group-build snippets; canvas-vs-DAG notes.
- `saga`: continue-mode compensation + events — Node/Java callouts.
- `gates`: gate conditions + events — Node/Java callouts.

## Reliability / extensibility / integrations
- `serializers`: Node + Java serializer-selection matrix.
- `prometheus`: real Java Micrometer→Prometheus section (was a 2-line stub).
- `retries`: Node custom-backoff block.
- `guarantees`: Java idempotency example fixed to show real dedup.

## Also
- fix: stop decimal `::marker` overlapping the `.flowsteps` step badges (Architecture → Mesh) — scoped the decimal-list rule to `.article ol:not(.flowsteps)`.

Parity gate, typecheck, and static build all pass.